### PR TITLE
feat(templates): add cross-cutting design notes to review and correctness-shaped criteria to plan

### DIFF
--- a/cli/simpletask/__init__.py
+++ b/cli/simpletask/__init__.py
@@ -1,6 +1,6 @@
 """simpletask: A Python CLI for managing AI-friendly task definition YAML files."""
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"
 
 import typer
 

--- a/cli/simpletask/templates/gemini/simpletask.plan.toml
+++ b/cli/simpletask/templates/gemini/simpletask.plan.toml
@@ -125,17 +125,39 @@ Use simpletask_criteria() MCP tool to add each criterion:
 - Repeat for each criterion (typically 3-6 criteria)
 ```
 
-Guidelines for acceptance criteria:
-- Must be testable (can verify if met)
-- Specific and unambiguous
-- Focus on user-visible outcomes
-- Include quality checks (tests, coverage, etc.)
+**Write correctness invariants, not implementation descriptions.**
 
-Example acceptance criteria:
-- AC1: "Feature X renders correctly in the UI"
-- AC2: "API endpoint returns correct response format"
-- AC3: "All existing tests pass"
-- AC4: "New functionality is covered by unit tests"
+Criteria should describe *what must remain true* in the system after the feature lands — not *what the code does*. Ask: "If this criterion is satisfied, can I be confident the feature is correct?" If the answer is "not really", the criterion is too weak.
+
+**Weak vs. strong criteria examples:**
+
+| Weak (avoid) | Strong (prefer) |
+|---|---|
+| "Posts to the endpoint" | "Constructed URL resolves to a valid endpoint given the configured base URL" |
+| "Maps priority values" | "All priority values, including unknown ones, are handled without unhandled exceptions" |
+| "Skips API call if record exists" | "Idempotency holds even when input text varies between runs for the same logical record" |
+| "Config file is parsed" | "All required keys are present and have valid types; missing or malformed keys produce a descriptive error naming the offending key" |
+
+**Required criteria by feature type:**
+
+- **Multi-file features with behavior crossing component boundaries**: At least one cross-component criterion — describe the correctness invariant *at the boundary* between components (e.g., "data passed from module A to module B preserves X property"). Not required for trivial multi-file edits like renames or config changes.
+- **Features processing external input**: At least one robustness criterion — describe correct behavior under malformed, missing, or unexpected input values
+
+**Additional guidelines:**
+- At least one criterion must describe the externally observable effect of the feature from the user's perspective
+- Must be independently verifiable (can you write a test or manual check for it?)
+- Specific and unambiguous — no "works correctly" or "behaves as expected"
+- Include one quality criterion (tests pass, coverage threshold met, schema validates)
+
+**Self-check before proceeding:**
+
+Re-read the criteria you just wrote and verify:
+1. **Multi-file feature with cross-component behavior?** At least one criterion references the correctness invariant at a cross-component boundary. If missing, add one. (Skip for trivial multi-file edits like renames.)
+2. **External input?** At least one criterion describes behavior under malformed, missing, or unexpected values. If missing, add one.
+3. **No restatements?** No criterion simply restates a task name or implementation step. If found, rewrite it as a correctness invariant.
+4. **User outcome?** At least one criterion describes the externally observable effect of the feature from the user's perspective. If missing, add one.
+
+Do NOT proceed to Step 5 until all four checks pass.
 
 **Step 5: Plan Implementation Tasks**
 

--- a/cli/simpletask/templates/gemini/simpletask.review.toml
+++ b/cli/simpletask/templates/gemini/simpletask.review.toml
@@ -134,7 +134,58 @@ Look for:
    - Are changes focused on the feature or scattered across unrelated areas? (Scope creep signal)
    - Do any modified files look unrelated to the original prompt? Flag these.
 
-**Step 6: Generate Scoped, Actionable Feedback**
+**Step 6: Cross-Cutting Design Notes**
+
+Scope: only the git diff for this branch. This step is **informational only** — design notes do NOT block merge, do NOT create fix tasks, and do NOT repeat issues already reported as blocking.
+
+Ask these 4 adversarial questions against the diff:
+
+| # | Question | What to look for |
+|---|----------|-----------------|
+| 1 | **Data flow across files** | Does data mutate or transform as it crosses file boundaries in ways that could silently lose information or introduce inconsistency? |
+| 2 | **Robustness under unexpected inputs** | Are there input shapes, edge values, or missing keys that could cause silent failures, wrong results, or unhandled exceptions in the new code? |
+| 3 | **Error semantics** | Do error paths in the diff propagate enough context? Could callers misinterpret a returned error or exception as success? |
+| 4 | **Test fidelity** | Do the new/changed tests actually exercise the behavior described in the acceptance criteria, or do they only test the happy path? |
+
+Produce **zero to 5 design notes**. Zero is the correct number if no observation is well-supported by the diff — do not manufacture notes to fill a quota. Each note **must**:
+- Be prefixed with one of these category tags:
+  - `[DATA_FLOW]` — cross-file data transformation issues
+  - `[ROBUSTNESS]` — unexpected input handling
+  - `[ERROR_SEM]` — error path semantics
+  - `[TEST_FIDELITY]` — test coverage gaps
+- Reference a specific `file:line` from the diff
+- Be 1-2 sentences describing the observation
+- Be informational — no fix required
+
+Format: `[CATEGORY] file:line — observation`
+
+**Do NOT flag:** naming conventions, code style, abstraction choices, architectural preferences, or anything already listed as a blocking issue.
+
+**Re-run safety:** Before persisting notes, clear any prior auto-generated design notes to avoid duplicates on repeated review runs:
+
+```
+simpletask_note(action="remove", all=True)
+```
+
+Then persist each design note:
+
+```
+Use simpletask_note() MCP tool to persist each note:
+- Call simpletask_note(action="add", content="[CATEGORY] file:line — [observation]")
+- Repeat for each design note (max 5)
+```
+
+simpletask note add "[ROBUSTNESS] server.py:42 — branch parameter is not validated before normalization"
+
+**Pattern detection:** If 3 or more design notes share the same category tag (e.g., 3 `[ROBUSTNESS]` notes), append this line to the review summary:
+
+```
+CRITERIA GAP DETECTED: [N]/[total] design notes concern [CATEGORY]. Consider adding a robustness/data-flow/error-semantics/test-fidelity acceptance criterion in future plans for this area.
+```
+
+This is informational only — it does not block merge or create tasks.
+
+**Step 7: Generate Scoped, Actionable Feedback**
 
 Only report issues that:
 - Prevent an acceptance criterion from being met, OR
@@ -159,7 +210,7 @@ Fix: [Specific, actionable remediation]
 
 Medium/Low severity observations (style, naming, minor inefficiencies) are noted in the summary but do NOT trigger fix tasks.
 
-**Step 7: Determine PR Readiness**
+**Step 8: Determine PR Readiness**
 
 Evaluate and report one of:
 
@@ -179,7 +230,7 @@ Evaluate and report one of:
 - Acceptance criteria remain with `completed: false`
 - Critical flaws prevent the feature from working as specified
 
-**Step 8: Display Review Summary**
+**Step 9: Display Review Summary**
 
 ```
 ╭─────────────────────────────────────────────────────────────╮
