### PR TITLE
feat: add Mistral Vibe CLI template support as fourth editor target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -672,6 +672,28 @@ uv tool dir simpletask
 
 **Note:** For Qwen CLI and Gemini CLI configuration, see [docs/MCP.md](docs/MCP.md).
 
+#### Mistral Vibe Configuration
+
+Add to `~/.vibe/config.toml`:
+
+```toml
+[[mcp_servers]]
+name = "simpletask"
+transport = "stdio"
+command = "simpletask"
+args = ["serve"]
+```
+
+**Note:** If simpletask is installed in a virtualenv, use the full path to the executable:
+
+```toml
+[[mcp_servers]]
+name = "simpletask"
+transport = "stdio"
+command = "/path/to/venv/bin/simpletask"
+args = ["serve"]
+```
+
 ### Breaking Changes in v0.19.0
 
 #### `quality(action='check')` Raises `ValueError` When No Quality Requirements Configured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to simpletask are documented here.
 
+## [0.29.0] - 2026-03-23
+
+### Added
+
+- Mistral Vibe CLI template support as a fourth AI editor target
+  - Four workflow skills: `simpletask-plan`, `simpletask-split`, `simpletask-implement`, `simpletask-review`
+  - Skills installed to `~/.vibe/skills/` (global) or `.vibe/skills/` (local)
+  - `simpletask ai install --vibe` flag to install Vibe skills only
+  - Default `simpletask ai install` now installs all four editors (OpenCode, Qwen, Gemini, Vibe)
+
 ## [0.28.0] - 2026-03-16
 
 Initial public release on GitHub.

--- a/README.md
+++ b/README.md
@@ -100,16 +100,17 @@ The recommended workflow uses slash commands in supported AI editors. These guid
 
 **Supported AI tools:**
 