@@ -231,7 +282,11 @@ BLOCKING ISSUES (require fix tasks)
   [Critical/High] CORRECTNESS (X issues)
     - file.py:101 - [issue description]
 
-OBSERVATIONS (informational only — no tasks created)
+DESIGN NOTES (cross-cutting analysis — informational, no tasks created)
+  - [DATA_FLOW] file.py:42 — [design note 1]
+  - [ROBUSTNESS] other.py:17 — [design note 2]
+
+OBSERVATIONS (minor issues in diff — informational, no tasks created)
   - [Low/Medium severity notes about the diff, if any]
 
 ───────────────────────────────────────────────────────────────
@@ -241,7 +296,7 @@ PR READINESS: [READY TO MERGE | NEEDS CHANGES | NOT READY]
 ───────────────────────────────────────────────────────────────
 ```
 
-**Step 9: Auto-Inject Fix Tasks (blocking issues only)**
+**Step 10: Auto-Inject Fix Tasks (blocking issues only)**
 
 Only auto-inject fix tasks if there are **Critical or High severity** issues that prevent acceptance criteria from being met or introduce regressions/security vulnerabilities in the diff. Do NOT create tasks for Medium/Low/Observations.
 

--- a/cli/simpletask/templates/opencode/simpletask.plan.md
+++ b/cli/simpletask/templates/opencode/simpletask.plan.md
@@ -126,17 +126,39 @@ Use simpletask_criteria() MCP tool to add each criterion:
 - Repeat for each criterion (typically 3-6 criteria)
 ```
 
-Guidelines for acceptance criteria:
-- Must be testable (can verify if met)
-- Specific and unambiguous
-- Focus on user-visible outcomes
-- Include quality checks (tests, coverage, etc.)
+**Write correctness invariants, not implementation descriptions.**
 
-Example acceptance criteria:
-- AC1: "Feature X renders correctly in the UI"
-- AC2: "API endpoint returns correct response format"
-- AC3: "All existing tests pass"
-- AC4: "New functionality is covered by unit tests"
+Criteria should describe *what must remain true* in the system after the feature lands — not *what the code does*. Ask: "If this criterion is satisfied, can I be confident the feature is correct?" If the answer is "not really", the criterion is too weak.
+
+**Weak vs. strong criteria examples:**
+
+| Weak (avoid) | Strong (prefer) |
+|---|---|
+| "Posts to the endpoint" | "Constructed URL resolves to a valid endpoint given the configured base URL" |
+| "Maps priority values" | "All priority values, including unknown ones, are handled without unhandled exceptions" |
+| "Skips API call if record exists" | "Idempotency holds even when input text varies between runs for the same logical record" |
+| "Config file is parsed" | "All required keys are present and have valid types; missing or malformed keys produce a descriptive error naming the offending key" |
+
+**Required criteria by feature type:**
+
+- **Multi-file features with behavior crossing component boundaries**: At least one cross-component criterion — describe the correctness invariant *at the boundary* between components (e.g., "data passed from module A to module B preserves X property"). Not required for trivial multi-file edits like renames or config changes.
+- **Features processing external input**: At least one robustness criterion — describe correct behavior under malformed, missing, or unexpected input values
+
+**Additional guidelines:**
+- At least one criterion must describe the externally observable effect of the feature from the user's perspective
+- Must be independently verifiable (can you write a test or manual check for it?)
+- Specific and unambiguous — no "works correctly" or "behaves as expected"
+- Include one quality criterion (tests pass, coverage threshold met, schema validates)
+
+**Self-check before proceeding:**
+
+Re-read the criteria you just wrote and verify:
+1. **Multi-file feature with cross-component behavior?** At least one criterion references the correctness invariant at a cross-component boundary. If missing, add one. (Skip for trivial multi-file edits like renames.)
+2. **External input?** At least one criterion describes behavior under malformed, missing, or unexpected values. If missing, add one.
+3. **No restatements?** No criterion simply restates a task name or implementation step. If found, rewrite it as a correctness invariant.
+4. **User outcome?** At least one criterion describes the externally observable effect of the feature from the user's perspective. If missing, add one.
+
+Do NOT proceed to Step 5 until all four checks pass.
 
 **Step 5: Plan Implementation Tasks**
 

--- a/cli/simpletask/templates/opencode/simpletask.review.md
+++ b/cli/simpletask/templates/opencode/simpletask.review.md
@@ -136,7 +136,61 @@ Look for:
    - Are changes focused on the feature or scattered across unrelated areas? (Scope creep signal)
    - Do any modified files look unrelated to the original prompt? Flag these.
 