-- **[OpenCode](https://opencode.ai)**, **[Qwen](https://github.com/QwenLM/qwen-code)**, and **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** - Install workflow commands:
+- **[OpenCode](https://opencode.ai)**, **[Qwen](https://github.com/QwenLM/qwen-code)**, **[Gemini CLI](https://github.com/google-gemini/gemini-cli)**, and **[Mistral Vibe](https://mistral.ai/news/vibe-coding)** - Install workflow commands:
   ```sh
-  simpletask ai install              # All three editors
+  simpletask ai install              # All four editors
   simpletask ai install --opencode   # OpenCode only
   simpletask ai install --qwen       # Qwen only
   simpletask ai install --gemini     # Gemini CLI only
+  simpletask ai install --vibe       # Mistral Vibe only
   simpletask ai install --local      # Project-local installation
   ```
 
-The three workflow commands are:
+The workflow commands are:
 - `/simpletask.plan` - Create specification and implementation plan
 - `/simpletask.split` - Split complex tasks into atomic subtasks (optional)
 - `/simpletask.implement` - Execute tasks from the plan
@@ -252,7 +253,7 @@ ajv validate -s schema/simpletask.schema.json -d .tasks/my-task.yml --spec=draft
 
 ### MCP Server for AI Editors
 
-simpletask includes a Model Context Protocol (MCP) server for integration with AI editors like OpenCode, Qwen-CLI, and Gemini CLI. The MCP server exposes task file operations as structured tools that AI assistants can use to read task definitions, check status, and understand project context.
+simpletask includes a Model Context Protocol (MCP) server for integration with AI editors like OpenCode, Qwen-CLI, Gemini CLI, and Mistral Vibe. The MCP server exposes task file operations as structured tools that AI assistants can use to read task definitions, check status, and understand project context.
 
 **Benefits:**
 - **Structured responses**: AI gets typed JSON instead of parsing CLI output

--- a/cli/simpletask/__init__.py
+++ b/cli/simpletask/__init__.py
@@ -1,6 +1,6 @@
 """simpletask: A Python CLI for managing AI-friendly task definition YAML files."""
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"
 
 import typer
 

--- a/cli/simpletask/commands/ai/install.py
+++ b/cli/simpletask/commands/ai/install.py
@@ -1,4 +1,4 @@
-"""Install OpenCode, Qwen, and Gemini CLI command templates and agents."""
+"""Install OpenCode, Qwen, Gemini, and Vibe CLI command templates and agents."""
 
 import typer
 
@@ -7,14 +7,17 @@ from simpletask.core.ai_templates import (
     get_global_commands_dir,
     get_global_gemini_commands_dir,
     get_global_qwen_commands_dir,
+    get_global_vibe_commands_dir,
     get_local_agents_dir,
     get_local_commands_dir,
     get_local_gemini_commands_dir,
     get_local_qwen_commands_dir,
+    get_local_vibe_commands_dir,
     install_agents,
     install_gemini_templates,
     install_qwen_templates,
     install_templates,
+    install_vibe_templates,
 )
 from simpletask.utils.console import error, info, success, warning
 
@@ -82,32 +85,39 @@ def install_command(
         "--gemini",
         help="Install Gemini CLI templates only",
     ),
+    vibe: bool = typer.Option(
+        False,
+        "--vibe",
+        help="Install Mistral Vibe skills only",
+    ),
 ) -> None:
-    """Install OpenCode, Qwen, and Gemini CLI command templates and agents.
+    """Install OpenCode, Qwen, Gemini, and Vibe CLI command templates and agents.
 
-    By default, installs ALL templates (OpenCode, Qwen, and Gemini CLI) globally. OpenCode
+    By default, installs ALL templates (OpenCode, Qwen, Gemini CLI, and Vibe) globally. OpenCode
     agents are installed alongside OpenCode command templates.
-    Use --opencode, --qwen, or --gemini to install only specific editor templates.
+    Use --opencode, --qwen, --gemini, or --vibe to install only specific editor templates.
 
     Examples:
-        simpletask ai install                 # Install all three editors globally
-        simpletask ai install --local         # Install all three editors locally
+        simpletask ai install                 # Install all four editors globally
+        simpletask ai install --local         # Install all four editors locally
         simpletask ai install --opencode      # Install OpenCode only
         simpletask ai install --qwen          # Install Qwen only
         simpletask ai install --gemini        # Install Gemini CLI only
-        simpletask ai install --opencode --qwen --gemini --local  # All three, locally
+        simpletask ai install --vibe          # Install Mistral Vibe only
+        simpletask ai install --opencode --qwen --gemini --vibe --local  # All four, locally
     """
-    # If no flags specified, install all three
-    none_specified = not opencode and not qwen and not gemini
+    # If no flags specified, install all four
+    none_specified = not opencode and not qwen and not gemini and not vibe
     install_opencode = opencode or none_specified
     install_qwen = qwen or none_specified
     install_gemini = gemini or none_specified
+    install_vibe = vibe or none_specified
 
     any_skipped = False
 
-    try:
-        # Install OpenCode templates
-        if install_opencode:
+    # Install OpenCode templates
+    if install_opencode:
+        try:
             target_dir = get_local_commands_dir() if local else get_global_commands_dir()
 
             info(f"Installing OpenCode commands to {target_dir}")
@@ -120,9 +130,14 @@ def install_command(
             any_skipped = (
                 _report_installation_results(installed, skipped, overwritten) or any_skipped
             )
+        except FileNotFoundError as e:
+            warning(f"Skipping OpenCode installation: {e}")
+        except Exception as e:
+            error(f"Unexpected error installing OpenCode: {e}")
 
-        # Install Qwen templates
-        if install_qwen:
+    # Install Qwen templates
+    if install_qwen:
+        try:
             target_dir = get_local_qwen_commands_dir() if local else get_global_qwen_commands_dir()
 
             info(f"Installing Qwen commands to {target_dir}")
@@ -135,9 +150,14 @@ def install_command(
             any_skipped = (
                 _report_installation_results(installed, skipped, overwritten) or any_skipped
             )
+        except FileNotFoundError as e:
+            warning(f"Skipping Qwen installation: {e}")
+        except Exception as e:
+            error(f"Unexpected error installing Qwen: {e}")
 
-        # Install Gemini CLI templates
-        if install_gemini:
+    # Install Gemini CLI templates
+    if install_gemini:
+        try:
             target_dir = (
                 get_local_gemini_commands_dir() if local else get_global_gemini_commands_dir()
             )
@@ -152,11 +172,30 @@ def install_command(
             any_skipped = (
                 _report_installation_results(installed, skipped, overwritten) or any_skipped
             )
+        except FileNotFoundError as e:
+            warning(f"Skipping Gemini installation: {e}")
+        except Exception as e:
+            error(f"Unexpected error installing Gemini: {e}")
 
-    except FileNotFoundError as e:
-        error(str(e))
-    except Exception as e:
-        error(f"Unexpected error: {e}")
+    # Install Vibe skills
+    if install_vibe:
+        try:
+            target_dir = get_local_vibe_commands_dir() if local else get_global_vibe_commands_dir()
+
+            info(f"Installing Mistral Vibe skills to {target_dir}")
+
+            installed, skipped, overwritten = install_vibe_templates(
+                target_dir=target_dir,
+                no_overwrite=no_overwrite,
+            )
+
+            any_skipped = (
+                _report_installation_results(installed, skipped, overwritten) or any_skipped
+            )
+        except FileNotFoundError as e:
+            warning(f"Skipping Vibe installation: {e}")
+        except Exception as e:
+            error(f"Unexpected error installing Vibe: {e}")
 
     # Install OpenCode agents separately with independent error handling
     if install_opencode:

--- a/cli/simpletask/commands/ai/list.py
+++ b/cli/simpletask/commands/ai/list.py
@@ -1,4 +1,4 @@
-"""List OpenCode, Qwen, and Gemini CLI command templates."""
+"""List OpenCode, Qwen, Gemini, and Vibe CLI command templates."""
 
 from pathlib import Path
 
@@ -11,17 +11,21 @@ from simpletask.core.ai_templates import (
     get_bundled_gemini_templates,
     get_bundled_qwen_templates,
     get_bundled_templates,
+    get_bundled_vibe_templates,
     get_gemini_installed_status,
     get_global_agents_dir,
     get_global_commands_dir,
     get_global_gemini_commands_dir,
     get_global_qwen_commands_dir,
+    get_global_vibe_commands_dir,
     get_installed_status,
     get_local_agents_dir,
     get_local_commands_dir,
     get_local_gemini_commands_dir,
     get_local_qwen_commands_dir,
+    get_local_vibe_commands_dir,
     get_qwen_installed_status,
+    get_vibe_installed_status,
 )
 from simpletask.utils.console import console, create_table
 
@@ -48,7 +52,9 @@ def _render_editor_table(
     )
 
     for template_path in templates:
-        name = template_path.stem  # Remove file extension
+        # For directory-based editors (e.g. Vibe), keep the full directory name;
+        # for flat-file editors, strip the file extension.
+        name = template_path.name if template_path.is_dir() else template_path.stem
         template_status = status[template_path.name]
 
         global_icon = "[green]✓[/green]" if template_status["global"] else "[dim]-[/dim]"
@@ -60,7 +66,7 @@ def _render_editor_table(
 
 
 def list_command() -> None:
-    """List available and installed OpenCode, Qwen, and Gemini CLI commands.
+    """List available and installed OpenCode, Qwen, Gemini, and Vibe CLI commands.
 
     Shows which command templates are bundled with simpletask
     and whether they are installed globally or locally.
@@ -85,11 +91,16 @@ def list_command() -> None:
         gemini_templates = get_bundled_gemini_templates()
         gemini_status = get_gemini_installed_status()
 
+        # Get Vibe skills
+        vibe_templates = get_bundled_vibe_templates()
+        vibe_status = get_vibe_installed_status()
+
         if (
             not opencode_templates
             and not opencode_agents
             and not qwen_templates
             and not gemini_templates
+            and not vibe_templates
         ):
             console.print("[dim]No templates or agents found[/dim]")
             return
@@ -146,6 +157,19 @@ def list_command() -> None:
             console.print(f"\n[bold]{EDITOR_CONFIGS['gemini'].display_name} Locations:[/bold]")
             console.print(f"  Global: {get_global_gemini_commands_dir()}")
             console.print(f"  Local:  {get_local_gemini_commands_dir()}\n")
+
+        # Vibe skills table
+        if vibe_templates:
+            _render_editor_table(
+                title="Mistral Vibe Skills",
+                editor_name=EDITOR_CONFIGS["vibe"].display_name,
+                templates=vibe_templates,
+                status=vibe_status,
+                name_label="Skill",
+            )
+            console.print(f"\n[bold]{EDITOR_CONFIGS['vibe'].display_name} Locations:[/bold]")
+            console.print(f"  Global: {get_global_vibe_commands_dir()}")
+            console.print(f"  Local:  {get_local_vibe_commands_dir()}\n")
 
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")

--- a/cli/simpletask/core/ai_templates.py
+++ b/cli/simpletask/core/ai_templates.py
@@ -1,4 +1,4 @@
-"""AI template management for OpenCode, Qwen, and Gemini CLI command files."""
+"""AI template management for OpenCode, Qwen, Gemini, and Vibe CLI command files."""
 
 import importlib.resources
 import shutil
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-EditorType = Literal["opencode", "qwen", "gemini"]
+EditorType = Literal["opencode", "qwen", "gemini", "vibe"]
 
 
 @dataclass(frozen=True)
@@ -20,6 +20,7 @@ class EditorConfig:
     local_config_dir: tuple[str, ...]
     global_agents_dir: tuple[str, ...] | None = None
     local_agents_dir: tuple[str, ...] | None = None
+    is_directory_based: bool = False
 
 
 EDITOR_CONFIGS: dict[EditorType, EditorConfig] = {
@@ -46,6 +47,14 @@ EDITOR_CONFIGS: dict[EditorType, EditorConfig] = {
         global_config_dir=(".gemini", "commands"),
         local_config_dir=(".gemini", "commands"),
     ),
+    "vibe": EditorConfig(
+        display_name="Mistral Vibe",
+        template_subdir="vibe",
+        file_extension=".md",
+        global_config_dir=(".vibe", "skills"),
+        local_config_dir=(".vibe", "skills"),
+        is_directory_based=True,
+    ),
 }
 
 
@@ -53,7 +62,7 @@ def _get_templates_dir(editor: EditorType) -> Path:
     """Get path to bundled templates directory for an editor.
 
     Args:
-        editor: Editor type ("opencode", "qwen", or "gemini")
+        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
 
     Returns:
         Path to the templates directory within the package.
@@ -73,18 +82,27 @@ def _get_templates_dir(editor: EditorType) -> Path:
 
 
 def _get_bundled_templates(editor: EditorType) -> list[Path]:
-    """Get list of template files bundled with the package for an editor.
+    """Get list of template files or skill directories bundled with the package.
+
+    For flat-file editors (OpenCode, Qwen, Gemini), returns file paths matching
+    the editor's file extension. For directory-based editors (Vibe), returns
+    skill directory paths (each containing a SKILL.md).
 
     Args:
-        editor: Editor type ("opencode", "qwen", or "gemini")
+        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
 
     Returns:
-        List of Path objects for each template file.
+        List of Path objects for each template file or skill directory.
     """
     config = EDITOR_CONFIGS[editor]
     templates_dir = _get_templates_dir(editor)
     if not templates_dir.exists():
         return []
+
+    if config.is_directory_based:
+        return sorted(
+            p for p in templates_dir.iterdir() if p.is_dir() and not p.name.startswith(".")
+        )
 
     return sorted(templates_dir.glob(f"*{config.file_extension}"))
 
@@ -93,7 +111,7 @@ def _get_global_commands_dir(editor: EditorType) -> Path:
     """Get global commands directory for an editor.
 
     Args:
-        editor: Editor type ("opencode", "qwen", or "gemini")
+        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
 
     Returns:
         Path to global commands directory.
@@ -106,7 +124,7 @@ def _get_local_commands_dir(editor: EditorType) -> Path:
     """Get local commands directory for an editor.
 
     Args:
-        editor: Editor type ("opencode", "qwen", or "gemini")
+        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
 
     Returns:
         Path to local commands directory in current working directory.
@@ -157,6 +175,48 @@ def _install_files(
     return installed, skipped, overwritten
 
 
+def _install_skill_dirs(
+    skill_dirs: list[Path],
+    target_dir: Path,
+    no_overwrite: bool = False,
+) -> tuple[list[str], list[str], list[str]]:
+    """Install skill directories to target directory.
+
+    For directory-based editors (like Vibe), each skill is a directory
+    containing a SKILL.md file. This copies entire directories instead
+    of individual files.
+
+    Args:
+        skill_dirs: List of source skill directory Path objects to install
+        target_dir: Directory to install skill directories into
+        no_overwrite: If True, skip existing directories instead of overwriting
+
+    Returns:
+        Tuple of (installed, skipped, overwritten) directory names.
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    installed = []
+    skipped = []
+    overwritten = []
+
+    for source_dir in skill_dirs:
+        target_path = target_dir / source_dir.name
+
+        if target_path.exists():
+            if no_overwrite:
+                skipped.append(source_dir.name)
+                continue
+            else:
+                overwritten.append(source_dir.name)
+        else:
+            installed.append(source_dir.name)
+
+        shutil.copytree(source_dir, target_path, dirs_exist_ok=True)
+
+    return installed, skipped, overwritten
+
+
 def _install_templates(
     editor: EditorType,
     target_dir: Path,
@@ -164,13 +224,16 @@ def _install_templates(
 ) -> tuple[list[str], list[str], list[str]]:
     """Install templates to target directory for an editor.
 
+    Dispatches to _install_files() for flat-file editors or
+    _install_skill_dirs() for directory-based editors.
+
     Args:
-        editor: Editor type ("opencode", "qwen", or "gemini")
+        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
         target_dir: Directory to install templates into
-        no_overwrite: If True, skip existing files instead of overwriting
+        no_overwrite: If True, skip existing files/directories instead of overwriting
 
     Returns:
-        Tuple of (installed, skipped, overwritten) file names.
+        Tuple of (installed, skipped, overwritten) names.
 
     Raises:
         FileNotFoundError: If templates directory doesn't exist
@@ -181,14 +244,20 @@ def _install_templates(
     if not templates:
         raise FileNotFoundError(f"No {config.display_name} templates found in package")
 
+    if config.is_directory_based:
+        return _install_skill_dirs(templates, target_dir, no_overwrite)
+
     return _install_files(templates, target_dir, no_overwrite)
 
 
 def _get_installed_status(editor: EditorType) -> dict[str, dict[str, bool]]:
     """Get installation status of each template for an editor.
 
+    For directory-based editors, checks for directory existence instead of
+    file existence.
+
     Args:
-        editor: Editor type ("opencode", "qwen", or "gemini")
+        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
 
     Returns:
         Dict mapping template name to {"global": bool, "local": bool}
@@ -568,3 +637,67 @@ def get_agents_installed_status() -> dict[str, dict[str, bool]]:
         Dict mapping agent name to {"global": bool, "local": bool}
     """
     return _get_agents_installed_status("opencode")
+
+
+def get_vibe_templates_dir() -> Path:
+    """Get path to bundled Vibe templates directory.
+
+    Returns:
+        Path to the templates/vibe directory within the package.
+    """
+    return _get_templates_dir("vibe")
+
+
+def get_bundled_vibe_templates() -> list[Path]:
+    """Get list of Vibe skill directories bundled with the package.
+
+    Returns:
+        List of Path objects for each skill directory.
+    """
+    return _get_bundled_templates("vibe")
+
+
+def get_global_vibe_commands_dir() -> Path:
+    """Get global Vibe skills directory.
+
+    Returns:
+        Path to ~/.vibe/skills/
+    """
+    return _get_global_commands_dir("vibe")
+
+
+def get_local_vibe_commands_dir() -> Path:
+    """Get local Vibe skills directory.
+
+    Returns:
+        Path to .vibe/skills/ in current directory.
+    """
+    return _get_local_commands_dir("vibe")
+
+
+def install_vibe_templates(
+    target_dir: Path,
+    no_overwrite: bool = False,
+) -> tuple[list[str], list[str], list[str]]:
+    """Install Vibe skill directories to target directory.
+
+    Args:
+        target_dir: Directory to install skills into
+        no_overwrite: If True, skip existing directories instead of overwriting
+
+    Returns:
+        Tuple of (installed, skipped, overwritten) directory names.
+
+    Raises:
+        FileNotFoundError: If templates directory doesn't exist
+    """
+    return _install_templates("vibe", target_dir, no_overwrite)
+
+
+def get_vibe_installed_status() -> dict[str, dict[str, bool]]:
+    """Get installation status of each Vibe skill.
+
+    Returns:
+        Dict mapping skill directory name to {"global": bool, "local": bool}
+    """
+    return _get_installed_status("vibe")

--- a/cli/simpletask/templates/vibe/simpletask-implement/SKILL.md
+++ b/cli/simpletask/templates/vibe/simpletask-implement/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: simpletask-implement
+description: Execute task list to implement feature/fix using simpletask.
+user-invocable: true
+---
+
+**CRITICAL MANDATES**
+1. Keep task statuses accurate via MCP updates throughout execution.
+2. Run quality checks before marking any task `completed`.
+3. Update acceptance criteria after implementation.
+4. Create exactly one final Conventional Commit when all work is done.
+5. **DO NOT** skip quality checks, implement tasks with unmet prerequisites, or create multiple commits.
+
+**WORKFLOW**
+1. Load task state with `simpletask_get`. Identify executable tasks: status `not_started` with all `prerequisites` satisfied. If iterations exist, prioritize tasks in the lowest/current iteration. If the user specifies task IDs, implement only those.
+2. For each task:
+   a. Set status to `in_progress` via `simpletask_task`.
+   b. Implement using task guidance: `steps`, `files`, `done_when`, `constraints`, `code_examples`, and `design` section.
+   c. Record significant decisions or blockers with `simpletask_note`.
+   d. Verify all `done_when` conditions are met.
+   e. Run `simpletask_quality` with `action="check"`.
+   f. If quality passes and goals satisfied: set status `completed`.
+      Otherwise: set `blocked` or `paused` with a note explaining why.
+3. Mark all satisfied acceptance criteria as completed via `simpletask_criteria`.
+4. Validate task file schema: `simpletask_get` with `validate=true`.
+5. Create one conventional commit covering all changes.
+
+**OUTPUT**
+Report: tasks completed, tasks blocked/paused, criteria completed, quality result, commit details.
+
+**TOOL REFERENCE**
+MCP tools used: `simpletask_get`, `simpletask_task`, `simpletask_criteria`, `simpletask_note`, `simpletask_quality`.
+Status values: `not_started`, `in_progress`, `completed`, `blocked`, `paused`.
+Status updates via `simpletask_task`: Returns SimpleTaskWriteResponse with success confirmation.

--- a/cli/simpletask/templates/vibe/simpletask-plan/SKILL.md
+++ b/cli/simpletask/templates/vibe/simpletask-plan/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: simpletask-plan
+description: Create specification and implementation plan from feature description using simpletask.
+user-invocable: true
+---
+
+**CRITICAL: This is a PLANNING phase. DO NOT implement code or execute tasks. Your job is to create/update the task file with acceptance criteria and task breakdown - then STOP.**
+
+**Step 0: Determine Branch Name**
+
+1. **Analyze the user prompt to determine branch type prefix:**
+
+   | If prompt contains... | Suggest prefix |
+   |----------------------|----------------|
+   | "fix", "bug", "error", "issue", "broken", "crash" | `fix/` |
+   | "refactor", "cleanup", "improve", "optimize" | `refactor/` |
+   | "test", "spec", "coverage" | `test/` |
+   | "doc", "readme", "documentation" | `docs/` |
+   | "chore", "config", "update deps", "upgrade", "bump" | `chore/` |
+   | Default (new functionality) | `feature/` |
+
+2. **Generate slug from description:**
+   - Convert to lowercase
+   - Remove stop words (the, a, an, for, to, of, in, on, at, by, with, from, as, is, are, was, were, be, have, has)
+   - Filter words shorter than 3 characters
+   - Take first 3-4 meaningful words, join with hyphens
+
+3. **Construct suggested branch name:** `[prefix]/[slug]`
+
+4. **ASK USER TO CONFIRM OR CUSTOMIZE** the branch name before proceeding.
+
+5. **Store the confirmed branch name as `[branch-name]` for subsequent steps.**
+
+**Step 1: Check for Existing Task File**
+
+1. Get current git branch name:
+   ```bash
+   git branch --show-current
+   ```
+
+2. Check if already on a feature branch with existing task file:
+
+   ```
+   Use simpletask_get() MCP tool to check for existing task:
+   - Call simpletask_get() to use current git branch
+   - If successful, task file exists - analyze spec.tasks to see if empty/minimal
+   - If error (FileNotFoundError), task file does not exist
+   ```
+
+3. If task file exists for current branch:
+   - Analyze output to see if tasks are empty or minimal
+   - If tasks already exist, analyze and report current state
+   - If tasks are empty/minimal, proceed to Step 3 to add detailed tasks
+   - Use current branch name as `[branch-name]`
+
+4. If task file does NOT exist:
+   - If on main/master/develop: proceed to Step 2 to create new branch
+   - If on other branch: ask user if they want to create task file for current branch or create new branch
+
+**Step 2: Create Git Branch (if needed)**
+
+If creating a new branch (from Step 0's confirmed `[branch-name]`):
+```bash
+git checkout -b [branch-name]
+```
+
+**Step 3: Create or Update Task File**
+
+1. If task file does NOT exist, create it:
+
+   ```
+   Use simpletask_new() MCP tool to create task file:
+   - Call simpletask_new(
+       branch="[branch-name]",
+       title="[brief title from user prompt]",
+       prompt="[original user request verbatim]",
+       criteria=[]
+     )
+   ```
+
+2. If task file exists but is minimal, you can update it by adding criteria and tasks in subsequent steps.
+
+**Step 4: Add Acceptance Criteria**
+
+Add testable, specific acceptance criteria using simpletask_criteria() MCP tool:
+
+```
+Use simpletask_criteria() MCP tool to add each criterion:
+- Call simpletask_criteria(
+    action="add",
+    description="Specific, testable outcome"
+  )
+- Repeat for each criterion (typically 3-6 criteria)
+```
+
+Guidelines for acceptance criteria:
+- Must be testable (can verify if met)
+- Specific and unambiguous
+- Focus on user-visible outcomes
+- Include quality checks (tests, coverage, etc.)
+
+**Step 5: Plan Implementation Tasks**
+
+Add implementation tasks using simpletask_task() MCP tool. Each task should be:
+- Completable in 5-30 minutes
+- Detailed enough for ANY LLM to execute without clarification
+- Include specific steps (what to do)
+
+```
+Use simpletask_task() MCP tool to add each task:
+- Call simpletask_task(
+    action="add",
+    name="Short descriptive task name",
+    goal="One sentence explaining what this accomplishes",
+    steps=[
+      "First specific action",
+      "Second specific action",
+      "Third specific action"
+    ],
+    iteration=<iteration_id>  # Optional: assign to an iteration if iterations are defined
+  )
+- Repeat for each implementation task
+```
+
+**Optionally group tasks into iterations** for phased delivery (e.g., MVP, polish, v2):
+
+```
+Use simpletask_iteration() MCP tool to create iterations first:
+- simpletask_iteration(action="add", label="MVP")
+- simpletask_iteration(action="add", label="Polish")
+Then assign tasks: simpletask_task(action="add", name="...", iteration=1)
+```
+
+**Step 6: Validate and Summarize**
+
+1. Validate the task file:
+
+   ```
+   Use simpletask_get() MCP tool with validation:
+   - Call simpletask_get(validate=True)
+   - Check validation.valid in response
+   ```
+
+2. Show the complete task and report completion:
+   ```
+   Task file created/updated: .tasks/[normalized-branch-name].yml
+
+   Summary:
+   - Branch: [branch-name]
+   - Title: [title]
+   - Acceptance Criteria: [count]
+   - Implementation Tasks: [count]
+   - Status: not_started
+
+   Next steps:
+   - For complex features, run /simpletask-split to analyze codebase and split tasks
+   - For simple features, run /simpletask-implement to execute tasks
+   ```
+
+---
+
+**STOP HERE. Do NOT proceed to implementation.**
+
+The planning phase is complete when:
+1. Task file exists at `.tasks/[normalized-branch-name].yml`
+2. All acceptance criteria are defined
+3. All implementation tasks are detailed with name, goal, and steps
+4. Validation passes

--- a/cli/simpletask/templates/vibe/simpletask-review/SKILL.md
+++ b/cli/simpletask/templates/vibe/simpletask-review/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: simpletask-review
+description: Scope-bounded code review that verifies implementation against original prompt and acceptance criteria only.
+user-invocable: true
+---
+
+**IMPORTANT: Scope constraint**
+
+This review is strictly scoped to the original prompt and acceptance criteria defined in the task file. Your job is to verify that the implementation satisfies those requirements - nothing more. Do NOT suggest features, refactoring, or improvements beyond what was explicitly requested. Do NOT flag issues in code outside the git diff. Do NOT expand the PR.
+
+**Step 1: Identify Task File**
+
+1. Get current git branch name:
+   ```bash
+   git branch --show-current
+   ```
+
+2. Load task file using MCP tools:
+
+   ```
+   Use simpletask_get() MCP tool to retrieve task data:
+   - Call simpletask_get() to use current git branch (auto-detected)
+   - Returns SimpleTaskGetResponse with spec, file_path, and summary
+   - If error occurs, task file does not exist - abort and inform the user
+   ```
+
+**Step 2: Analyze Task Completion**
+
+From the `simpletask_get()` response:
+- Filter `spec.tasks` by status: completed, in_progress, not_started, blocked, paused
+- Use `summary` fields for quick counts
+
+**Step 3: Check Acceptance Criteria**
+
+From the `simpletask_get()` response:
+- Check `spec.acceptance_criteria` array for `completed` status
+- Use `summary.criteria_total` and `summary.criteria_completed` for counts
+
+**Step 4: Verify Implementation Against Criteria and Diff**
+
+Scope: only the files in `git diff --name-only main..HEAD`. Do not review anything outside the diff.
+
+For each acceptance criterion, check whether the diff actually satisfies it. Also read any implementation notes for context on decisions made.
+
+```
+Use simpletask_note() MCP tool to list notes:
+- Call simpletask_note(action="list")
+- Returns root_notes and task_notes
+```
+
+Look for:
+
+### Criteria Satisfaction
+- For each criterion: does the diff contain code that implements it?
+- Are there criteria marked complete but with no corresponding changes?
+- Are there criteria still incomplete that are actually implemented?
+
+### Security (within diff scope only)
+- Exposed credentials, API keys, or secrets
+- Input validation gaps relevant to the feature
+- Injection vulnerabilities in new code only
+
+### Correctness
+- Logic errors preventing acceptance criteria from being met
+- Missing edge cases for paths described in criteria
+- Error handling gaps causing user-visible failures
+
+**Do NOT flag:** code style, naming conventions, missing abstractions, performance of unchanged code, documentation outside feature scope.
+
+**Step 5: Analyze Git Changes**
+
+```bash
+git log --oneline main..HEAD
+git diff --stat main..HEAD
+git diff --name-only main..HEAD | head -20
+```
+
+Analyze: commits on branch, files modified, lines changed, scope focus vs scatter.
+
+**Step 6: Generate Scoped, Actionable Feedback**
+
+Only report issues that:
+- Prevent an acceptance criterion from being met, OR
+- Are Critical/High severity security or correctness issues in changed code
+
+**Categories:**
+1. **UNMET CRITERIA** - Acceptance criteria not satisfied
+2. **SECURITY** - Critical/High severity in new/changed code only
+3. **CORRECTNESS** - Logic errors preventing feature from working
+4. **SCOPE CREEP** - Changes beyond original prompt (informational)
+
+**Step 7: Determine PR Readiness**
+
+- **READY TO MERGE**: All tasks completed, all criteria met, no blocking issues
+- **NEEDS CHANGES**: All done but has Critical/High severity issues
+- **NOT READY**: Tasks incomplete, criteria unmet, or critical flaws
+
+**Step 8: Display Review Summary**
+
+Show: original prompt, task completion stats, criteria status, git changes, blocking issues, observations, and PR readiness determination.
+
+**Step 9: Auto-Inject Fix Tasks (blocking issues only)**
+
+If Critical/High severity blocking issues exist:
+
+1. Create iteration: `simpletask_iteration(action="add", label="review fixes")`
+2. Add fix tasks: `simpletask_task(action="add", name="Fix: [issue]", goal="[remediation]", iteration=<id>)`
+3. Validate: `simpletask_get(validate=True)`
+
+If no blocking issues: report "No fix tasks needed."
+
+---
+
+## Quality Gates
+
+Before marking as "READY TO MERGE":
+1. All tasks completed
+2. All criteria met
+3. No blocking issues
+4. Tests pass
+5. Schema valid: `simpletask_get(validate=True)`

--- a/cli/simpletask/templates/vibe/simpletask-split/SKILL.md
+++ b/cli/simpletask/templates/vibe/simpletask-split/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: simpletask-split
+description: Split complex tasks into atomic subtasks to reduce cognitive load for AI execution.
+user-invocable: true
+---
+
+**Purpose:** This skill ensures AI models have minimal context per task by splitting complex tasks into ultra-atomic units (1-2 steps, 5-10 minutes). This eliminates ambiguity and decision-making during implementation.
+
+**CRITICAL: This is a TASK REFINEMENT phase. You will automatically split ALL complex tasks, remove originals, add subtasks, renumber IDs, and update the task file. No preview, no confirmation - execute immediately.**
+
+---
+
+## Step 1: Load Task File
+
+```
+simpletask_get()  # Uses current git branch
+Returns: SimpleTaskGetResponse with spec, file_path, summary
+```
+
+If task file not found: Report "No task file found. Run /simpletask-plan first." and STOP.
+
+---
+
+## Step 1.5: Codebase Analysis & Design (Conditional)
+
+**SKIP this step if:**
+- `simpletask_get()` shows `spec.design` is already populated (has patterns, constraints, or references)
+- `simpletask_get()` shows `spec.quality_requirements` already configured
+
+**If design section is empty or missing, execute this mandatory codebase analysis:**
+
+### 1.5.1: Find Reference Implementations
+
+Search the codebase for similar existing code. Look for:
+- Similar functionality or patterns
+- Existing implementations to follow
+- Code that solves related problems
+
+Document findings:
+```
+Use simpletask_design() MCP tool to add references:
+- Call simpletask_design(
+    action="set",
+    field="reference",
+    value="[file path]",
+    reason="[why this is relevant]"
+  )
+```
+
+### 1.5.2: Document Patterns to Follow
+
+Analyze relevant files to identify coding patterns (Repository, Factory, Observer, etc.), code organization, naming conventions, and dependency injection patterns.
+
+```
+Call simpletask_design(
+  action="set",
+  field="pattern",
+  value="[Pattern description]"
+)
+```
+
+### 1.5.3: Define Architectural Constraints
+
+Analyze codebase structure for layer separation rules, module boundaries, and technology stack limitations.
+
+```
+Call simpletask_design(
+  action="set",
+  field="constraint",
+  value="[Constraint description]"
+)
+```
+
+### 1.5.4: Identify Security Considerations
+
+Analyze relevant files for input validation, authentication/authorization patterns, data sanitization, and sensitive data handling.
+
+```
+Call simpletask_design(
+  action="set",
+  field="security",
+  value="[Security consideration]"
+)
+```
+
+### 1.5.5: Define Error Handling Pattern
+
+Identify how errors are handled: exception types, error propagation, logging, and user-facing messages.
+
+```
+Call simpletask_design(
+  action="set",
+  field="error-handling",
+  value="[Error handling pattern]"
+)
+```
+
+### 1.5.6: Define Quality Requirements
+
+Based on the codebase tech stack, apply a quality preset:
+
+```
+Call simpletask_quality(
+  action="preset",
+  preset_name="[python|typescript|node|go|rust|java-maven|java-gradle]"
+)
+```
+
+**After completing Step 1.5, reload the task file:**
+```
+simpletask_get()  # Refresh to see populated design section
+```
+
+---
+
+## Step 2: Identify Tasks to Split
+
+**A task MUST be split if it meets ANY criterion:**
+- **>2 steps** in the steps array
+- **>1 file** in the files array
+- **>3 conditions** in done_when array
+- **>100 characters** in goal description
+
+**SKIP splitting (already atomic) if:**
+- Exactly 1 step AND step <50 characters
+- Task name contains: "Add import", "Update version", "Fix typo", "Remove unused", "Rename variable"
+- Task name starts with "Fix:" (bug fixes need full context)
+
+---
+
+## Step 3: Analyze and Generate Subtasks
+
+For EACH complex task, generate atomic subtasks using these patterns:
+
+### Pattern Recognition Guide
+
+**1. Model/Class Creation** (Multiple methods/fields):
+- Subtask per field/method group
+
+**2. API Endpoint** (Multiple concerns):
+- Route file, endpoint skeleton, validation, logic, response, error handling
+
+**3. Multi-File Feature** (Touches multiple files):
+- Each file operation = separate subtask
+
+**4. Testing** (Multiple test cases):
+- Each test case = separate subtask
+
+**5. Configuration + Implementation** (Setup then use):
+- Config, setup, core implementation, integration
+
+### Subtask Generation Rules
+
+**Each subtask MUST have:**
+- 1-2 steps maximum (preferably 1)
+- Single clear objective
+- Completable in 5-10 minutes
+- No ambiguity
+
+---
+
+## Step 4: Apply Changes Atomically with Batch Operations
+
+**CRITICAL:** Use batch operations to remove complex tasks and add subtasks atomically.
+
+```python
+operations = []
+
+# Remove complex tasks
+for task in complex_tasks:
+    operations.append({"op": "remove", "task_id": task.id})
+
+# Add subtasks
+for subtask in generated_subtasks:
+    operations.append({
+        "op": "add",
+        "name": subtask.name,
+        "goal": subtask.goal,
+        "steps": subtask.steps
+    })
+
+# Execute atomically
+result = simpletask_task(action="batch", operations=operations)
+```
+
+---
+
+## Step 5: Renumber Task IDs Sequentially
+
+Renumber ALL tasks to sequential IDs (T001, T002, T003...) and update prerequisites.
+
+1. Load updated task file with `simpletask_get()`
+2. Create ID mapping: old_id -> new_id
+3. Edit `.tasks/[branch].yml` directly to update IDs and prerequisite references
+4. Verify all IDs sequential, all prerequisite references valid
+
+---
+
+## Step 6: Validate and Report
+
+```
+simpletask_get(validate=True)
+```
+
+Generate split summary showing: original state, splitting results, cognitive load reduction, and validation status.
+
+Next steps:
+- Review split tasks: `simpletask show`
+- Start implementation: `/simpletask-implement`

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -9,6 +9,7 @@ This guide covers how to integrate simpletask with AI editors using the Model Co
   - [OpenCode](#opencode)
   - [Qwen-CLI](#qwen-cli)
   - [Gemini CLI](#gemini-cli)
+  - [Mistral Vibe](#mistral-vibe)
   - [Other MCP Clients](#other-mcp-clients)
 - [Available Tools](#available-tools)
   - [get](#get)
@@ -197,6 +198,38 @@ Gemini CLI is a command-line AI assistant with MCP support.
 **Verify connection:**
 ```sh
 gemini "List available MCP tools"
+```
+
+### Mistral Vibe
+
+Mistral Vibe is a coding assistant that supports custom skills via SKILL.md files. simpletask integrates via skills rather than MCP — each workflow phase (plan, split, implement, review) is a separate skill that guides Vibe through the simpletask workflow.
+
+**Install simpletask skills:**
+
+```sh
+simpletask ai install --vibe
+```
+
+This installs skills to `~/.vibe/skills/`. For project-local installation:
+
+```sh
+simpletask ai install --vibe --local  # installs to .vibe/skills/
+```
+
+**Installed skills:**
+
+| Skill | Description |
+|-------|-------------|
+| `simpletask-plan` | Create task specification from feature description |
+| `simpletask-split` | Analyze codebase and split complex tasks into atomic subtasks |
+| `simpletask-implement` | Execute tasks step-by-step |
+| `simpletask-review` | Review implementation against acceptance criteria |
+
+**Note:** Vibe skills use the simpletask CLI (`simpletask serve` is not required for Vibe). Ensure `simpletask` is on your `PATH` before invoking a skill.
+
+**Verify installation:**
+```sh
+simpletask ai list
 ```
 
 ### Other MCP Clients

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simpletask"
-version = "0.28.0"
+version = "0.29.0"
 description = "CLI tool for managing AI-friendly task definitions in branch-based development workflows"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/tests/integration/test_ai_install_cli.py
+++ b/tests/integration/test_ai_install_cli.py
@@ -15,18 +15,27 @@ class TestAiInstallCLI:
     @patch("simpletask.commands.ai.install.get_global_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_qwen_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_gemini_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_agents_dir")
-    def test_default_installs_all_three_editors(
-        self, mock_agents_dir, mock_gemini_dir, mock_qwen_dir, mock_opencode_dir, tmp_path: Path
+    def test_default_installs_all_four_editors(
+        self,
+        mock_agents_dir,
+        mock_vibe_dir,
+        mock_gemini_dir,
+        mock_qwen_dir,
+        mock_opencode_dir,
+        tmp_path: Path,
     ):
-        """Should install all three editors (OpenCode, Qwen, Gemini) by default."""
+        """Should install all four editors (OpenCode, Qwen, Gemini, Vibe) by default."""
         opencode_dir = tmp_path / "opencode"
         qwen_dir = tmp_path / "qwen"
         gemini_dir = tmp_path / "gemini"
+        vibe_dir = tmp_path / "vibe"
         agents_dir = tmp_path / "agents"
         mock_opencode_dir.return_value = opencode_dir
         mock_qwen_dir.return_value = qwen_dir
         mock_gemini_dir.return_value = gemini_dir
+        mock_vibe_dir.return_value = vibe_dir
         mock_agents_dir.return_value = agents_dir
 
         result = runner.invoke(app, ["ai", "install"])
@@ -35,8 +44,9 @@ class TestAiInstallCLI:
         assert "Installing OpenCode commands" in result.stdout
         assert "Installing Qwen commands" in result.stdout
         assert "Installing Gemini CLI commands" in result.stdout
+        assert "Installing Mistral Vibe skills" in result.stdout
 
-        # Verify all three sets of files were created
+        # Verify all four sets of files were created
         assert (opencode_dir / "simpletask.plan.md").exists()
         assert (opencode_dir / "simpletask.implement.md").exists()
         assert (opencode_dir / "simpletask.review.md").exists()
@@ -46,6 +56,8 @@ class TestAiInstallCLI:
         assert (gemini_dir / "simpletask.plan.toml").exists()
         assert (gemini_dir / "simpletask.implement.toml").exists()
         assert (gemini_dir / "simpletask.review.toml").exists()
+        assert (vibe_dir / "simpletask-plan").is_dir()
+        assert (vibe_dir / "simpletask-plan" / "SKILL.md").exists()
 
     @patch("simpletask.commands.ai.install.get_global_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_qwen_commands_dir")
@@ -393,3 +405,133 @@ class TestAiInstallAgentsCLI:
         # Verify existing agent was overwritten
         assert existing_agent.read_text() != old_content
         assert len(existing_agent.read_text()) > 0
+
+
+class TestAiInstallVibeCLI:
+    """Integration tests for Vibe skill installation via 'simpletask ai install' command."""
+
+    @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
+    def test_vibe_flag_only(self, mock_vibe_dir, tmp_path: Path):
+        """Should install only Vibe skills with --vibe flag."""
+        vibe_dir = tmp_path / "vibe"
+        mock_vibe_dir.return_value = vibe_dir
+
+        result = runner.invoke(app, ["ai", "install", "--vibe"])
+
+        assert result.exit_code == 0
+        assert "Installing Mistral Vibe skills" in result.stdout
+        assert "Installing OpenCode commands" not in result.stdout
+        assert "Installing Qwen commands" not in result.stdout
+        assert "Installing Gemini CLI commands" not in result.stdout
+
+        # Verify skill directories were created with SKILL.md inside
+        assert (vibe_dir / "simpletask-plan").is_dir()
+        assert (vibe_dir / "simpletask-plan" / "SKILL.md").exists()
+        assert (vibe_dir / "simpletask-split").is_dir()
+        assert (vibe_dir / "simpletask-implement").is_dir()
+        assert (vibe_dir / "simpletask-review").is_dir()
+
+    @patch("simpletask.commands.ai.install.get_global_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_qwen_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_gemini_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_agents_dir")
+    def test_default_installs_all_four_editors(
+        self,
+        mock_agents_dir,
+        mock_vibe_dir,
+        mock_gemini_dir,
+        mock_qwen_dir,
+        mock_opencode_dir,
+        tmp_path: Path,
+    ):
+        """Should install all four editors (including Vibe) by default."""
+        opencode_dir = tmp_path / "opencode"
+        qwen_dir = tmp_path / "qwen"
+        gemini_dir = tmp_path / "gemini"
+        vibe_dir = tmp_path / "vibe"
+        agents_dir = tmp_path / "agents"
+        mock_opencode_dir.return_value = opencode_dir
+        mock_qwen_dir.return_value = qwen_dir
+        mock_gemini_dir.return_value = gemini_dir
+        mock_vibe_dir.return_value = vibe_dir
+        mock_agents_dir.return_value = agents_dir
+
+        result = runner.invoke(app, ["ai", "install"])
+
+        assert result.exit_code == 0
+        assert "Installing OpenCode commands" in result.stdout
+        assert "Installing Qwen commands" in result.stdout
+        assert "Installing Gemini CLI commands" in result.stdout
+        assert "Installing Mistral Vibe skills" in result.stdout
+
+        # Verify Vibe skill directories were created
+        assert (vibe_dir / "simpletask-plan").is_dir()
+        assert (vibe_dir / "simpletask-plan" / "SKILL.md").exists()
+
+    @patch("simpletask.commands.ai.install.get_local_vibe_commands_dir")
+    def test_vibe_local_flag(self, mock_vibe_dir, tmp_path: Path):
+        """Should install Vibe skills to local directory with --local flag."""
+        vibe_dir = tmp_path / "vibe_local"
+        mock_vibe_dir.return_value = vibe_dir
+
+        result = runner.invoke(app, ["ai", "install", "--vibe", "--local"])
+
+        assert result.exit_code == 0
+        assert "Installing Mistral Vibe skills" in result.stdout
+        assert str(vibe_dir) in result.stdout
+
+        # Verify skills were installed in local directory
+        assert (vibe_dir / "simpletask-plan").is_dir()
+        assert (vibe_dir / "simpletask-plan" / "SKILL.md").exists()
+
+    @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
+    def test_vibe_no_overwrite_skips_existing(self, mock_vibe_dir, tmp_path: Path):
+        """Should skip existing Vibe skill directories when --no-overwrite is used."""
+        vibe_dir = tmp_path / "vibe"
+        vibe_dir.mkdir(parents=True)
+        mock_vibe_dir.return_value = vibe_dir
+
+        # Create existing skill directory
+        existing = vibe_dir / "simpletask-plan"
+        existing.mkdir()
+        (existing / "SKILL.md").write_text("old content")
+
+        result = runner.invoke(app, ["ai", "install", "--vibe", "--no-overwrite"])
+
+        assert result.exit_code == 0
+        assert "Skipped (already exists): simpletask-plan" in result.stdout
+
+        # Verify existing skill was not overwritten
+        assert (existing / "SKILL.md").read_text() == "old content"
+
+    @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
+    def test_vibe_overwrite_default(self, mock_vibe_dir, tmp_path: Path):
+        """Should overwrite existing Vibe skill directories by default."""
+        vibe_dir = tmp_path / "vibe"
+        vibe_dir.mkdir(parents=True)
+        mock_vibe_dir.return_value = vibe_dir
+
+        # Create existing skill directory with old content
+        existing = vibe_dir / "simpletask-plan"
+        existing.mkdir()
+        (existing / "SKILL.md").write_text("old content")
+
+        result = runner.invoke(app, ["ai", "install", "--vibe"])
+
+        assert result.exit_code == 0
+        assert "Overwriting: simpletask-plan" in result.stdout
+
+        # Verify existing skill was overwritten
+        assert (existing / "SKILL.md").read_text() != "old content"
+
+    @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
+    def test_vibe_does_not_install_agents(self, mock_vibe_dir, tmp_path: Path):
+        """Vibe-only install should NOT install OpenCode agents."""
+        vibe_dir = tmp_path / "vibe"
+        mock_vibe_dir.return_value = vibe_dir
+
+        result = runner.invoke(app, ["ai", "install", "--vibe"])
+
+        assert result.exit_code == 0
+        assert "Installing OpenCode agents" not in result.stdout

--- a/tests/unit/test_ai_commands.py
+++ b/tests/unit/test_ai_commands.py
@@ -9,22 +9,27 @@ from simpletask.core.ai_templates import (
     get_bundled_gemini_templates,
     get_bundled_qwen_templates,
     get_bundled_templates,
+    get_bundled_vibe_templates,
     get_gemini_installed_status,
     get_gemini_templates_dir,
     get_global_agents_dir,
     get_global_commands_dir,
     get_global_gemini_commands_dir,
     get_global_qwen_commands_dir,
+    get_global_vibe_commands_dir,
     get_installed_status,
     get_local_agents_dir,
     get_local_commands_dir,
     get_local_gemini_commands_dir,
     get_local_qwen_commands_dir,
+    get_local_vibe_commands_dir,
     get_qwen_installed_status,
+    get_vibe_installed_status,
     install_agents,
     install_gemini_templates,
     install_qwen_templates,
     install_templates,
+    install_vibe_templates,
 )
 
 
@@ -1047,21 +1052,28 @@ class TestAgentTemplateContent:
 
 
 class TestCrossEditorConsistency:
-    """Verify consistency across OpenCode, Qwen, and Gemini templates."""
+    """Verify consistency across OpenCode, Qwen, Gemini, and Vibe templates."""
 
     def test_all_editors_have_same_template_names(self):
         """All editors should have templates with the same base names."""
         opencode_templates = get_bundled_templates()
         qwen_templates = get_bundled_qwen_templates()
         gemini_templates = get_bundled_gemini_templates()
+        vibe_templates = get_bundled_vibe_templates()
 
         # Extract base names (stems) without extensions
         opencode_bases = sorted([t.stem for t in opencode_templates])
         qwen_bases = sorted([t.stem for t in qwen_templates])
         gemini_bases = sorted([t.stem for t in gemini_templates])
+        # Vibe uses hyphen naming (simpletask-plan); normalise dots to hyphens for comparison
+        vibe_bases = sorted([t.name.replace("-", ".") for t in vibe_templates])
 
         assert opencode_bases == qwen_bases == gemini_bases, (
-            "All editors should have the same template base names"
+            "All flat-file editors should have the same template base names"
+        )
+        # Vibe names after normalisation should also match (simpletask-plan -> simpletask.plan)
+        assert opencode_bases == vibe_bases, (
+            "Vibe skill names (after normalisation) should match other editors"
         )
 
     def test_all_split_templates_have_splitting_criteria(self):
@@ -1069,19 +1081,23 @@ class TestCrossEditorConsistency:
         opencode_templates = get_bundled_templates()
         qwen_templates = get_bundled_qwen_templates()
         gemini_templates = get_bundled_gemini_templates()
+        vibe_templates = get_bundled_vibe_templates()
 
         opencode_split = next((t for t in opencode_templates if t.stem == "simpletask.split"), None)
         qwen_split = next((t for t in qwen_templates if t.stem == "simpletask.split"), None)
         gemini_split = next((t for t in gemini_templates if t.stem == "simpletask.split"), None)
+        vibe_split = next((t for t in vibe_templates if t.name == "simpletask-split"), None)
 
         assert opencode_split is not None
         assert qwen_split is not None
         assert gemini_split is not None
+        assert vibe_split is not None
 
         # Read files once outside the loop for efficiency
         opencode_content = opencode_split.read_text()
         qwen_content = qwen_split.read_text()
         gemini_content = gemini_split.read_text()
+        vibe_content = (vibe_split / "SKILL.md").read_text()
 
         # Splitting criteria markers that should be in all templates
         splitting_criteria = [
@@ -1095,22 +1111,26 @@ class TestCrossEditorConsistency:
             assert criterion in opencode_content, f"OpenCode missing: {criterion}"
             assert criterion in qwen_content, f"Qwen missing: {criterion}"
             assert criterion in gemini_content, f"Gemini missing: {criterion}"
+            assert criterion in vibe_content, f"Vibe missing: {criterion}"
 
     def test_all_implement_templates_reference_same_mcp_tools(self):
         """All implement templates should reference the same core MCP tools."""
         opencode_templates = get_bundled_templates()
         qwen_templates = get_bundled_qwen_templates()
         gemini_templates = get_bundled_gemini_templates()
+        vibe_templates = get_bundled_vibe_templates()
 
         opencode_impl = next(
             (t for t in opencode_templates if t.stem == "simpletask.implement"), None
         )
         qwen_impl = next((t for t in qwen_templates if t.stem == "simpletask.implement"), None)
         gemini_impl = next((t for t in gemini_templates if t.stem == "simpletask.implement"), None)
+        vibe_impl = next((t for t in vibe_templates if t.name == "simpletask-implement"), None)
 
         assert opencode_impl is not None
         assert qwen_impl is not None
         assert gemini_impl is not None
+        assert vibe_impl is not None
 
         # Core MCP tools that should be in all implement templates
         core_mcp_tools = [
@@ -1125,11 +1145,13 @@ class TestCrossEditorConsistency:
         opencode_content = opencode_impl.read_text()
         qwen_content = qwen_impl.read_text()
         gemini_content = gemini_impl.read_text()
+        vibe_content = (vibe_impl / "SKILL.md").read_text()
 
         for tool in core_mcp_tools:
             assert tool in opencode_content, f"OpenCode missing MCP tool: {tool}"
             assert tool in qwen_content, f"Qwen missing MCP tool: {tool}"
             assert tool in gemini_content, f"Gemini missing MCP tool: {tool}"
+            assert tool in vibe_content, f"Vibe missing MCP tool: {tool}"
 
     def test_no_branch_parameter_in_any_implement_template(self):
         """No implement template should reference branch=None (removed in v0.18.0)."""
@@ -1639,3 +1661,521 @@ class TestAgentEditorRestrictions:
 
         result = _get_bundled_agents("gemini")
         assert result == []
+
+    def test_get_global_agents_dir_rejects_vibe(self):
+        """Should raise ValueError for Vibe editor."""
+        from simpletask.core.ai_templates import _get_global_agents_dir
+
+        with pytest.raises(ValueError, match="does not support agents"):
+            _get_global_agents_dir("vibe")
+
+    def test_get_local_agents_dir_rejects_vibe(self):
+        """Should raise ValueError for Vibe editor."""
+        from simpletask.core.ai_templates import _get_local_agents_dir
+
+        with pytest.raises(ValueError, match="does not support agents"):
+            _get_local_agents_dir("vibe")
+
+    def test_get_bundled_agents_vibe_returns_empty(self):
+        """Should return empty list for Vibe editor."""
+        from simpletask.core.ai_templates import _get_bundled_agents
+
+        result = _get_bundled_agents("vibe")
+        assert result == []
+
+
+class TestGetBundledVibeTemplates:
+    """Tests for get_bundled_vibe_templates function."""
+
+    def test_returns_list_of_paths(self):
+        """Should return a list of Path objects."""
+        templates = get_bundled_vibe_templates()
+        assert isinstance(templates, list)
+        for template in templates:
+            assert isinstance(template, Path)
+
+    def test_returns_directories_not_files(self):
+        """Should return directories (skill dirs), not files."""
+        templates = get_bundled_vibe_templates()
+        for template in templates:
+            assert template.is_dir(), f"{template.name} should be a directory"
+
+    def test_each_directory_contains_skill_md(self):
+        """Each skill directory should contain a SKILL.md file."""
+        templates = get_bundled_vibe_templates()
+        for template in templates:
+            skill_file = template / "SKILL.md"
+            assert skill_file.exists(), f"{template.name} missing SKILL.md"
+            assert skill_file.is_file()
+
+    def test_returns_expected_templates(self):
+        """Should return the four bundled Vibe skill directories."""
+        templates = get_bundled_vibe_templates()
+        template_names = {t.name for t in templates}
+
+        expected = {
+            "simpletask-plan",
+            "simpletask-split",
+            "simpletask-implement",
+            "simpletask-review",
+        }
+
+        assert template_names == expected
+
+
+class TestGetGlobalVibeCommandsDir:
+    """Tests for get_global_vibe_commands_dir function."""
+
+    def test_returns_path_object(self):
+        """Should return a Path object."""
+        result = get_global_vibe_commands_dir()
+        assert isinstance(result, Path)
+
+    def test_returns_expected_location(self):
+        """Should return ~/.vibe/skills/"""
+        result = get_global_vibe_commands_dir()
+        expected = Path.home() / ".vibe" / "skills"
+        assert result == expected
+
+
+class TestGetLocalVibeCommandsDir:
+    """Tests for get_local_vibe_commands_dir function."""
+
+    def test_returns_path_object(self):
+        """Should return a Path object."""
+        result = get_local_vibe_commands_dir()
+        assert isinstance(result, Path)
+
+    def test_returns_expected_location(self):
+        """Should return .vibe/skills/ in current directory."""
+        result = get_local_vibe_commands_dir()
+        expected = Path.cwd() / ".vibe" / "skills"
+        assert result == expected
+
+
+class TestInstallVibeTemplates:
+    """Tests for install_vibe_templates function."""
+
+    def test_install_to_empty_directory(self, tmp_path: Path):
+        """Should successfully install all Vibe skill directories to empty directory."""
+        target_dir = tmp_path / "skills"
+
+        installed, skipped, overwritten = install_vibe_templates(target_dir, no_overwrite=False)
+
+        # Should create target directory
+        assert target_dir.exists()
+
+        # Should install all four skill directories
+        assert len(installed) == 4
+        assert len(skipped) == 0
+        assert len(overwritten) == 0
+
+        # All skill directories should exist in target with SKILL.md inside
+        for name in installed:
+            skill_dir = target_dir / name
+            assert skill_dir.exists()
+            assert skill_dir.is_dir()
+            assert (skill_dir / "SKILL.md").exists()
+
+    def test_overwrite_existing_directories(self, tmp_path: Path):
+        """Should overwrite existing directories when no_overwrite=False."""
+        target_dir = tmp_path / "skills"
+        target_dir.mkdir(parents=True)
+
+        # Create existing skill directory with old content
+        existing_dir = target_dir / "simpletask-plan"
+        existing_dir.mkdir()
+        (existing_dir / "SKILL.md").write_text("old content")
+
+        installed, _skipped, overwritten = install_vibe_templates(target_dir, no_overwrite=False)
+
+        # Should report one overwrite
+        assert "simpletask-plan" in overwritten
+        assert len(overwritten) == 1
+
+        # Should not report overwritten dirs as newly installed
+        assert "simpletask-plan" not in installed
+
+        # Should install the other three
+        assert len(installed) == 3
+
+        # Directory should have new content (not "old content")
+        assert (existing_dir / "SKILL.md").read_text() != "old content"
+        assert len((existing_dir / "SKILL.md").read_text()) > 0
+
+    def test_no_overwrite_skips_existing(self, tmp_path: Path):
+        """Should skip existing directories when no_overwrite=True."""
+        target_dir = tmp_path / "skills"
+        target_dir.mkdir(parents=True)
+
+        # Create existing skill directory
+        existing_dir = target_dir / "simpletask-plan"
+        existing_dir.mkdir()
+        old_content = "old content"
+        (existing_dir / "SKILL.md").write_text(old_content)
+
+        installed, skipped, overwritten = install_vibe_templates(target_dir, no_overwrite=True)
+
+        # Should report one skip
+        assert "simpletask-plan" in skipped
+        assert len(skipped) == 1
+
+        # Should not report as overwritten
+        assert len(overwritten) == 0
+
+        # Should install the other three
+        assert len(installed) == 3
+
+        # Original content should be unchanged
+        assert (existing_dir / "SKILL.md").read_text() == old_content
+
+    def test_creates_target_directory(self, tmp_path: Path):
+        """Should create target directory if it doesn't exist."""
+        target_dir = tmp_path / "nested" / "path" / "skills"
+
+        assert not target_dir.exists()
+
+        install_vibe_templates(target_dir, no_overwrite=False)
+
+        assert target_dir.exists()
+        assert target_dir.is_dir()
+
+
+class TestGetVibeInstalledStatus:
+    """Tests for get_vibe_installed_status function."""
+
+    def test_no_installations(self, tmp_path: Path, monkeypatch):
+        """Should report nothing installed when directories don't exist."""
+        fake_global = tmp_path / "global"
+        fake_local = tmp_path / "local"
+
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_global_commands_dir",
+            lambda editor: fake_global,
+        )
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_local_commands_dir",
+            lambda editor: fake_local,
+        )
+
+        status = get_vibe_installed_status()
+
+        # All skills should report not installed
+        for _skill_name, locations in status.items():
+            assert locations["global"] is False
+            assert locations["local"] is False
+
+    def test_global_only(self, tmp_path: Path, monkeypatch):
+        """Should detect Vibe skills in global directory only."""
+        fake_global = tmp_path / "global"
+        fake_global.mkdir(parents=True)
+        fake_local = tmp_path / "local"
+
+        # Install to global
+        install_vibe_templates(fake_global, no_overwrite=False)
+
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_global_commands_dir",
+            lambda editor: fake_global,
+        )
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_local_commands_dir",
+            lambda editor: fake_local,
+        )
+
+        status = get_vibe_installed_status()
+
+        # All skills should be in global, none in local
+        for _skill_name, locations in status.items():
+            assert locations["global"] is True
+            assert locations["local"] is False
+
+    def test_local_only(self, tmp_path: Path, monkeypatch):
+        """Should detect Vibe skills in local directory only."""
+        fake_global = tmp_path / "global"
+        fake_local = tmp_path / "local"
+        fake_local.mkdir(parents=True)
+
+        # Install to local
+        install_vibe_templates(fake_local, no_overwrite=False)
+
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_global_commands_dir",
+            lambda editor: fake_global,
+        )
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_local_commands_dir",
+            lambda editor: fake_local,
+        )
+
+        status = get_vibe_installed_status()
+
+        # All skills should be in local, none in global
+        for _skill_name, locations in status.items():
+            assert locations["global"] is False
+            assert locations["local"] is True
+
+    def test_both_locations(self, tmp_path: Path, monkeypatch):
+        """Should detect Vibe skills in both directories."""
+        fake_global = tmp_path / "global"
+        fake_global.mkdir(parents=True)
+        fake_local = tmp_path / "local"
+        fake_local.mkdir(parents=True)
+
+        # Install to both
+        install_vibe_templates(fake_global, no_overwrite=False)
+        install_vibe_templates(fake_local, no_overwrite=False)
+
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_global_commands_dir",
+            lambda editor: fake_global,
+        )
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_local_commands_dir",
+            lambda editor: fake_local,
+        )
+
+        status = get_vibe_installed_status()
+
+        # All skills should be in both locations
+        for _skill_name, locations in status.items():
+            assert locations["global"] is True
+            assert locations["local"] is True
+
+
+class TestVibeSkillContent:
+    """Validate Vibe SKILL.md template content structure."""
+
+    def test_all_skills_have_agent_skills_frontmatter(self):
+        """Each Vibe SKILL.md should have Agent Skills frontmatter."""
+        templates = get_bundled_vibe_templates()
+        for template in templates:
+            content = (template / "SKILL.md").read_text()
+            assert content.startswith("---\n"), f"{template.name} missing frontmatter opening"
+            assert "\n---\n" in content, f"{template.name} missing frontmatter closing"
+            assert "name:" in content, f"{template.name} missing name field"
+            assert "description:" in content, f"{template.name} missing description field"
+            assert "user-invocable: true" in content, (
+                f"{template.name} missing user-invocable: true"
+            )
+
+    def test_skill_names_match_directory_names(self):
+        """Frontmatter name field should match the directory name."""
+        templates = get_bundled_vibe_templates()
+        for template in templates:
+            content = (template / "SKILL.md").read_text()
+            # Parse frontmatter name
+            for line in content.split("\n"):
+                if line.startswith("name:"):
+                    name_value = line.split(":", 1)[1].strip()
+                    assert name_value == template.name, (
+                        f"Directory {template.name} has mismatched name: {name_value}"
+                    )
+                    break
+
+    def test_split_skill_has_splitting_criteria(self):
+        """Vibe split skill should define splitting criteria."""
+        templates = get_bundled_vibe_templates()
+        split_template = next((t for t in templates if t.name == "simpletask-split"), None)
+        assert split_template is not None
+
+        content = (split_template / "SKILL.md").read_text()
+
+        splitting_criteria = [">2 steps", ">1 file", ">3 conditions", ">100 characters"]
+        for criterion in splitting_criteria:
+            assert criterion in content, f"Missing splitting criterion: {criterion}"
+
+    def test_implement_skill_references_mcp_tools(self):
+        """Vibe implement skill should reference core MCP tools."""
+        templates = get_bundled_vibe_templates()
+        impl_template = next((t for t in templates if t.name == "simpletask-implement"), None)
+        assert impl_template is not None
+
+        content = (impl_template / "SKILL.md").read_text()
+
+        core_mcp_tools = [
+            "simpletask_get",
+            "simpletask_task",
+            "simpletask_criteria",
+            "simpletask_note",
+            "simpletask_quality",
+        ]
+
+        for tool in core_mcp_tools:
+            assert tool in content, f"Missing MCP tool reference: {tool}"
+
+    def test_no_branch_parameter_in_any_skill(self):
+        """No Vibe skill should contain deprecated branch=None."""
+        templates = get_bundled_vibe_templates()
+        for template in templates:
+            content = (template / "SKILL.md").read_text()
+            assert "branch=None" not in content, f"{template.name} has deprecated branch=None"
+
+    def test_skill_size_under_500_lines(self):
+        """Each Vibe SKILL.md should be under 500 lines for token efficiency."""
+        templates = get_bundled_vibe_templates()
+        for template in templates:
+            content = (template / "SKILL.md").read_text()
+            line_count = len(content.splitlines())
+            assert line_count < 500, (
+                f"{template.name}/SKILL.md is {line_count} lines, should be <500"
+            )
+
+
+class TestVibeAndOtherEditorConsistency:
+    """Verify Vibe templates are consistent with other editors."""
+
+    def test_vibe_has_same_template_count(self):
+        """Vibe should have the same number of templates as other editors."""
+        opencode_count = len(get_bundled_templates())
+        qwen_count = len(get_bundled_qwen_templates())
+        gemini_count = len(get_bundled_gemini_templates())
+        vibe_count = len(get_bundled_vibe_templates())
+
+        assert vibe_count == opencode_count == qwen_count == gemini_count
+
+    def test_vibe_has_matching_base_names(self):
+        """Vibe skill directory names should match other editors' template base names.
+
+        Vibe uses hyphen naming (simpletask-plan) while others use dot naming
+        (simpletask.plan), so we normalize by replacing dots with hyphens.
+        """
+        opencode_templates = get_bundled_templates()
+        vibe_templates = get_bundled_vibe_templates()
+
+        # OpenCode base names: simpletask.plan -> simpletask-plan (normalize dots to hyphens)
+        opencode_bases = sorted([t.stem.replace(".", "-") for t in opencode_templates])
+        vibe_bases = sorted([t.name for t in vibe_templates])
+
+        assert opencode_bases == vibe_bases, (
+            "Vibe and OpenCode should have matching template names (after normalization)"
+        )
+
+    def test_all_split_templates_have_splitting_criteria_including_vibe(self):
+        """All editors including Vibe should define the same splitting criteria."""
+        vibe_templates = get_bundled_vibe_templates()
+        vibe_split = next((t for t in vibe_templates if t.name == "simpletask-split"), None)
+        assert vibe_split is not None
+
+        vibe_content = (vibe_split / "SKILL.md").read_text()
+
+        splitting_criteria = [">2 steps", ">1 file", ">3 conditions", ">100 characters"]
+        for criterion in splitting_criteria:
+            assert criterion in vibe_content, f"Vibe missing splitting criterion: {criterion}"
+
+
+class TestInstallSkillDirs:
+    """Tests for _install_skill_dirs internal function."""
+
+    def test_install_to_empty_directory(self, tmp_path: Path):
+        """Should copy skill directories to target."""
+        from simpletask.core.ai_templates import _install_skill_dirs
+
+        # Create source skill directories
+        source_dir = tmp_path / "source"
+        skill_a = source_dir / "skill-a"
+        skill_a.mkdir(parents=True)
+        (skill_a / "SKILL.md").write_text("# Skill A")
+
+        skill_b = source_dir / "skill-b"
+        skill_b.mkdir(parents=True)
+        (skill_b / "SKILL.md").write_text("# Skill B")
+
+        target_dir = tmp_path / "target"
+
+        installed, skipped, overwritten = _install_skill_dirs(
+            [skill_a, skill_b], target_dir, no_overwrite=False
+        )
+
+        assert len(installed) == 2
+        assert len(skipped) == 0
+        assert len(overwritten) == 0
+        assert (target_dir / "skill-a" / "SKILL.md").read_text() == "# Skill A"
+        assert (target_dir / "skill-b" / "SKILL.md").read_text() == "# Skill B"
+
+    def test_overwrite_existing_skill_dir(self, tmp_path: Path):
+        """Should overwrite existing skill directory when no_overwrite=False."""
+        from simpletask.core.ai_templates import _install_skill_dirs
+
+        # Create source
+        source_dir = tmp_path / "source" / "skill-a"
+        source_dir.mkdir(parents=True)
+        (source_dir / "SKILL.md").write_text("new content")
+
+        # Create existing target
+        target_dir = tmp_path / "target"
+        existing = target_dir / "skill-a"
+        existing.mkdir(parents=True)
+        (existing / "SKILL.md").write_text("old content")
+
+        installed, _skipped, overwritten = _install_skill_dirs(
+            [source_dir], target_dir, no_overwrite=False
+        )
+
+        assert len(installed) == 0
+        assert len(overwritten) == 1
+        assert "skill-a" in overwritten
+        assert (target_dir / "skill-a" / "SKILL.md").read_text() == "new content"
+
+    def test_no_overwrite_skips_existing_skill_dir(self, tmp_path: Path):
+        """Should skip existing skill directory when no_overwrite=True."""
+        from simpletask.core.ai_templates import _install_skill_dirs
+
+        # Create source
+        source_dir = tmp_path / "source" / "skill-a"
+        source_dir.mkdir(parents=True)
+        (source_dir / "SKILL.md").write_text("new content")
+
+        # Create existing target
+        target_dir = tmp_path / "target"
+        existing = target_dir / "skill-a"
+        existing.mkdir(parents=True)
+        (existing / "SKILL.md").write_text("old content")
+
+        installed, skipped, overwritten = _install_skill_dirs(
+            [source_dir], target_dir, no_overwrite=True
+        )
+
+        assert len(installed) == 0
+        assert len(skipped) == 1
+        assert "skill-a" in skipped
+        assert len(overwritten) == 0
+        # Original should be preserved
+        assert (target_dir / "skill-a" / "SKILL.md").read_text() == "old content"
+
+
+class TestEditorConfigVibeEntry:
+    """Tests for Vibe entry in EDITOR_CONFIGS."""
+
+    def test_vibe_config_exists(self):
+        """Vibe should have an entry in EDITOR_CONFIGS."""
+        from simpletask.core.ai_templates import EDITOR_CONFIGS
+
+        assert "vibe" in EDITOR_CONFIGS
+
+    def test_vibe_is_directory_based(self):
+        """Vibe config should be marked as directory-based."""
+        from simpletask.core.ai_templates import EDITOR_CONFIGS
+
+        assert EDITOR_CONFIGS["vibe"].is_directory_based is True
+
+    def test_other_editors_are_not_directory_based(self):
+        """OpenCode, Qwen, Gemini should NOT be directory-based."""
+        from simpletask.core.ai_templates import EDITOR_CONFIGS
+
+        assert EDITOR_CONFIGS["opencode"].is_directory_based is False
+        assert EDITOR_CONFIGS["qwen"].is_directory_based is False
+        assert EDITOR_CONFIGS["gemini"].is_directory_based is False
+
+    def test_vibe_display_name(self):
+        """Vibe should have correct display name."""
+        from simpletask.core.ai_templates import EDITOR_CONFIGS
+
+        assert EDITOR_CONFIGS["vibe"].display_name == "Mistral Vibe"
+
+    def test_vibe_has_no_agent_support(self):
+        """Vibe should not have agent directories configured."""
+        from simpletask.core.ai_templates import EDITOR_CONFIGS
+
+        assert EDITOR_CONFIGS["vibe"].global_agents_dir is None
+        assert EDITOR_CONFIGS["vibe"].local_agents_dir is None