-**Step 6: Generate Scoped, Actionable Feedback**
+**Step 6: Cross-Cutting Design Notes**
+
+Scope: only the git diff for this branch. This step is **informational only** — design notes do NOT block merge, do NOT create fix tasks, and do NOT repeat issues already reported as blocking.
+
+Ask these 4 adversarial questions against the diff:
+
+| # | Question | What to look for |
+|---|----------|-----------------|
+| 1 | **Data flow across files** | Does data mutate or transform as it crosses file boundaries in ways that could silently lose information or introduce inconsistency? |
+| 2 | **Robustness under unexpected inputs** | Are there input shapes, edge values, or missing keys that could cause silent failures, wrong results, or unhandled exceptions in the new code? |
+| 3 | **Error semantics** | Do error paths in the diff propagate enough context? Could callers misinterpret a returned error or exception as success? |
+| 4 | **Test fidelity** | Do the new/changed tests actually exercise the behavior described in the acceptance criteria, or do they only test the happy path? |
+
+Produce **zero to 5 design notes**. Zero is the correct number if no observation is well-supported by the diff — do not manufacture notes to fill a quota. Each note **must**:
+- Be prefixed with one of these category tags:
+  - `[DATA_FLOW]` — cross-file data transformation issues
+  - `[ROBUSTNESS]` — unexpected input handling
+  - `[ERROR_SEM]` — error path semantics
+  - `[TEST_FIDELITY]` — test coverage gaps
+- Reference a specific `file:line` from the diff
+- Be 1-2 sentences describing the observation
+- Be informational — no fix required
+
+Format: `[CATEGORY] file:line — observation`
+
+**Do NOT flag:** naming conventions, code style, abstraction choices, architectural preferences, or anything already listed as a blocking issue.
+
+**Re-run safety:** Before persisting notes, clear any prior auto-generated design notes to avoid duplicates on repeated review runs:
+
+```
+simpletask_note(action="remove", all=True)
+```
+
+Then persist each design note via MCP tool:
+
+```
+Use simpletask_note() MCP tool to persist each note:
+- Call simpletask_note(action="add", content="[CATEGORY] file:line — [observation]")
+- Repeat for each design note (max 5)
+```
+
+```bash
+# CLI equivalent
+simpletask note add "[ROBUSTNESS] server.py:42 — branch parameter is not validated before normalization"
+```
+
+**Pattern detection:** If 3 or more design notes share the same category tag (e.g., 3 `[ROBUSTNESS]` notes), append this line to the review summary:
+
+```
+CRITERIA GAP DETECTED: [N]/[total] design notes concern [CATEGORY]. Consider adding a robustness/data-flow/error-semantics/test-fidelity acceptance criterion in future plans for this area.
+```
+
+This is informational only — it does not block merge or create tasks.
+
+**Step 7: Generate Scoped, Actionable Feedback**
 
 Only report issues that:
 - Prevent an acceptance criterion from being met, OR
@@ -161,7 +215,7 @@ Fix: [Specific, actionable remediation]
 
 Medium/Low severity observations (style, naming, minor inefficiencies) are noted in the summary but do NOT trigger fix tasks.
 
-**Step 7: Determine PR Readiness**
+**Step 8: Determine PR Readiness**
 
 Evaluate and report one of:
 
@@ -181,7 +235,7 @@ Evaluate and report one of:
 - Acceptance criteria remain with `completed: false`
 - Critical flaws prevent the feature from working as specified
 
-**Step 8: Display Review Summary**
+**Step 9: Display Review Summary**
 
 ```
 ╭─────────────────────────────────────────────────────────────╮
@@ -233,7 +287,11 @@ BLOCKING ISSUES (require fix tasks)
   [Critical/High] CORRECTNESS (X issues)
     - file.py:101 - [issue description]
 
-OBSERVATIONS (informational only — no tasks created)
+DESIGN NOTES (cross-cutting analysis — informational, no tasks created)
+  - [DATA_FLOW] file.py:42 — [design note 1]
+  - [ROBUSTNESS] other.py:17 — [design note 2]
+
+OBSERVATIONS (minor issues in diff — informational, no tasks created)
   - [Low/Medium severity notes about the diff, if any]
 
 ───────────────────────────────────────────────────────────────
@@ -243,7 +301,7 @@ PR READINESS: [READY TO MERGE | NEEDS CHANGES | NOT READY]
 ───────────────────────────────────────────────────────────────
 ```
 
-**Step 9: Auto-Inject Fix Tasks (blocking issues only)**
+**Step 10: Auto-Inject Fix Tasks (blocking issues only)**
 
 Only auto-inject fix tasks if there are **Critical or High severity** issues that prevent acceptance criteria from being met or introduce regressions/security vulnerabilities in the diff. Do NOT create tasks for Medium/Low/Observations.
 