### PR DESCRIPTION
## Summary

- Adds Mistral Vibe CLI as a fourth editor target in simpletask's AI template system
- Generalizes the installation logic to support both flat-file editors (OpenCode, Qwen, Gemini) and directory-based editors using the Agent Skills spec (Vibe)
- Creates four Vibe skill directories (`simpletask-plan`, `simpletask-split`, `simpletask-implement`, `simpletask-review`) each with a valid `SKILL.md`

## Changes

### Core (`cli/simpletask/core/ai_templates.py`)
- `EditorConfig` gains `is_directory_based: bool = False` field
- `EditorType` Literal extended to include `"vibe"`
- `EDITOR_CONFIGS` gains a Vibe entry (`~/.vibe/skills/`, `is_directory_based=True`)
- New `_install_skill_dirs()` helper copies entire skill directories (using `shutil.copytree`)
- `_get_bundled_templates()` and `_get_installed_status()` dispatch on `is_directory_based`
- New convenience wrappers: `get_vibe_templates_dir()`, `get_global_vibe_commands_dir()`, `install_vibe_templates()`

### CLI
- `simpletask ai install --vibe` installs to `~/.vibe/skills/` (global) or `.vibe/skills/` (local)
- `simpletask ai install` (no flags) now installs all four editors including Vibe
- `simpletask ai list` displays Vibe skills with correct installation status

### Templates (`cli/simpletask/templates/vibe/`)
- Four SKILL.md files with Agent Skills spec frontmatter (`name`, `description`, `user-invocable: true`)

### Docs (`AGENTS.md`)
- Documents Vibe MCP server configuration via `~/.vibe/config.toml` `[[mcp_servers]]` section

### Tests
- Unit and integration tests covering: Vibe `EditorConfig`, `_install_skill_dirs()` (new/overwrite/skip), `--vibe` CLI flag, `ai list` Vibe output

## Version
`0.28.0` → `0.29.0`