--- a/cli/simpletask/templates/qwen/simpletask.plan.md
+++ b/cli/simpletask/templates/qwen/simpletask.plan.md
@@ -126,17 +126,39 @@ Use simpletask_criteria() MCP tool to add each criterion:
 - Repeat for each criterion (typically 3-6 criteria)
 ```
 
-Guidelines for acceptance criteria:
-- Must be testable (can verify if met)
-- Specific and unambiguous
-- Focus on user-visible outcomes
-- Include quality checks (tests, coverage, etc.)
+**Write correctness invariants, not implementation descriptions.**
 
-Example acceptance criteria:
-- AC1: "Feature X renders correctly in the UI"
-- AC2: "API endpoint returns correct response format"
-- AC3: "All existing tests pass"
-- AC4: "New functionality is covered by unit tests"
+Criteria should describe *what must remain true* in the system after the feature lands — not *what the code does*. Ask: "If this criterion is satisfied, can I be confident the feature is correct?" If the answer is "not really", the criterion is too weak.
+
+**Weak vs. strong criteria examples:**
+
+| Weak (avoid) | Strong (prefer) |
+|---|---|
+| "Posts to the endpoint" | "Constructed URL resolves to a valid endpoint given the configured base URL" |
+| "Maps priority values" | "All priority values, including unknown ones, are handled without unhandled exceptions" |
+| "Skips API call if record exists" | "Idempotency holds even when input text varies between runs for the same logical record" |
+| "Config file is parsed" | "All required keys are present and have valid types; missing or malformed keys produce a descriptive error naming the offending key" |
+
+**Required criteria by feature type:**
+
+- **Multi-file features with behavior crossing component boundaries**: At least one cross-component criterion — describe the correctness invariant *at the boundary* between components (e.g., "data passed from module A to module B preserves X property"). Not required for trivial multi-file edits like renames or config changes.
+- **Features processing external input**: At least one robustness criterion — describe correct behavior under malformed, missing, or unexpected input values
+
+**Additional guidelines:**
+- At least one criterion must describe the externally observable effect of the feature from the user's perspective
+- Must be independently verifiable (can you write a test or manual check for it?)
+- Specific and unambiguous — no "works correctly" or "behaves as expected"
+- Include one quality criterion (tests pass, coverage threshold met, schema validates)
+
+**Self-check before proceeding:**
+
+Re-read the criteria you just wrote and verify:
+1. **Multi-file feature with cross-component behavior?** At least one criterion references the correctness invariant at a cross-component boundary. If missing, add one. (Skip for trivial multi-file edits like renames.)
+2. **External input?** At least one criterion describes behavior under malformed, missing, or unexpected values. If missing, add one.
+3. **No restatements?** No criterion simply restates a task name or implementation step. If found, rewrite it as a correctness invariant.
+4. **User outcome?** At least one criterion describes the externally observable effect of the feature from the user's perspective. If missing, add one.
+
+Do NOT proceed to Step 5 until all four checks pass.
 
 **Step 5: Plan Implementation Tasks**
 

--- a/cli/simpletask/templates/qwen/simpletask.review.md
+++ b/cli/simpletask/templates/qwen/simpletask.review.md
@@ -135,7 +135,61 @@ Look for:
    - Are changes focused on the feature or scattered across unrelated areas? (Scope creep signal)
    - Do any modified files look unrelated to the original prompt? Flag these.
 
-**Step 6: Generate Scoped, Actionable Feedback**
+**Step 6: Cross-Cutting Design Notes**
+
+Scope: only the git diff for this branch. This step is **informational only** — design notes do NOT block merge, do NOT create fix tasks, and do NOT repeat issues already reported as blocking.
+
+Ask these 4 adversarial questions against the diff:
+
+| # | Question | What to look for |
+|---|----------|-----------------|
+| 1 | **Data flow across files** | Does data mutate or transform as it crosses file boundaries in ways that could silently lose information or introduce inconsistency? |
+| 2 | **Robustness under unexpected inputs** | Are there input shapes, edge values, or missing keys that could cause silent failures, wrong results, or unhandled exceptions in the new code? |
+| 3 | **Error semantics** | Do error paths in the diff propagate enough context? Could callers misinterpret a returned error or exception as success? |
+| 4 | **Test fidelity** | Do the new/changed tests actually exercise the behavior described in the acceptance criteria, or do they only test the happy path? |
+
+Produce **zero to 5 design notes**. Zero is the correct number if no observation is well-supported by the diff — do not manufacture notes to fill a quota. Each note **must**:
+- Be prefixed with one of these category tags:
+  - `[DATA_FLOW]` — cross-file data transformation issues
+  - `[ROBUSTNESS]` — unexpected input handling
+  - `[ERROR_SEM]` — error path semantics
+  - `[TEST_FIDELITY]` — test coverage gaps
+- Reference a specific `file:line` from the diff
+- Be 1-2 sentences describing the observation
+- Be informational — no fix required
+
+Format: `[CATEGORY] file:line — observation`
+
+**Do NOT flag:** naming conventions, code style, abstraction choices, architectural preferences, or anything already listed as a blocking issue.
+
+**Re-run safety:** Before persisting notes, clear any prior auto-generated design notes to avoid duplicates on repeated review runs:
+
+```
+simpletask_note(action="remove", all=True)
+```
+
+Then persist each design note:
+
+```
+Use simpletask_note() MCP tool to persist each note:
+- Call simpletask_note(action="add", content="[CATEGORY] file:line — [observation]")
+- Repeat for each design note (max 5)
+```
+
+```bash
+# CLI equivalent
+simpletask note add "[ROBUSTNESS] server.py:42 — branch parameter is not validated before normalization"
+```
+
+**Pattern detection:** If 3 or more design notes share the same category tag (e.g., 3 `[ROBUSTNESS]` notes), append this line to the review summary:
+
+```
+CRITERIA GAP DETECTED: [N]/[total] design notes concern [CATEGORY]. Consider adding a robustness/data-flow/error-semantics/test-fidelity acceptance criterion in future plans for this area.
+```
+
+This is informational only — it does not block merge or create tasks.
+
+**Step 7: Generate Scoped, Actionable Feedback**
 
 Only report issues that:
 - Prevent an acceptance criterion from being met, OR
@@ -160,7 +214,7 @@ Fix: [Specific, actionable remediation]
 
 Medium/Low severity observations (style, naming, minor inefficiencies) are noted in the summary but do NOT trigger fix tasks.
 
-**Step 7: Determine PR Readiness**
+**Step 8: Determine PR Readiness**
 
 Evaluate and report one of:
 
@@ -180,7 +234,7 @@ Evaluate and report one of:
 - Acceptance criteria remain with `completed: false`
 - Critical flaws prevent the feature from working as specified
 
-**Step 8: Display Review Summary**
+**Step 9: Display Review Summary**
 
 ```
 ╭─────────────────────────────────────────────────────────────╮
@@ -232,7 +286,11 @@ BLOCKING ISSUES (require fix tasks)
   [Critical/High] CORRECTNESS (X issues)
     - file.py:101 - [issue description]
 
-OBSERVATIONS (informational only — no tasks created)
+DESIGN NOTES (cross-cutting analysis — informational, no tasks created)
+  - [DATA_FLOW] file.py:42 — [design note 1]
+  - [ROBUSTNESS] other.py:17 — [design note 2]
+
+OBSERVATIONS (minor issues in diff — informational, no tasks created)
   - [Low/Medium severity notes about the diff, if any]
 
 ───────────────────────────────────────────────────────────────
@@ -242,7 +300,7 @@ PR READINESS: [READY TO MERGE | NEEDS CHANGES | NOT READY]
 ───────────────────────────────────────────────────────────────
 ```
 
-**Step 9: Auto-Inject Fix Tasks (blocking issues only)**
+**Step 10: Auto-Inject Fix Tasks (blocking issues only)**
 
 Only auto-inject fix tasks if there are **Critical or High severity** issues that prevent acceptance criteria from being met or introduce regressions/security vulnerabilities in the diff. Do NOT create tasks for Medium/Low/Observations.
 

--- a/cli/simpletask/templates/vibe/simpletask-plan/SKILL.md
+++ b/cli/simpletask/templates/vibe/simpletask-plan/SKILL.md
@@ -93,11 +93,24 @@ Use simpletask_criteria() MCP tool to add each criterion:
 - Repeat for each criterion (typically 3-6 criteria)
 ```
 
-Guidelines for acceptance criteria:
-- Must be testable (can verify if met)
-- Specific and unambiguous
-- Focus on user-visible outcomes
-- Include quality checks (tests, coverage, etc.)
+**Write correctness invariants, not implementation descriptions.** Ask: "If this criterion is satisfied, can I be confident the feature is correct?" Weak criteria describe what code does; strong criteria describe what must remain true.
+
+**Weak vs. strong examples:**
+
+| Weak (avoid) | Strong (prefer) |
+|---|---|
+| "Posts to the endpoint" | "Constructed URL resolves to a valid endpoint given the configured base URL" |
+| "Maps priority values" | "All priority values, including unknown ones, are handled without unhandled exceptions" |
+| "Skips API call if record exists" | "Idempotency holds even when input text varies between runs for the same logical record" |
+| "Config file is parsed" | "All required keys are present and have valid types; missing or malformed keys produce a descriptive error naming the offending key" |
+
+**Required by feature type:**
+- **Multi-file features with behavior crossing component boundaries**: At least one cross-component criterion describing the correctness invariant at the boundary between components. Not required for trivial multi-file edits like renames or config changes.
+- **Features processing external input**: At least one robustness criterion for malformed, missing, or unexpected input values
+
+Include one quality criterion (tests pass, schema validates, etc.). At least one criterion must describe the externally observable effect of the feature from the user's perspective.
+
+**Self-check:** Before proceeding, verify: (1) multi-file feature with cross-component behavior has a boundary criterion (skip for trivial renames), (2) external input has a robustness criterion, (3) no criterion restates a task name, (4) at least one criterion describes the externally observable effect on users. Fix any gaps before Step 5.
 
 **Step 5: Plan Implementation Tasks**
 

--- a/cli/simpletask/templates/vibe/simpletask-review/SKILL.md
+++ b/cli/simpletask/templates/vibe/simpletask-review/SKILL.md
@@ -77,7 +77,38 @@ git diff --name-only main..HEAD | head -20
 
 Analyze: commits on branch, files modified, lines changed, scope focus vs scatter.
 
-**Step 6: Generate Scoped, Actionable Feedback**
+**Step 6: Cross-Cutting Design Notes**
+
+Scope: only the git diff. **Informational only** — do NOT block merge, create fix tasks, or repeat blocking issues.
+
+Ask 4 adversarial questions against the diff:
+
+| # | Question | What to look for |
+|---|----------|-----------------|
+| 1 | **Data flow across files** | Does data mutate or transform as it crosses file boundaries in ways that could silently lose information or introduce inconsistency? |
+| 2 | **Robustness under unexpected inputs** | Are there input shapes, edge values, or missing keys that could cause silent failures, wrong results, or unhandled exceptions in the new code? |
+| 3 | **Error semantics** | Do error paths in the diff propagate enough context? Could callers misinterpret a returned error or exception as success? |
+| 4 | **Test fidelity** | Do the new/changed tests actually exercise the behavior described in the acceptance criteria, or do they only test the happy path? |
+
+Produce **zero to 5 notes**. Zero is correct if nothing non-obvious is found. Prefix each with `[DATA_FLOW]`, `[ROBUSTNESS]`, `[ERROR_SEM]`, or `[TEST_FIDELITY]`, referencing `file:line` from the diff.
+
+**Re-run safety:** Clear prior auto-generated notes before persisting new ones:
+
+```
+simpletask_note(action="remove", all=True)
+```
+
+Then persist:
+
+```
+simpletask_note(action="add", content="[ROBUSTNESS] server.py:42 — None branch crashes normalize_branch_name()")
+```
+
+If 3+ notes share a category, add to summary: `CRITERIA GAP DETECTED: [N] notes concern [CATEGORY]. Consider adding that criterion type in future plans.`
+
+**Do NOT flag:** naming, style, abstractions, architectural preferences, or anything already blocking.
+
+**Step 7: Generate Scoped, Actionable Feedback**
 
 Only report issues that:
 - Prevent an acceptance criterion from being met, OR
@@ -89,17 +120,17 @@ Only report issues that:
 3. **CORRECTNESS** - Logic errors preventing feature from working
 4. **SCOPE CREEP** - Changes beyond original prompt (informational)
 
-**Step 7: Determine PR Readiness**
+**Step 8: Determine PR Readiness**
 
 - **READY TO MERGE**: All tasks completed, all criteria met, no blocking issues
 - **NEEDS CHANGES**: All done but has Critical/High severity issues
 - **NOT READY**: Tasks incomplete, criteria unmet, or critical flaws
 
-**Step 8: Display Review Summary**
+**Step 9: Display Review Summary**
 
-Show: original prompt, task completion stats, criteria status, git changes, blocking issues, observations, and PR readiness determination.
+Show: original prompt, task completion stats, criteria status, git changes, blocking issues, design notes (cross-cutting analysis, with category tags), observations, and PR readiness determination.
 
-**Step 9: Auto-Inject Fix Tasks (blocking issues only)**
+**Step 10: Auto-Inject Fix Tasks (blocking issues only)**
 
 If Critical/High severity blocking issues exist:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simpletask"
-version = "0.29.0"
+version = "0.30.0"
 description = "CLI tool for managing AI-friendly task definitions in branch-based development workflows"
 requires-python = ">=3.11"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- Inserts a new **Step 5 "Cross-Cutting Design Notes"** into all four review templates (OpenCode, Qwen, Gemini, Vibe) with four bounded adversarial questions (data flow, robustness, error semantics, test fidelity), capped at five informational-only notes per review, persisted via `simpletask_note`
- Renumbers all subsequent review steps 6–10 and adds a **DESIGN NOTES** block to the summary display, positioned between BLOCKING ISSUES and OBSERVATIONS
- Replaces generic acceptance criteria guidance in **Step 4** of all four plan templates with correctness-shaped criteria guidance: weak-vs-strong example table, plus explicit requirements for at least one cross-component criterion (multi-file features) and at least one robustness criterion (external input processing)

Closes #7