### PR TITLE
feat: project-level defaults for design, quality, constraints, and context

### DIFF
--- a/cli/simpletask/__init__.py
+++ b/cli/simpletask/__init__.py
@@ -1,6 +1,6 @@
 """simpletask: A Python CLI for managing AI-friendly task definition YAML files."""
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"
 
 import typer
 
@@ -11,6 +11,7 @@ from .commands import (
     constraint,
     context,
     criteria,
+    defaults,
     design,
     iteration,
     new,
@@ -69,6 +70,7 @@ app.add_typer(design.app, name="design")
 app.add_typer(note.app, name="note")
 app.add_typer(constraint.app, name="constraint")
 app.add_typer(context.app, name="context")
+app.add_typer(defaults.app, name="defaults")
 app.add_typer(ai.app, name="ai")
 app.add_typer(iteration.app, name="iteration")
 

--- a/cli/simpletask/commands/defaults/__init__.py
+++ b/cli/simpletask/commands/defaults/__init__.py
@@ -1,0 +1,5 @@
+"""CLI commands for managing project-level defaults."""
+
+from .commands import app
+
+__all__ = ["app"]

--- a/cli/simpletask/commands/defaults/commands.py
+++ b/cli/simpletask/commands/defaults/commands.py
@@ -1,0 +1,640 @@
+"""Defaults subcommand group — manage project-level defaults in .tasks/defaults.yml."""
+
+from enum import Enum
+from typing import Annotated
+
+import typer
+from rich.panel import Panel
+from rich.text import Text
+
+from simpletask.core.defaults import (
+    DEFAULTS_FILENAME,
+    get_defaults_path,
+    load_defaults,
+    save_defaults,
+)
+from simpletask.core.models import (
+    ArchitecturalPattern,
+    Design,
+    DesignReference,
+    ErrorHandlingStrategy,
+    ProjectDefaults,
+    SecurityCategory,
+    SecurityRequirement,
+    ToolName,
+)
+from simpletask.core.presets import (
+    QUALITY_PRESETS,
+    load_all_presets,
+)
+from simpletask.core.project import ensure_project
+from simpletask.core.quality_ops import apply_quality_preset, update_quality_requirements
+from simpletask.utils.console import console, error, success
+
+# ---------------------------------------------------------------------------
+# App definitions (nested Typers)
+# ---------------------------------------------------------------------------
+
+app = typer.Typer(help="Manage project-level defaults injected into new task files")
+design_app = typer.Typer(help="Manage design defaults")
+quality_app = typer.Typer(help="Manage quality defaults")
+constraint_app = typer.Typer(help="Manage constraint defaults")
+context_app = typer.Typer(help="Manage context defaults")
+
+app.add_typer(design_app, name="design")
+app.add_typer(quality_app, name="quality")
+app.add_typer(constraint_app, name="constraint")
+app.add_typer(context_app, name="context")
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _load_or_empty(project) -> ProjectDefaults:  # type: ignore[no-untyped-def]
+    """Load defaults file or return a fresh empty ProjectDefaults."""
+    defaults = load_defaults(project)
+    return defaults if defaults is not None else ProjectDefaults()
+
+
+# ---------------------------------------------------------------------------
+# simpletask defaults show
+# ---------------------------------------------------------------------------
+
+
+@app.command(name="show")
+def show_command() -> None:
+    """Show current project-level defaults from .tasks/defaults.yml.
+
+    Examples:
+        simpletask defaults show
+    """
+    try:
+        project = ensure_project()
+        defaults = load_defaults(project)
+
+        defaults_path = get_defaults_path(project)
+
+        if defaults is None:
+            console.print(
+                f"\n[yellow]No project defaults configured.[/yellow]"
+                f"\n[dim]File not found: {defaults_path}[/dim]\n"
+            )
+            console.print(
+                "Use [cyan]simpletask defaults design set[/cyan], "
+                "[cyan]simpletask defaults quality set[/cyan], "
+                "[cyan]simpletask defaults constraint add[/cyan], or "
+                "[cyan]simpletask defaults context set[/cyan] to add defaults.\n"
+            )
+            return
+
+        console.print(f"\n[bold]Project Defaults[/bold] ({defaults_path.name})\n")
+
+        any_content = False
+
+        # ---- Design ----
+        if defaults.design:
+            any_content = True
+            d = defaults.design
+
+            if d.patterns:
+                text = Text()
+                for p in d.patterns:
+                    text.append(f"• {p.value}\n")
+                console.print(
+                    Panel(text, title="[cyan]Design › Patterns[/cyan]", border_style="cyan")
+                )
+
+            if d.reference_implementations:
+                text = Text()
+                for ref in d.reference_implementations:
+                    text.append("• ", style="bold")
+                    text.append(f"{ref.path}\n", style="cyan")
+                    text.append(f"  {ref.reason}\n\n")
+                console.print(
+                    Panel(
+                        text,
+                        title="[cyan]Design › References[/cyan]",
+                        border_style="cyan",
+                    )
+                )
+
+            if d.architectural_constraints:
+                text = Text()
+                for c in d.architectural_constraints:
+                    text.append(f"• {c}\n")
+                console.print(
+                    Panel(
+                        text,
+                        title="[cyan]Design › Constraints[/cyan]",
+                        border_style="cyan",
+                    )
+                )
+
+            if d.security:
+                text = Text()
+                for req in d.security:
+                    text.append("• ", style="bold")
+                    text.append(f"{req.category.value}: ", style="yellow")
+                    text.append(f"{req.description}\n")
+                console.print(
+                    Panel(
+                        text,
+                        title="[yellow]Design › Security[/yellow]",
+                        border_style="yellow",
+                    )
+                )
+
+            if d.error_handling:
+                console.print(
+                    Panel(
+                        d.error_handling.value,
+                        title="[cyan]Design › Error Handling[/cyan]",
+                        border_style="cyan",
+                    )
+                )
+
+        # ---- Quality ----
+        if defaults.quality_requirements:
+            any_content = True
+            q = defaults.quality_requirements
+            text = Text()
+            for cfg_name, cfg in [
+                ("linting", q.linting),
+                ("type_checking", q.type_checking),
+                ("testing", q.testing),
+                ("security_check", q.security_check),
+            ]:
+                if cfg is not None:
+                    status = "[green]enabled[/green]" if cfg.enabled else "[dim]disabled[/dim]"
+                    tool_str = cfg.tool.value if cfg.tool else "(none)"
+                    text.append(f"• {cfg_name}: {tool_str} — ")
+                    text.append_text(Text.from_markup(status))
+                    text.append("\n")
+            console.print(
+                Panel(text, title="[cyan]Quality Requirements[/cyan]", border_style="cyan")
+            )
+
+        # ---- Constraints ----
+        if defaults.constraints:
+            any_content = True
+            text = Text()
+            for c in defaults.constraints:
+                text.append(f"• {c}\n")
+            console.print(Panel(text, title="[cyan]Constraints[/cyan]", border_style="cyan"))
+
+        # ---- Context ----
+        if defaults.context:
+            any_content = True
+            text = Text()
+            for k, v in sorted(defaults.context.items()):
+                text.append("• ", style="bold")
+                text.append(f"{k}: ", style="cyan")
+                text.append(f"{v}\n")
+            console.print(Panel(text, title="[cyan]Context[/cyan]", border_style="cyan"))
+
+        if not any_content:
+            console.print("[dim]defaults.yml exists but all sections are empty.[/dim]")
+
+        console.print("")
+
+    except (ValueError, FileNotFoundError) as e:
+        error(str(e))
+    except Exception as e:
+        error(f"Unexpected error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# simpletask defaults clear
+# ---------------------------------------------------------------------------
+
+_VALID_CLEAR_FIELDS = ("design", "quality", "constraints", "context")
+
+
+@app.command(name="clear")
+def clear_command(
+    field: Annotated[
+        str | None,
+        typer.Option(
+            "--field",
+            "-f",
+            help="Specific section to clear: design, quality, constraints, context. "
+            "Omit to delete the entire defaults file.",
+        ),
+    ] = None,
+) -> None:
+    """Clear project defaults — entire file or a specific section.
+
+    Examples:
+        simpletask defaults clear
+        simpletask defaults clear --field design
+        simpletask defaults clear --field quality
+        simpletask defaults clear --field constraints
+        simpletask defaults clear --field context
+    """
+    try:
+        project = ensure_project()
+        defaults_path = get_defaults_path(project)
+
+        if field is None:
+            # Delete the entire file
+            if not defaults_path.exists():
+                console.print("[dim]No defaults file to remove.[/dim]\n")
+                return
+            defaults_path.unlink()
+            success(f"Removed {defaults_path.name}")
+            return
+
+        # Validate field name
+        if field not in _VALID_CLEAR_FIELDS:
+            valid = ", ".join(_VALID_CLEAR_FIELDS)
+            error(f"Invalid field '{field}'. Valid fields: {valid}")
+
+        defaults = _load_or_empty(project)
+
+        if field == "design":
+            defaults.design = None
+        elif field == "quality":
+            defaults.quality_requirements = None
+        elif field == "constraints":
+            defaults.constraints = None
+        elif field == "context":
+            defaults.context = None
+
+        save_defaults(project, defaults)
+        success(f"Cleared defaults section: {field}")
+
+    except (ValueError, FileNotFoundError) as e:
+        error(str(e))
+    except Exception as e:
+        error(f"Unexpected error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# simpletask defaults design set
+# ---------------------------------------------------------------------------
+
+
+@design_app.command(name="set")
+def design_set_command(
+    field: Annotated[
+        str,
+        typer.Argument(
+            help="Field to set: pattern, reference, constraint, security, error-handling"
+        ),
+    ],
+    value: Annotated[
+        str,
+        typer.Argument(help="Value to set"),
+    ],
+    reference_reason: Annotated[
+        str | None,
+        typer.Option("--reason", "-r", help="Reason for reference (required when field=reference)"),
+    ] = None,
+    security_category: Annotated[
+        str | None,
+        typer.Option(
+            "--category",
+            "-c",
+            help="Security category (required when field=security)",
+        ),
+    ] = None,
+) -> None:
+    """Set a design field in project defaults.
+
+    Examples:
+        simpletask defaults design set pattern repository
+        simpletask defaults design set constraint "Use Pydantic models with extra='forbid'"
+        simpletask defaults design set reference src/module.py --reason "Follow this pattern"
+        simpletask defaults design set security "Validate inputs" --category input_validation
+        simpletask defaults design set error-handling exceptions
+    """
+    try:
+        project = ensure_project()
+        defaults = _load_or_empty(project)
+
+        # Initialise design section if absent
+        if defaults.design is None:
+            defaults.design = Design(
+                patterns=None,
+                reference_implementations=None,
+                architectural_constraints=None,
+                security=None,
+                error_handling=None,
+            )
+
+        d = defaults.design
+
+        if field == "pattern":
+            try:
+                pattern = ArchitecturalPattern(value)
+            except ValueError:
+                valid = ", ".join(p.value for p in ArchitecturalPattern)
+                error(f"Invalid pattern '{value}'. Valid: {valid}")
+            if not d.patterns:
+                d.patterns = []
+            d.patterns.append(pattern)
+            console.print(f"[green]✓[/green] Added pattern: {pattern.value}")
+
+        elif field == "reference":
+            if not reference_reason:
+                error("--reason is required when adding a reference implementation")
+            if not d.reference_implementations:
+                d.reference_implementations = []
+            ref = DesignReference(path=value, reason=reference_reason)  # type: ignore[arg-type]
+            d.reference_implementations.append(ref)
+            console.print(f"[green]✓[/green] Added reference: {value}")
+
+        elif field == "constraint":
+            if not d.architectural_constraints:
+                d.architectural_constraints = []
+            d.architectural_constraints.append(value)
+            console.print("[green]✓[/green] Added design constraint")
+
+        elif field == "security":
+            if not security_category:
+                error("--category is required when adding a security requirement")
+            try:
+                category = SecurityCategory(security_category)
+            except ValueError:
+                valid = ", ".join(c.value for c in SecurityCategory)
+                error(f"Invalid category '{security_category}'. Valid: {valid}")
+            if not d.security:
+                d.security = []
+            req = SecurityRequirement(category=category, description=value)  # type: ignore[arg-type]
+            d.security.append(req)
+            console.print(f"[green]✓[/green] Added security requirement: {category.value}")  # type: ignore[union-attr]
+
+        elif field == "error-handling":
+            try:
+                strategy = ErrorHandlingStrategy(value)
+            except ValueError:
+                valid = ", ".join(s.value for s in ErrorHandlingStrategy)
+                error(f"Invalid strategy '{value}'. Valid: {valid}")
+            d.error_handling = strategy  # type: ignore[assignment]
+            console.print(f"[green]✓[/green] Set error handling strategy: {strategy.value}")  # type: ignore[union-attr]
+
+        else:
+            error(
+                f"Invalid field '{field}'. "
+                "Use: pattern, reference, constraint, security, error-handling"
+            )
+
+        save_defaults(project, defaults)
+        console.print(f"[dim]Saved to {DEFAULTS_FILENAME}[/dim]\n")
+
+    except (ValueError, FileNotFoundError) as e:
+        error(str(e))
+    except typer.Exit:
+        raise
+    except Exception as e:
+        error(f"Unexpected error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# simpletask defaults quality set / preset
+# ---------------------------------------------------------------------------
+
+
+class ConfigType(str, Enum):
+    """Valid quality configuration types."""
+
+    LINTING = "linting"
+    TYPE_CHECKING = "type-checking"
+    TESTING = "testing"
+    SECURITY = "security"
+
+
+@quality_app.command(name="set")
+def quality_set_command(
+    config_type: Annotated[
+        ConfigType,
+        typer.Argument(help="Config type: linting, type-checking, testing, security"),
+    ],
+    tool: Annotated[
+        ToolName | None,
+        typer.Option("--tool", "-t", help="Tool to execute (e.g., ruff, mypy, pytest)"),
+    ] = None,
+    args: Annotated[
+        str | None,
+        typer.Option(
+            "--args", "-a", help="Tool arguments as comma-separated list (e.g., 'check,.,--fix')"
+        ),
+    ] = None,
+    enable: Annotated[bool, typer.Option("--enable", help="Enable this quality check")] = False,
+    disable: Annotated[bool, typer.Option("--disable", help="Disable this quality check")] = False,
+    min_coverage: Annotated[
+        int | None,
+        typer.Option(
+            "--min-coverage",
+            help="Minimum test coverage percentage (0-100, testing only)",
+            min=0,
+            max=100,
+        ),
+    ] = None,
+    timeout: Annotated[
+        int | None,
+        typer.Option("--timeout", help="Timeout in seconds (default: 300)", min=1),
+    ] = None,
+) -> None:
+    """Set a quality configuration in project defaults.
+
+    Examples:
+        simpletask defaults quality set linting --tool ruff --args "check,."
+        simpletask defaults quality set testing --tool pytest --min-coverage 80
+        simpletask defaults quality set type-checking --tool mypy --enable
+    """
+    try:
+        if enable and disable:
+            error("Cannot specify both --enable and --disable")
+
+        project = ensure_project()
+        defaults = _load_or_empty(project)
+
+        # update_quality_requirements operates directly on QualityRequirements.
+
+        args_list: list[str] | None = None
+        if args:
+            args_list = [a.strip() for a in args.split(",")]
+
+        enabled_status: bool | None = None
+        if enable:
+            enabled_status = True
+        elif disable:
+            enabled_status = False
+
+        # config_type may be a ConfigType enum or a plain string (when called directly in tests)
+        config_type_str = config_type.value if hasattr(config_type, "value") else str(config_type)
+
+        updated_reqs = update_quality_requirements(
+            defaults.quality_requirements,
+            config_type_str,  # type: ignore[arg-type]
+            tool=tool,
+            args=args_list,
+            enabled=enabled_status,
+            min_coverage=min_coverage,
+            timeout=timeout,
+        )
+        defaults.quality_requirements = updated_reqs
+        save_defaults(project, defaults)
+
+        console.print(
+            f"\n[green]✓[/green] Updated quality defaults for [bold]{config_type_str}[/bold]"
+        )
+
+        changes: list[str] = []
+        if tool:
+            changes.append(f"tool: {tool.value}")
+        if args_list:
+            changes.append(f"args: {', '.join(args_list)}")
+        if enabled_status is not None:
+            changes.append(f"enabled: {str(enabled_status).lower()}")
+        if min_coverage is not None:
+            changes.append(f"min_coverage: {min_coverage}%")
+        if timeout is not None:
+            changes.append(f"timeout: {timeout}s")
+        if changes:
+            console.print(f"[dim]Changes: {', '.join(changes)}[/dim]\n")
+
+    except (ValueError, FileNotFoundError) as e:
+        error(str(e))
+    except Exception as e:
+        error(f"Unexpected error: {e}")
+
+
+@quality_app.command(name="preset")
+def quality_preset_command(
+    preset_name: Annotated[
+        str | None,
+        typer.Argument(help="Preset name (python, typescript, node, …). Use --list to see all."),
+    ] = None,
+    list_flag: Annotated[bool, typer.Option("--list", "-l", help="List available presets")] = False,
+) -> None:
+    """Apply a quality preset to project defaults.
+
+    Uses fill-gaps-only strategy: only sets values not already configured.
+
+    Examples:
+        simpletask defaults quality preset --list
+        simpletask defaults quality preset python
+    """
+    try:
+        if list_flag:
+            all_presets = load_all_presets()
+            builtin_names = set(QUALITY_PRESETS.keys())
+            custom_names = set(all_presets.keys()) - builtin_names
+
+            console.print("\n[bold]Available Quality Presets:[/bold]\n")
+
+            if builtin_names:
+                console.print("[bold cyan]Built-in Presets:[/bold cyan]")
+                for preset in sorted(builtin_names):
+                    console.print(f"  • [cyan]{preset}[/cyan]")
+                console.print()
+
+            if custom_names:
+                console.print("[bold green]Custom Presets:[/bold green]")
+                for preset in sorted(custom_names):
+                    console.print(f"  • [green]{preset}[/green]")
+                console.print()
+
+            console.print("[dim]Use 'simpletask defaults quality preset <name>' to apply[/dim]\n")
+            return
+
+        if not preset_name:
+            error("Preset name required. Use --list to see available presets.")
+
+        project = ensure_project()
+        defaults = _load_or_empty(project)
+
+        merged_reqs, applied = apply_quality_preset(defaults.quality_requirements, preset_name)  # type: ignore[arg-type]
+        defaults.quality_requirements = merged_reqs
+        save_defaults(project, defaults)
+
+        console.print(f"\n[green]✓[/green] Applied [bold]{preset_name}[/bold] preset to defaults")
+
+        applied_items = [k for k, v in applied.items() if v]
+        kept_items = [k for k, v in applied.items() if not v]
+
+        if applied_items:
+            console.print("[green]Applied from preset:[/green]")
+            for item in applied_items:
+                console.print(f"  • {item}")
+
+        if kept_items:
+            console.print("[yellow]Kept existing configuration:[/yellow]")
+            for item in kept_items:
+                console.print(f"  • {item}")
+
+        console.print("\n[dim]Use 'simpletask defaults show' to view current defaults[/dim]\n")
+
+    except (ValueError, FileNotFoundError) as e:
+        error(str(e))
+    except Exception as e:
+        error(f"Unexpected error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# simpletask defaults constraint add
+# ---------------------------------------------------------------------------
+
+
+@constraint_app.command(name="add")
+def constraint_add_command(
+    value: Annotated[str, typer.Argument(help="Constraint text")],
+) -> None:
+    """Add a constraint to project defaults.
+
+    Examples:
+        simpletask defaults constraint add "Use Pydantic models with extra='forbid'"
+        simpletask defaults constraint add "No shell=True in subprocess calls"
+    """
+    try:
+        project = ensure_project()
+        defaults = _load_or_empty(project)
+
+        if defaults.constraints is None:
+            defaults.constraints = []
+        defaults.constraints.append(value)
+
+        save_defaults(project, defaults)
+        success("Added constraint to defaults")
+
+    except (ValueError, FileNotFoundError) as e:
+        error(str(e))
+    except Exception as e:
+        error(f"Unexpected error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# simpletask defaults context set
+# ---------------------------------------------------------------------------
+
+
+@context_app.command(name="set")
+def context_set_command(
+    key: Annotated[str, typer.Argument(help="Context key")],
+    value: Annotated[str, typer.Argument(help="Context value")],
+) -> None:
+    """Set a context key-value pair in project defaults.
+
+    Examples:
+        simpletask defaults context set framework django
+        simpletask defaults context set database postgresql
+    """
+    try:
+        project = ensure_project()
+        defaults = _load_or_empty(project)
+
+        if defaults.context is None:
+            defaults.context = {}
+        defaults.context[key] = value
+
+        save_defaults(project, defaults)
+        success(f"Set defaults context key '{key}'")
+
+    except (ValueError, FileNotFoundError) as e:
+        error(str(e))
+    except Exception as e:
+        error(f"Unexpected error: {e}")

--- a/cli/simpletask/core/defaults.py
+++ b/cli/simpletask/core/defaults.py
@@ -1,0 +1,151 @@
+"""Project-level defaults management for simpletask.
+
+Provides load/save/merge operations for .tasks/defaults.yml — the file that
+stores project-level defaults automatically injected into new task files.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from .models import ProjectDefaults, SimpleTaskSpec
+from .project import Project
+from .yaml_parser import InvalidTaskFileError
+
+# The filename for project-level defaults within the .tasks/ directory
+DEFAULTS_FILENAME = "defaults.yml"
+
+
+def get_defaults_path(project: Project) -> Path:
+    """Return the path to the project defaults file.
+
+    Args:
+        project: Project instance
+
+    Returns:
+        Path to .tasks/defaults.yml
+    """
+    return project.tasks_dir / DEFAULTS_FILENAME
+
+
+def load_defaults(project: Project) -> ProjectDefaults | None:
+    """Load project defaults from .tasks/defaults.yml.
+
+    Args:
+        project: Project instance
+
+    Returns:
+        ProjectDefaults if file exists and is valid, None if file doesn't exist.
+
+    Raises:
+        InvalidTaskFileError: If the file exists but is malformed YAML or fails
+                              Pydantic validation.
+    """
+    path = get_defaults_path(project)
+
+    if not path.exists():
+        return None
+
+    content = path.read_text(encoding="utf-8")
+
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError as e:
+        raise InvalidTaskFileError(
+            f"Invalid YAML syntax in defaults file:\n{e!s}\n\nFile: {path}"
+        ) from e
+
+    # Empty file or null YAML produces None — treat as empty defaults
+    if data is None:
+        return ProjectDefaults()
+
+    if not isinstance(data, dict):
+        raise InvalidTaskFileError(
+            f"Invalid defaults file: expected a dictionary, got {type(data).__name__}.\n"
+            f"File: {path}"
+        )
+
+    try:
+        return ProjectDefaults.model_validate(data)
+    except ValidationError as e:
+        error_messages = []
+        for error in e.errors():
+            field = ".".join(str(x) for x in error["loc"])
+            message = error["msg"]
+            error_type = error["type"]
+            error_messages.append(f"  • {field}: {message} (type: {error_type})")
+
+        raise InvalidTaskFileError(
+            "Invalid defaults file — content doesn't match expected schema:\n\n"
+            + "\n".join(error_messages)
+            + f"\n\nFile: {path}"
+        ) from e
+
+
+def save_defaults(project: Project, defaults: ProjectDefaults) -> Path:
+    """Save project defaults to .tasks/defaults.yml.
+
+    Args:
+        project: Project instance
+        defaults: ProjectDefaults to save
+
+    Returns:
+        Path to the written file.
+    """
+    project.ensure_tasks_dir()
+    path = get_defaults_path(project)
+
+    # Serialize — exclude_none omits unpopulated optional fields for clean output
+    data: dict[str, Any] = defaults.model_dump(mode="json", exclude_none=True)
+
+    yaml_content = yaml.dump(
+        data,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+        width=100,
+        indent=2,
+    )
+
+    path.write_text(yaml_content, encoding="utf-8")
+    return path
+
+
+def merge_defaults_into_spec(spec: SimpleTaskSpec, defaults: ProjectDefaults) -> SimpleTaskSpec:
+    """Merge project defaults into a task spec using fill-gaps-only strategy.
+
+    Only populates fields that are currently None in *spec*. Existing values in
+    *spec* are never overwritten. This is a one-time merge at task file creation
+    time; once written, the task file is fully independent of defaults.yml.
+
+    Args:
+        spec: Task specification to enrich.
+        defaults: Project defaults to merge from.
+
+    Returns:
+        The same *spec* object (mutated in-place) with gaps filled from defaults.
+    """
+    if spec.design is None and defaults.design is not None:
+        spec.design = defaults.design
+
+    if spec.quality_requirements is None and defaults.quality_requirements is not None:
+        spec.quality_requirements = defaults.quality_requirements
+
+    if spec.constraints is None and defaults.constraints is not None:
+        spec.constraints = defaults.constraints
+
+    if spec.context is None and defaults.context is not None:
+        spec.context = defaults.context
+
+    return spec
+
+
+__all__ = [
+    "DEFAULTS_FILENAME",
+    "get_defaults_path",
+    "load_defaults",
+    "merge_defaults_into_spec",
+    "save_defaults",
+]

--- a/cli/simpletask/core/design_ops.py
+++ b/cli/simpletask/core/design_ops.py
@@ -4,31 +4,35 @@ This module provides shared functions for managing design section operations
 to avoid code duplication between CLI commands and MCP tools.
 """
 
-from simpletask.core.models import SimpleTaskSpec
+from simpletask.core.models import Design, SimpleTaskSpec
 
 
-def remove_design_field(
-    spec: SimpleTaskSpec,
+def remove_from_design(
+    design: Design | None,
     field: str,
     index: int | None = None,
     all_items: bool = False,
-) -> tuple[SimpleTaskSpec, str]:
-    """Remove design field or list items.
+) -> tuple[Design | None, str]:
+    """Remove a field or list item from a Design object.
+
+    Operates directly on a Design instance without requiring a SimpleTaskSpec
+    wrapper. Suitable for both branch task files and project defaults.
 
     Args:
-        spec: Task specification with design section
-        field: Field to remove (pattern/patterns, reference/references, constraint/constraints,
-               security, error-handling, all)
+        design: Design object to modify (may be None)
+        field: Field to remove (pattern/patterns, reference/references,
+               constraint/constraints, security, error-handling, all)
         index: Index to remove from list fields (0-based), None to remove all
-        all_items: If True, remove all items from list field (for MCP explicit all=True)
+        all_items: If True, remove all items from list field
 
     Returns:
-        Tuple of (updated_spec, success_message)
+        Tuple of (updated_design, success_message). updated_design is None
+        when field='all' or the entire section is cleared.
 
     Raises:
         ValueError: If field is invalid, design section missing, or index out of range
     """
-    if not spec.design:
+    if not design:
         raise ValueError("No design section found")
 
     # Normalize field names (CLI uses plural, MCP uses singular)
@@ -54,90 +58,117 @@ def remove_design_field(
 
     # Handle "all" - remove entire design section
     if field_key == "all":
-        spec.design = None
-        return spec, "Removed entire design section"
+        return None, "Removed entire design section"
 
     # Handle error-handling (single value field)
     if field_key == "error-handling":
-        if not spec.design.error_handling:
+        if not design.error_handling:
             raise ValueError("No error handling strategy found")
-        spec.design.error_handling = None
-        return spec, "Cleared error handling strategy"
+        design.error_handling = None
+        return design, "Cleared error handling strategy"
 
     # Handle list fields
     if field_key == "patterns":
-        if not spec.design.patterns:
+        if not design.patterns:
             raise ValueError("No patterns found")
 
         if index is not None:
-            if 0 <= index < len(spec.design.patterns):
-                removed = spec.design.patterns.pop(index)
-                return spec, f"Removed pattern: {removed.value}"
+            if 0 <= index < len(design.patterns):
+                removed = design.patterns.pop(index)
+                return design, f"Removed pattern: {removed.value}"
             else:
-                raise ValueError(f"Index {index} out of range (0-{len(spec.design.patterns) - 1})")
+                raise ValueError(f"Index {index} out of range (0-{len(design.patterns) - 1})")
         elif all_items or index is None:
-            # For CLI: index=None means clear all
-            # For MCP: all_items=True means clear all
-            spec.design.patterns = None
-            return spec, "Cleared all patterns"
+            design.patterns = None
+            return design, "Cleared all patterns"
         else:
             raise ValueError("Either 'index' or 'all_items=True' is required for pattern removal")
 
     elif field_key == "references":
-        if not spec.design.reference_implementations:
+        if not design.reference_implementations:
             raise ValueError("No references found")
 
         if index is not None:
-            if 0 <= index < len(spec.design.reference_implementations):
-                removed_ref = spec.design.reference_implementations.pop(index)
-                return spec, f"Removed reference: {removed_ref.path}"
+            if 0 <= index < len(design.reference_implementations):
+                removed_ref = design.reference_implementations.pop(index)
+                return design, f"Removed reference: {removed_ref.path}"
             else:
                 raise ValueError(
-                    f"Index {index} out of range "
-                    f"(0-{len(spec.design.reference_implementations) - 1})"
+                    f"Index {index} out of range (0-{len(design.reference_implementations) - 1})"
                 )
         elif all_items or index is None:
-            spec.design.reference_implementations = None
-            return spec, "Cleared all references"
+            design.reference_implementations = None
+            return design, "Cleared all references"
         else:
             raise ValueError("Either 'index' or 'all_items=True' is required for reference removal")
 
     elif field_key == "constraints":
-        if not spec.design.architectural_constraints:
+        if not design.architectural_constraints:
             raise ValueError("No constraints found")
 
         if index is not None:
-            if 0 <= index < len(spec.design.architectural_constraints):
-                removed_constraint = spec.design.architectural_constraints.pop(index)
-                return spec, f"Removed constraint: {removed_constraint}"
+            if 0 <= index < len(design.architectural_constraints):
+                removed_constraint = design.architectural_constraints.pop(index)
+                return design, f"Removed constraint: {removed_constraint}"
             else:
                 raise ValueError(
-                    f"Index {index} out of range "
-                    f"(0-{len(spec.design.architectural_constraints) - 1})"
+                    f"Index {index} out of range (0-{len(design.architectural_constraints) - 1})"
                 )
         elif all_items or index is None:
-            spec.design.architectural_constraints = None
-            return spec, "Cleared all constraints"
+            design.architectural_constraints = None
+            return design, "Cleared all constraints"
         else:
             raise ValueError(
                 "Either 'index' or 'all_items=True' is required for constraint removal"
             )
 
     elif field_key == "security":
-        if not spec.design.security:
+        if not design.security:
             raise ValueError("No security requirements found")
 
         if index is not None:
-            if 0 <= index < len(spec.design.security):
-                removed_security = spec.design.security.pop(index)
-                return spec, f"Removed security requirement: {removed_security.category.value}"
+            if 0 <= index < len(design.security):
+                removed_security = design.security.pop(index)
+                return design, f"Removed security requirement: {removed_security.category.value}"
             else:
-                raise ValueError(f"Index {index} out of range (0-{len(spec.design.security) - 1})")
+                raise ValueError(f"Index {index} out of range (0-{len(design.security) - 1})")
         elif all_items or index is None:
-            spec.design.security = None
-            return spec, "Cleared all security requirements"
+            design.security = None
+            return design, "Cleared all security requirements"
         else:
             raise ValueError("Either 'index' or 'all_items=True' is required for security removal")
 
     # Should never reach here due to field_key validation above
     raise ValueError(f"Unhandled field: {field_key}")
+
+
+def remove_design_field(
+    spec: SimpleTaskSpec,
+    field: str,
+    index: int | None = None,
+    all_items: bool = False,
+) -> tuple[SimpleTaskSpec, str]:
+    """Remove design field or list items.
+
+    Delegates to remove_from_design, which operates directly on the Design
+    object. This wrapper preserves the SimpleTaskSpec-based interface used by
+    branch task file operations and CLI commands.
+
+    Args:
+        spec: Task specification with design section
+        field: Field to remove (pattern/patterns, reference/references, constraint/constraints,
+               security, error-handling, all)
+        index: Index to remove from list fields (0-based), None to remove all
+        all_items: If True, remove all items from list field (for MCP explicit all=True)
+
+    Returns:
+        Tuple of (updated_spec, success_message)
+
+    Raises:
+        ValueError: If field is invalid, design section missing, or index out of range
+    """
+    updated_design, message = remove_from_design(
+        spec.design, field, index=index, all_items=all_items
+    )
+    spec.design = updated_design
+    return spec, message

--- a/cli/simpletask/core/models.py
+++ b/cli/simpletask/core/models.py
@@ -482,6 +482,34 @@ class QualityCheckResult(BaseModel):
     stderr: str = Field(default="", description="Standard error from command")
 
 
+class ProjectDefaults(BaseModel):
+    """Project-level defaults stored in .tasks/defaults.yml.
+
+    These defaults are automatically merged (fill-gaps-only) into new task files
+    at creation time. All fields are optional; unset fields have no effect on
+    task file creation.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    design: Design | None = Field(
+        default=None,
+        description="Default design guidance (patterns, constraints, references, security)",
+    )
+    quality_requirements: QualityRequirements | None = Field(
+        default=None,
+        description="Default quality requirements (linting, type-checking, testing, security)",
+    )
+    constraints: list[str] | None = Field(
+        default=None,
+        description="Default implementation constraints applied to every new task file",
+    )
+    context: dict[str, Any] | None = Field(
+        default=None,
+        description="Default context key-value pairs applied to every new task file",
+    )
+
+
 # Export all models
 __all__ = [
     "AcceptanceCriterion",
@@ -491,6 +519,7 @@ __all__ = [
     "FileAction",
     "Iteration",
     "LintingConfig",
+    "ProjectDefaults",
     "QualityCheckResult",
     "QualityRequirements",
     "SecurityCheckConfig",

--- a/cli/simpletask/core/project.py
+++ b/cli/simpletask/core/project.py
@@ -13,6 +13,10 @@ from .git import current_branch, is_git_repo
 TASK_FILE_EXTENSION = ".yml"
 _DOUBLEDOT_MARKER = "\x00DOUBLEDOT\x00"  # Internal: security marker during normalization
 
+# Filename of the project-level defaults file (must be imported lazily to avoid circular imports
+# — use this constant directly rather than importing DEFAULTS_FILENAME from defaults.py)
+_DEFAULTS_FILENAME = "defaults.yml"
+
 
 def normalize_branch_name(branch: str, max_length: int = 200) -> str:
     """Normalize branch name to a safe filename.
@@ -137,6 +141,9 @@ class Project:
         tasks = []
         for item in sorted(self.tasks_dir.iterdir()):
             if item.is_file() and item.suffix == TASK_FILE_EXTENSION:
+                # Explicitly skip defaults.yml by filename before any parsing
+                if item.name == _DEFAULTS_FILENAME:
+                    continue
                 try:
                     # Lightweight parsing: only extract branch field
                     content = item.read_text(encoding="utf-8")
@@ -169,6 +176,9 @@ class Project:
         tasks = []
         for item in self.tasks_dir.iterdir():
             if item.is_file() and item.suffix == TASK_FILE_EXTENSION:
+                # Explicitly skip defaults.yml by filename before any parsing
+                if item.name == _DEFAULTS_FILENAME:
+                    continue
                 try:
                     # Lightweight parsing: only extract branch field
                     content = item.read_text(encoding="utf-8")

--- a/cli/simpletask/core/quality_ops.py
+++ b/cli/simpletask/core/quality_ops.py
@@ -3,10 +3,12 @@
 from typing import Any, Literal
 
 from simpletask.core.models import (
+    LintingConfig,
     QualityCheckResult,
     QualityRequirements,
     SecurityCheckConfig,
     SimpleTaskSpec,
+    TestingConfig,
     ToolName,
     TypeCheckConfig,
 )
@@ -160,6 +162,122 @@ def update_quality_config(
     spec = spec.model_copy(update={"quality_requirements": quality_reqs})
 
     return spec
+
+
+def update_quality_requirements(
+    existing: QualityRequirements | None,
+    config_type: Literal["linting", "type-checking", "testing", "security"],
+    tool: ToolName | None = None,
+    args: list[str] | None = None,
+    enabled: bool | None = None,
+    min_coverage: int | None = None,
+    timeout: int | None = None,
+) -> QualityRequirements:
+    """Update quality requirements without wrapping in a SimpleTaskSpec.
+
+    Equivalent to update_quality_config but operates directly on QualityRequirements.
+    Used by operations that manage quality outside a task file context (e.g. defaults.yml).
+
+    Args:
+        existing: Existing quality requirements. When None, only 'linting' and 'testing'
+            config_types are accepted; 'type-checking' and 'security' require an existing
+            QualityRequirements (apply a preset first) to avoid creating phantom placeholder
+            linting/testing entries that would block future fill-gaps-only preset merges.
+        config_type: Type of configuration to update
+        tool: Tool to use (optional)
+        args: Tool arguments (optional)
+        enabled: Enable/disable status (optional)
+        min_coverage: Minimum coverage for testing (optional)
+        timeout: Timeout in seconds (optional)
+
+    Returns:
+        Updated QualityRequirements
+
+    Raises:
+        ValueError: If invalid configuration provided, or existing is None and config_type
+            is 'type-checking' or 'security'.
+    """
+    if (
+        tool is None
+        and args is None
+        and enabled is None
+        and min_coverage is None
+        and timeout is None
+    ):
+        raise ValueError(
+            "At least one option must be provided: tool, args, enabled, min_coverage, or timeout"
+        )
+
+    if min_coverage is not None and config_type != "testing":
+        raise ValueError("min_coverage can only be used with 'testing' config type")
+
+    quality_reqs = existing
+    if quality_reqs is None:
+        if config_type in ("type-checking", "security"):
+            raise ValueError(
+                f"Cannot configure '{config_type}' when no quality_requirements exist yet. "
+                "Apply a preset first (e.g. simpletask defaults quality preset python) "
+                "or configure linting/testing before adding type-checking or security."
+            )
+        # For linting/testing, auto-initialise with minimal placeholders so the
+        # caller can configure just that section without needing a preset first.
+        quality_reqs = QualityRequirements(
+            linting=LintingConfig(enabled=False, tool=ToolName.RUFF, args=[]),
+            testing=TestingConfig(enabled=False, tool=ToolName.PYTEST, args=[], min_coverage=0),
+        )
+
+    updates: dict[str, Any] = {}
+    if tool is not None:
+        updates["tool"] = tool
+    if args is not None:
+        updates["args"] = args
+    if enabled is not None:
+        updates["enabled"] = enabled
+    if min_coverage is not None:
+        updates["min_coverage"] = min_coverage
+    if timeout is not None:
+        updates["timeout"] = timeout
+
+    if config_type == "linting":
+        quality_reqs = quality_reqs.model_copy(
+            update={"linting": quality_reqs.linting.model_copy(update=updates)}
+        )
+    elif config_type == "type-checking":
+        if quality_reqs.type_checking is None:
+            if tool is None:
+                raise ValueError("tool is required when creating a new type-checking configuration")
+            quality_reqs = quality_reqs.model_copy(
+                update={
+                    "type_checking": TypeCheckConfig(
+                        enabled=True, tool=tool, args=args if args else []
+                    )
+                }
+            )
+        else:
+            quality_reqs = quality_reqs.model_copy(
+                update={"type_checking": quality_reqs.type_checking.model_copy(update=updates)}
+            )
+    elif config_type == "testing":
+        quality_reqs = quality_reqs.model_copy(
+            update={"testing": quality_reqs.testing.model_copy(update=updates)}
+        )
+    elif config_type == "security":
+        if quality_reqs.security_check is None:
+            if tool is None:
+                raise ValueError("tool is required when creating a new security configuration")
+            quality_reqs = quality_reqs.model_copy(
+                update={
+                    "security_check": SecurityCheckConfig(
+                        enabled=True, tool=tool, args=args if args else []
+                    )
+                }
+            )
+        else:
+            quality_reqs = quality_reqs.model_copy(
+                update={"security_check": quality_reqs.security_check.model_copy(update=updates)}
+            )
+
+    return quality_reqs
 
 
 def apply_quality_preset(

--- a/cli/simpletask/core/task_file_ops.py
+++ b/cli/simpletask/core/task_file_ops.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 
+from .defaults import load_defaults, merge_defaults_into_spec
 from .models import AcceptanceCriterion, SimpleTaskSpec
 from .project import Project
 from .yaml_parser import write_task_file
@@ -63,6 +64,11 @@ def create_task_file(
         context=None,
         tasks=None,
     )
+
+    # Merge project-level defaults (fill-gaps-only) before writing
+    defaults = load_defaults(project)
+    if defaults is not None:
+        spec = merge_defaults_into_spec(spec, defaults)
 
     project.ensure_tasks_dir()
     task_file = project.get_task_file(branch)

--- a/cli/simpletask/mcp/models.py
+++ b/cli/simpletask/mcp/models.py
@@ -238,7 +238,9 @@ class SimpleTaskQualityResponse(BaseModel):
         None, description="Fields applied from preset (for 'preset' action)"
     )
     file_path: str = Field(..., description="Path to task file")
-    summary: StatusSummary = Field(..., description="Pre-computed status summary")
+    summary: StatusSummary | CompactStatusSummary = Field(
+        ..., description="Pre-computed status summary"
+    )
 
 
 class SimpleTaskDesignResponse(BaseModel):
@@ -252,7 +254,9 @@ class SimpleTaskDesignResponse(BaseModel):
     action: str = Field(..., description="Action performed (e.g., 'design_get')")
     design: Design | None = Field(None, description="Current design section")
     file_path: str = Field(..., description="Path to task file")
-    summary: StatusSummary = Field(..., description="Pre-computed status summary")
+    summary: StatusSummary | CompactStatusSummary = Field(
+        ..., description="Pre-computed status summary"
+    )
 
 
 class SimpleTaskNoteResponse(BaseModel):

--- a/cli/simpletask/mcp/server.py
+++ b/cli/simpletask/mcp/server.py
@@ -16,7 +16,8 @@ from ..core.criteria_ops import (
     remove_acceptance_criterion,
     update_acceptance_criterion,
 )
-from ..core.design_ops import remove_design_field
+from ..core.defaults import DEFAULTS_FILENAME, load_defaults, save_defaults
+from ..core.design_ops import remove_design_field, remove_from_design
 from ..core.iteration_ops import (
     add_iteration_to_spec,
     get_iteration_from_spec,
@@ -29,6 +30,7 @@ from ..core.models import (
     DesignReference,
     ErrorHandlingStrategy,
     FileAction,
+    ProjectDefaults,
     SecurityCategory,
     SecurityRequirement,
     TaskStatus,
@@ -40,6 +42,7 @@ from ..core.quality_ops import (
     apply_quality_preset,
     run_quality_checks,
     update_quality_config,
+    update_quality_requirements,
 )
 from ..core.task_file_ops import create_task_file
 from ..core.task_ops import (
@@ -99,6 +102,44 @@ from .models import (
 # Preserve reference to built-in list type before defining list() function
 # This allows type hints to use list[T] even after list() function is defined
 _list = builtins.list
+
+# TargetType for tools that support operating on defaults.yml vs branch task file
+TargetType = Literal["branch", "defaults"]
+
+
+# ---------------------------------------------------------------------------
+# Private helpers for defaults-target operations
+# ---------------------------------------------------------------------------
+
+
+def _load_defaults_for_write() -> tuple[ProjectDefaults, str]:
+    """Load ProjectDefaults from defaults.yml, creating empty one if missing.
+
+    Used by write operations (set/add/remove) when target='defaults'.
+
+    Returns:
+        Tuple of (ProjectDefaults, str path to defaults file)
+    """
+    project = ensure_project()
+    path = project.tasks_dir / DEFAULTS_FILENAME
+    defaults = load_defaults(project) or ProjectDefaults()
+    return defaults, str(path)
+
+
+def _commit_defaults(defaults: ProjectDefaults) -> str:
+    """Save ProjectDefaults back to defaults.yml and return the path as str."""
+    project = ensure_project()
+    return str(save_defaults(project, defaults))
+
+
+def _defaults_compact_summary(_path: object = None) -> CompactStatusSummary:
+    """Return a dummy CompactStatusSummary for defaults target responses."""
+    return CompactStatusSummary(
+        branch="defaults",
+        title="Project Defaults",
+        overall_status=TaskStatus.NOT_STARTED,
+    )
+
 
 # Initialize FastMCP server
 mcp = FastMCP("simpletask")
@@ -525,6 +566,7 @@ def quality(
     test_only: bool = False,
     type_only: bool = False,
     security_only: bool = False,
+    target: TargetType = "branch",
 ) -> SimpleTaskQualityResponse | SimpleTaskWriteResponse:
     """Manage quality requirements and run quality checks.
 
@@ -545,10 +587,13 @@ def quality(
             ValueError if combined with a non-check action or another filter flag.
         security_only: Only run security check (for 'check' action). Raises
             ValueError if combined with a non-check action or another filter flag.
+        target: Whether to operate on the current branch task file ('branch', default)
+            or the project defaults file ('defaults').
 
     Note:
         lint_only, test_only, type_only, and security_only are mutually exclusive.
         Pass at most one. They are only valid with action='check'.
+        The 'check' action is not supported when target='defaults'.
 
     Returns:
         SimpleTaskQualityResponse for check/get actions.
@@ -559,8 +604,6 @@ def quality(
             or filter flags (lint_only, test_only, type_only, security_only)
             are used with a non-check action or combined together.
     """
-    file_path = get_current_task_file_path()
-    spec = parse_task_file(file_path)
     summary: StatusSummary | CompactStatusSummary
 
     # Validate that filter flags are only used with action='check'
@@ -568,6 +611,13 @@ def quality(
         raise ValueError(
             "Filter flags (lint_only, test_only, type_only, security_only) "
             "are only valid with action='check'"
+        )
+
+    # 'check' action is not meaningful for defaults
+    if action == "check" and target == "defaults":
+        raise ValueError(
+            "Quality checks can only run against branch task files, not defaults. "
+            "Use target='branch' for action='check'."
         )
 
     # Parse args if provided
@@ -583,6 +633,81 @@ def quality(
         except ValueError:
             valid_tools = ", ".join([t.value for t in ToolName])
             raise ValueError(f"Invalid tool '{tool}'. Valid tools: {valid_tools}") from None
+
+    # ------------------------------------------------------------------ #
+    # Defaults target path
+    # ------------------------------------------------------------------ #
+    if target == "defaults":
+        match action:
+            case "get":
+                project = ensure_project()
+                defaults = load_defaults(project) or ProjectDefaults()
+                defaults_path = project.tasks_dir / DEFAULTS_FILENAME
+                return SimpleTaskQualityResponse(
+                    action="quality_get",
+                    quality_requirements=defaults.quality_requirements,
+                    check_results=None,
+                    all_passed=None,
+                    applied_fields=None,
+                    file_path=str(defaults_path),
+                    summary=_defaults_compact_summary(defaults_path),
+                )
+
+            case "set":
+                if not config_type:
+                    raise ValueError("'config_type' is required for action='set'")
+                if config_type not in ["linting", "type-checking", "testing", "security"]:
+                    raise ValueError(
+                        f"Invalid config_type '{config_type}'. "
+                        "Valid options: linting, type-checking, testing, security"
+                    )
+                if min_coverage is not None and config_type != "testing":
+                    raise ValueError("min_coverage can only be used with 'testing' config type")
+
+                validated_config_type = cast(
+                    Literal["linting", "type-checking", "testing", "security"], config_type
+                )
+                defaults, _path = _load_defaults_for_write()
+                defaults.quality_requirements = update_quality_requirements(
+                    existing=defaults.quality_requirements,
+                    config_type=validated_config_type,
+                    tool=tool_enum,
+                    args=args_list if args_list else None,
+                    enabled=enabled,
+                    min_coverage=min_coverage,
+                    timeout=timeout,
+                )
+                set_defaults_path: str = _commit_defaults(defaults)
+                return SimpleTaskWriteResponse(
+                    success=True,
+                    action="quality_set",
+                    message=f"Updated quality configuration for {config_type} in project defaults",
+                    file_path=set_defaults_path,
+                    summary=_defaults_compact_summary(set_defaults_path),
+                    new_item_ids=[],
+                )
+
+            case "preset":
+                if not preset_name:
+                    raise ValueError("'preset_name' is required for action='preset'")
+                defaults, _path = _load_defaults_for_write()
+                merged, _applied = apply_quality_preset(defaults.quality_requirements, preset_name)
+                defaults.quality_requirements = merged
+                preset_defaults_path: str = _commit_defaults(defaults)
+                return SimpleTaskWriteResponse(
+                    success=True,
+                    action="quality_preset_applied",
+                    message=f"Applied preset '{preset_name}' (filled gaps only) to project defaults",
+                    file_path=preset_defaults_path,
+                    summary=_defaults_compact_summary(preset_defaults_path),
+                    new_item_ids=[],
+                )
+
+    # ------------------------------------------------------------------ #
+    # Branch target path (existing behaviour)
+    # ------------------------------------------------------------------ #
+    file_path = get_current_task_file_path()
+    spec = parse_task_file(file_path)
 
     match action:
         case "get":
@@ -697,6 +822,7 @@ def design(
     category: str | None = None,
     index: int | None = None,
     all: bool = False,
+    target: TargetType = "branch",
 ) -> SimpleTaskDesignResponse | SimpleTaskWriteResponse:
     """Manage design guidance and architectural context.
 
@@ -708,6 +834,8 @@ def design(
         category: Security category (required when field='security')
         index: Index of item to remove (for list fields in 'remove' action)
         all: Remove all items from field or entire design section (for 'remove' action)
+        target: Whether to operate on the current branch task file ('branch', default)
+            or the project defaults file ('defaults').
 
     Returns:
         SimpleTaskDesignResponse for get action.
@@ -716,9 +844,136 @@ def design(
     Raises:
         ValueError: If required parameters missing or invalid values provided.
     """
+    summary: StatusSummary | CompactStatusSummary
+
+    # ------------------------------------------------------------------ #
+    # Defaults target path
+    # ------------------------------------------------------------------ #
+    if target == "defaults":
+        project = ensure_project()
+        defaults_path = project.tasks_dir / DEFAULTS_FILENAME
+
+        match action:
+            case "get":
+                defaults = load_defaults(project) or ProjectDefaults()
+                return SimpleTaskDesignResponse(
+                    action="design_get",
+                    design=defaults.design,
+                    file_path=str(defaults_path),
+                    summary=_defaults_compact_summary(defaults_path),
+                )
+
+            case "set":
+                if not field:
+                    raise ValueError("'field' is required for action='set'")
+                if not value:
+                    raise ValueError("'value' is required for action='set'")
+
+                defaults = load_defaults(project) or ProjectDefaults()
+                if not defaults.design:
+                    defaults.design = Design(
+                        patterns=None,
+                        reference_implementations=None,
+                        architectural_constraints=None,
+                        security=None,
+                        error_handling=None,
+                    )
+
+                if field == "pattern":
+                    try:
+                        pattern = ArchitecturalPattern(value)
+                    except ValueError:
+                        valid_patterns = ", ".join([p.value for p in ArchitecturalPattern])
+                        raise ValueError(
+                            f"Invalid pattern: {value}. Valid patterns: {valid_patterns}"
+                        ) from None
+                    if not defaults.design.patterns:
+                        defaults.design.patterns = []
+                    defaults.design.patterns.append(pattern)
+                    message = f"Added pattern: {pattern.value}"
+
+                elif field == "reference":
+                    if not reason:
+                        raise ValueError("'reason' is required when field='reference'")
+                    if not defaults.design.reference_implementations:
+                        defaults.design.reference_implementations = []
+                    ref = DesignReference(path=value, reason=reason)
+                    defaults.design.reference_implementations.append(ref)
+                    message = f"Added reference: {value}"
+
+                elif field == "constraint":
+                    if not defaults.design.architectural_constraints:
+                        defaults.design.architectural_constraints = []
+                    defaults.design.architectural_constraints.append(value)
+                    message = "Added constraint"
+
+                elif field == "security":
+                    if not category:
+                        raise ValueError("'category' is required when field='security'")
+                    try:
+                        cat = SecurityCategory(category)
+                    except ValueError:
+                        valid_categories = ", ".join([c.value for c in SecurityCategory])
+                        raise ValueError(
+                            f"Invalid category: {category}. Valid categories: {valid_categories}"
+                        ) from None
+                    if not defaults.design.security:
+                        defaults.design.security = []
+                    req = SecurityRequirement(category=cat, description=value)
+                    defaults.design.security.append(req)
+                    message = f"Added security requirement: {cat.value}"
+
+                elif field == "error-handling":
+                    try:
+                        strategy = ErrorHandlingStrategy(value)
+                    except ValueError:
+                        valid_strategies = ", ".join([s.value for s in ErrorHandlingStrategy])
+                        raise ValueError(
+                            f"Invalid strategy: {value}. Valid strategies: {valid_strategies}"
+                        ) from None
+                    defaults.design.error_handling = strategy
+                    message = f"Set error handling strategy: {strategy.value}"
+
+                else:
+                    raise ValueError(
+                        f"Invalid field: {field}. "
+                        "Valid options: pattern, reference, constraint, security, error-handling"
+                    )
+
+                save_defaults(project, defaults)
+                return SimpleTaskWriteResponse(
+                    success=True,
+                    action="design_set",
+                    message=message,
+                    file_path=str(defaults_path),
+                    summary=_defaults_compact_summary(defaults_path),
+                    new_item_ids=[],
+                )
+
+            case "remove":
+                if not field:
+                    raise ValueError("'field' is required for action='remove'")
+
+                defaults = load_defaults(project) or ProjectDefaults()
+                updated_design, message = remove_from_design(
+                    defaults.design, field, index=index, all_items=all
+                )
+                defaults.design = updated_design
+                save_defaults(project, defaults)
+                return SimpleTaskWriteResponse(
+                    success=True,
+                    action="design_remove",
+                    message=message,
+                    file_path=str(defaults_path),
+                    summary=_defaults_compact_summary(defaults_path),
+                    new_item_ids=[],
+                )
+
+    # ------------------------------------------------------------------ #
+    # Branch target path (existing behaviour)
+    # ------------------------------------------------------------------ #
     file_path = get_current_task_file_path()
     spec = parse_task_file(file_path)
-    summary: StatusSummary | CompactStatusSummary
 
     match action:
         case "get":
@@ -948,6 +1203,7 @@ def constraint(
     value: str | None = None,
     index: int | None = None,
     all: bool = False,
+    target: TargetType = "branch",
 ) -> SimpleTaskWriteResponse | SimpleTaskConstraintResponse:
     """Manage implementation constraints.
 
@@ -956,6 +1212,8 @@ def constraint(
         value: Constraint text (required for add)
         index: Constraint index to remove (0-based, required for remove unless all=True)
         all: Remove all constraints (for remove action)
+        target: Whether to operate on the current branch task file ('branch', default)
+            or the project defaults file ('defaults').
 
     Returns:
         SimpleTaskWriteResponse for write operations (add/remove).
@@ -964,18 +1222,82 @@ def constraint(
     Raises:
         ValueError: If required parameters missing or invalid index.
     """
-    file_path = get_current_task_file_path()
     summary: StatusSummary | CompactStatusSummary
+
+    # ------------------------------------------------------------------ #
+    # Defaults target path
+    # ------------------------------------------------------------------ #
+    if target == "defaults":
+        project = ensure_project()
+        defaults_path = project.tasks_dir / DEFAULTS_FILENAME
+
+        match action:
+            case "list":
+                defaults = load_defaults(project) or ProjectDefaults()
+                return SimpleTaskConstraintResponse(
+                    action="constraint_list",
+                    constraints=defaults.constraints,
+                    file_path=str(defaults_path),
+                    summary=_defaults_compact_summary(defaults_path),
+                )
+
+            case "add":
+                if value is None:
+                    raise ValueError("'value' is required for action='add'")
+                defaults = load_defaults(project) or ProjectDefaults()
+                if defaults.constraints is None:
+                    defaults.constraints = []
+                defaults.constraints.append(value)
+                save_defaults(project, defaults)
+                return SimpleTaskWriteResponse(
+                    success=True,
+                    action="constraint_added",
+                    message="Added constraint to project defaults",
+                    file_path=str(defaults_path),
+                    summary=_defaults_compact_summary(defaults_path),
+                    new_item_ids=[],
+                )
+
+            case "remove":
+                if not all and index is None:
+                    raise ValueError("Either 'index' or 'all=True' is required for action='remove'")
+                defaults = load_defaults(project) or ProjectDefaults()
+                constraints = defaults.constraints or []
+                if all:
+                    defaults.constraints = None
+                    message = "Removed all constraints from project defaults"
+                else:
+                    if index is None or index < 0 or index >= len(constraints):
+                        raise ValueError(
+                            f"Invalid index {index}. Valid range: 0-{len(constraints) - 1}"
+                        )
+                    constraints.pop(index)
+                    defaults.constraints = constraints if constraints else None
+                    message = f"Removed constraint {index} from project defaults"
+                save_defaults(project, defaults)
+                return SimpleTaskWriteResponse(
+                    success=True,
+                    action="constraint_removed",
+                    message=message,
+                    file_path=str(defaults_path),
+                    summary=_defaults_compact_summary(defaults_path),
+                    new_item_ids=[],
+                )
+
+    # ------------------------------------------------------------------ #
+    # Branch target path (existing behaviour)
+    # ------------------------------------------------------------------ #
+    file_path = get_current_task_file_path()
 
     match action:
         case "list":
             spec = parse_task_file(file_path)
-            constraints = list_constraints(spec=spec)
+            branch_constraints = list_constraints(spec=spec)
             summary = compute_status_summary(spec)
 
             return SimpleTaskConstraintResponse(
                 action="constraint_list",
-                constraints=constraints,
+                constraints=branch_constraints,
                 file_path=str(file_path),
                 summary=summary,
             )
@@ -1023,6 +1345,7 @@ def context(
     key: str | None = None,
     value: str | None = None,
     all: bool = False,
+    target: TargetType = "branch",
 ) -> SimpleTaskWriteResponse | SimpleTaskContextResponse:
     """Manage context key-value pairs.
 
@@ -1031,6 +1354,8 @@ def context(
         key: Context key (required for set/remove)
         value: Context value (required for set)
         all: Remove all context entries (for remove action)
+        target: Whether to operate on the current branch task file ('branch', default)
+            or the project defaults file ('defaults').
 
     Returns:
         SimpleTaskWriteResponse for write operations (set/remove).
@@ -1039,8 +1364,72 @@ def context(
     Raises:
         ValueError: If required parameters missing or invalid key.
     """
-    file_path = get_current_task_file_path()
     summary: StatusSummary | CompactStatusSummary
+
+    # ------------------------------------------------------------------ #
+    # Defaults target path
+    # ------------------------------------------------------------------ #
+    if target == "defaults":
+        project = ensure_project()
+        defaults_path = project.tasks_dir / DEFAULTS_FILENAME
+
+        match action:
+            case "show":
+                defaults = load_defaults(project) or ProjectDefaults()
+                return SimpleTaskContextResponse(
+                    action="context_show",
+                    context=defaults.context,
+                    file_path=str(defaults_path),
+                    summary=_defaults_compact_summary(defaults_path),
+                )
+
+            case "set":
+                if not key:
+                    raise ValueError("'key' is required for action='set'")
+                if value is None:
+                    raise ValueError("'value' is required for action='set'")
+                defaults = load_defaults(project) or ProjectDefaults()
+                if defaults.context is None:
+                    defaults.context = {}
+                defaults.context[key] = value
+                save_defaults(project, defaults)
+                return SimpleTaskWriteResponse(
+                    success=True,
+                    action="context_set",
+                    message=f"Set context key '{key}' in project defaults",
+                    file_path=str(defaults_path),
+                    summary=_defaults_compact_summary(defaults_path),
+                    new_item_ids=[],
+                )
+
+            case "remove":
+                if not all and not key:
+                    raise ValueError("Either 'key' or 'all=True' is required for action='remove'")
+                defaults = load_defaults(project) or ProjectDefaults()
+                ctx = defaults.context or {}
+                if all:
+                    defaults.context = None
+                    message = "Removed all context entries from project defaults"
+                else:
+                    if key not in ctx:
+                        raise ValueError(f"Context key '{key}' not found in project defaults")
+                    del ctx[key]
+                    defaults.context = ctx if ctx else None
+                    message = f"Removed context key '{key}' from project defaults"
+                save_defaults(project, defaults)
+                return SimpleTaskWriteResponse(
+                    success=True,
+                    action="context_removed",
+                    message=message,
+                    file_path=str(defaults_path),
+                    summary=_defaults_compact_summary(defaults_path),
+                    new_item_ids=[],
+                )
+
+    # ------------------------------------------------------------------ #
+    # Branch target path (existing behaviour)
+    # ------------------------------------------------------------------ #
+    file_path = get_current_task_file_path()
 
     match action:
         case "show":

--- a/cli/simpletask/templates/gemini/simpletask.plan.toml
+++ b/cli/simpletask/templates/gemini/simpletask.plan.toml
@@ -112,6 +112,32 @@ git checkout -b [branch-name]
 
 2. If task file exists but is minimal, you can update it by adding criteria and tasks in subsequent steps.
 
+**Step 3.5: Project Defaults**
+
+Check whether project-level defaults exist and inform the user:
+
+```bash
+# Check if defaults file exists
+ls .tasks/defaults.yml 2>/dev/null && echo "exists" || echo "missing"
+```
+
+- **If `.tasks/defaults.yml` exists:** Inform the user that project defaults (design patterns, quality requirements, constraints, context) were automatically merged into the new task file. No action needed.
+
+- **If `.tasks/defaults.yml` does NOT exist:** Ask the user if they want to run codebase analysis now to set up project-level defaults. These defaults are written once and automatically applied to every future task file.
+
+  If user says **yes**:
+  1. Run the codebase analysis from `/simpletask.split` Step 1.5 (find references, patterns, constraints, security, error handling, quality preset) — but write results to **defaults** using `target="defaults"`:
+     ```
+     simpletask_design(action="set", field="pattern", value="...", target="defaults")
+     simpletask_design(action="set", field="constraint", value="...", target="defaults")
+     simpletask_quality(action="preset", preset_name="python", target="defaults")
+     # etc.
+     ```
+  2. After saving to defaults, also copy the same values into the current task file (call the same tools without `target="defaults"`).
+  3. Inform the user: "Project defaults saved to `.tasks/defaults.yml`. All future task files will inherit these settings automatically."
+
+  If user says **no**: Skip — the user can set up defaults later with `simpletask defaults`.
+
 **Step 4: Add Acceptance Criteria**
 
 Add testable, specific acceptance criteria using simpletask_criteria() MCP tool:

--- a/cli/simpletask/templates/gemini/simpletask.split.toml
+++ b/cli/simpletask/templates/gemini/simpletask.split.toml
@@ -23,9 +23,10 @@ If task file not found: Report "No task file found. Run /simpletask.plan first."
 
 ## Step 1.5: Codebase Analysis & Design (Conditional)
 
-**SKIP this step if:**
+**SKIP this step if ANY of the following are true:**
 - `simpletask_get()` shows `spec.design` is already populated (has patterns, constraints, or references)
 - `simpletask_get()` shows `spec.quality_requirements` already configured
+- `.tasks/defaults.yml` exists AND contains design patterns or quality requirements (they were already auto-merged into the task file at creation time — no need to repeat analysis)
 
 **If design section is empty or missing, execute this mandatory codebase analysis:**
 
@@ -169,6 +170,19 @@ Use simpletask_quality() MCP tool to apply preset:
 ```
 
 **Available presets:** python, typescript, node, go, rust, java-maven, java-gradle
+
+**Save analysis results to project defaults (recommended):**
+
+If `.tasks/defaults.yml` does not yet exist, save the analysis results there too so future task files inherit them automatically:
+
+```
+simpletask_design(action="set", field="pattern", value="...", target="defaults")
+simpletask_design(action="set", field="constraint", value="...", target="defaults")
+simpletask_quality(action="preset", preset_name="python", target="defaults")
+# Repeat for all findings above
+```
+
+This is a one-time investment — future `/simpletask.plan` runs will skip this entire Step 1.5.
 
 **After completing Step 1.5, reload the task file:**
 ```

--- a/cli/simpletask/templates/opencode/agents/simpletask-plan.md
+++ b/cli/simpletask/templates/opencode/agents/simpletask-plan.md
@@ -103,6 +103,18 @@ git checkout -b [branch-name]
 
 2. If task file exists but is minimal, you can update it by adding criteria and tasks in subsequent steps.
 
+**Step 3.5: Project Defaults Check**
+
+(Non-interactive: agent cannot prompt the user. Apply silently.)
+
+```bash
+# Check if defaults file exists
+ls .tasks/defaults.yml 2>/dev/null && echo "exists" || echo "missing"
+```
+
+- **If `.tasks/defaults.yml` exists:** Defaults are automatically merged by `simpletask_new` — no action needed. Note this in the structured summary.
+- **If `.tasks/defaults.yml` does NOT exist:** Skip silently. Do NOT attempt to run codebase analysis. The user can set up defaults later with `simpletask defaults` or via `/simpletask.plan`.
+
 **Step 4: Add Acceptance Criteria**
 
 Add testable, specific acceptance criteria using simpletask_criteria() MCP tool:

--- a/cli/simpletask/templates/opencode/simpletask.plan.md
+++ b/cli/simpletask/templates/opencode/simpletask.plan.md
@@ -113,6 +113,32 @@ git checkout -b [branch-name]
 
 2. If task file exists but is minimal, you can update it by adding criteria and tasks in subsequent steps.
 
+**Step 3.5: Project Defaults**
+
+Check whether project-level defaults exist and inform the user:
+
+```bash
+# Check if defaults file exists
+ls .tasks/defaults.yml 2>/dev/null && echo "exists" || echo "missing"
+```
+
+- **If `.tasks/defaults.yml` exists:** Inform the user that project defaults (design patterns, quality requirements, constraints, context) were automatically merged into the new task file. No action needed.
+
+- **If `.tasks/defaults.yml` does NOT exist:** Ask the user if they want to run codebase analysis now to set up project-level defaults. These defaults are written once and automatically applied to every future task file.
+
+  If user says **yes**:
+  1. Run the codebase analysis from `/simpletask.split` Step 1.5 (find references, patterns, constraints, security, error handling, quality preset) — but write results to **defaults** using `target="defaults"`:
+     ```
+     simpletask_design(action="set", field="pattern", value="...", target="defaults")
+     simpletask_design(action="set", field="constraint", value="...", target="defaults")
+     simpletask_quality(action="preset", preset_name="python", target="defaults")
+     # etc.
+     ```
+  2. After saving to defaults, also copy the same values into the current task file (call the same tools without `target="defaults"`).
+  3. Inform the user: "Project defaults saved to `.tasks/defaults.yml`. All future task files will inherit these settings automatically."
+
+  If user says **no**: Skip — the user can set up defaults later with `simpletask defaults`.
+
 **Step 4: Add Acceptance Criteria**
 
 Add testable, specific acceptance criteria using simpletask_criteria() MCP tool:

--- a/cli/simpletask/templates/opencode/simpletask.plan.md
+++ b/cli/simpletask/templates/opencode/simpletask.plan.md
@@ -113,9 +113,9 @@ git checkout -b [branch-name]
 
 2. If task file exists but is minimal, you can update it by adding criteria and tasks in subsequent steps.
 
-**Step 3.5: Project Defaults**
+**Step 3.5: Project Defaults — MANDATORY — DO NOT SKIP**
 
-Check whether project-level defaults exist and inform the user:
+Check whether project-level defaults exist:
 
 ```bash
 # Check if defaults file exists
@@ -124,7 +124,13 @@ ls .tasks/defaults.yml 2>/dev/null && echo "exists" || echo "missing"
 
 - **If `.tasks/defaults.yml` exists:** Inform the user that project defaults (design patterns, quality requirements, constraints, context) were automatically merged into the new task file. No action needed.
 
-- **If `.tasks/defaults.yml` does NOT exist:** Ask the user if they want to run codebase analysis now to set up project-level defaults. These defaults are written once and automatically applied to every future task file.
+- **If `.tasks/defaults.yml` does NOT exist:** You MUST present the following question to the user and wait for their explicit answer. Do NOT assume, infer, reason around, or skip this step based on project familiarity or available documentation.
+
+  Present this exact question:
+
+  > "No project defaults found (`.tasks/defaults.yml` is missing). Would you like to run a codebase analysis now to set up project-level defaults? They are written once and automatically applied to every future task file. (yes / no)"
+
+  **Wait for the user's response before continuing.**
 
   If user says **yes**:
   1. Run the codebase analysis from `/simpletask.split` Step 1.5 (find references, patterns, constraints, security, error handling, quality preset) — but write results to **defaults** using `target="defaults"`:

--- a/cli/simpletask/templates/opencode/simpletask.split.md
+++ b/cli/simpletask/templates/opencode/simpletask.split.md
@@ -23,9 +23,10 @@ If task file not found: Report "No task file found. Run /simpletask.plan first."
 
 ## Step 1.5: Codebase Analysis & Design (Conditional)
 
-**SKIP this step if:**
+**SKIP this step if ANY of the following are true:**
 - `simpletask_get()` shows `spec.design` is already populated (has patterns, constraints, or references)
 - `simpletask_get()` shows `spec.quality_requirements` already configured
+- `.tasks/defaults.yml` exists AND contains design patterns or quality requirements (they were already auto-merged into the task file at creation time — no need to repeat analysis)
 
 **If design section is empty or missing, execute this mandatory codebase analysis:**
 
@@ -185,6 +186,8 @@ Use simpletask_quality() MCP tool to apply preset:
 ```
 
 **Available presets:** python, typescript, node, go, rust, java-maven, java-gradle
+
+**Save to project defaults (one-time, recommended):** If `.tasks/defaults.yml` does not yet exist, also repeat every `simpletask_design` and `simpletask_quality` call above with `target="defaults"` to persist the analysis for future task files. Future `/simpletask.plan` runs will auto-merge these defaults and skip this step entirely.
 
 **After completing Step 1.5, reload the task file:**
 ```

--- a/cli/simpletask/templates/qwen/simpletask.plan.md
+++ b/cli/simpletask/templates/qwen/simpletask.plan.md
@@ -113,6 +113,32 @@ git checkout -b [branch-name]
 
 2. If task file exists but is minimal, you can update it by adding criteria and tasks in subsequent steps.
 
+**Step 3.5: Project Defaults**
+
+Check whether project-level defaults exist and inform the user:
+
+```bash
+# Check if defaults file exists
+ls .tasks/defaults.yml 2>/dev/null && echo "exists" || echo "missing"
+```
+
+- **If `.tasks/defaults.yml` exists:** Inform the user that project defaults (design patterns, quality requirements, constraints, context) were automatically merged into the new task file. No action needed.
+
+- **If `.tasks/defaults.yml` does NOT exist:** Ask the user if they want to run codebase analysis now to set up project-level defaults. These defaults are written once and automatically applied to every future task file.
+
+  If user says **yes**:
+  1. Run the codebase analysis from `/simpletask.split` Step 1.5 (find references, patterns, constraints, security, error handling, quality preset) — but write results to **defaults** using `target="defaults"`:
+     ```
+     simpletask_design(action="set", field="pattern", value="...", target="defaults")
+     simpletask_design(action="set", field="constraint", value="...", target="defaults")
+     simpletask_quality(action="preset", preset_name="python", target="defaults")
+     # etc.
+     ```
+  2. After saving to defaults, also copy the same values into the current task file (call the same tools without `target="defaults"`).
+  3. Inform the user: "Project defaults saved to `.tasks/defaults.yml`. All future task files will inherit these settings automatically."
+
+  If user says **no**: Skip — the user can set up defaults later with `simpletask defaults`.
+
 **Step 4: Add Acceptance Criteria**
 
 Add testable, specific acceptance criteria using simpletask_criteria() MCP tool:

--- a/cli/simpletask/templates/qwen/simpletask.plan.md
+++ b/cli/simpletask/templates/qwen/simpletask.plan.md
@@ -113,9 +113,9 @@ git checkout -b [branch-name]
 
 2. If task file exists but is minimal, you can update it by adding criteria and tasks in subsequent steps.
 
-**Step 3.5: Project Defaults**
+**Step 3.5: Project Defaults — MANDATORY — DO NOT SKIP**
 
-Check whether project-level defaults exist and inform the user:
+Check whether project-level defaults exist:
 
 ```bash
 # Check if defaults file exists
@@ -124,7 +124,13 @@ ls .tasks/defaults.yml 2>/dev/null && echo "exists" || echo "missing"
 
 - **If `.tasks/defaults.yml` exists:** Inform the user that project defaults (design patterns, quality requirements, constraints, context) were automatically merged into the new task file. No action needed.
 
-- **If `.tasks/defaults.yml` does NOT exist:** Ask the user if they want to run codebase analysis now to set up project-level defaults. These defaults are written once and automatically applied to every future task file.
+- **If `.tasks/defaults.yml` does NOT exist:** You MUST present the following question to the user and wait for their explicit answer. Do NOT assume, infer, reason around, or skip this step based on project familiarity or available documentation.
+
+  Present this exact question:
+
+  > "No project defaults found (`.tasks/defaults.yml` is missing). Would you like to run a codebase analysis now to set up project-level defaults? They are written once and automatically applied to every future task file. (yes / no)"
+
+  **Wait for the user's response before continuing.**
 
   If user says **yes**:
   1. Run the codebase analysis from `/simpletask.split` Step 1.5 (find references, patterns, constraints, security, error handling, quality preset) — but write results to **defaults** using `target="defaults"`:

--- a/cli/simpletask/templates/qwen/simpletask.split.md
+++ b/cli/simpletask/templates/qwen/simpletask.split.md
@@ -23,9 +23,10 @@ If task file not found: Report "No task file found. Run /simpletask.plan first."
 
 ## Step 1.5: Codebase Analysis & Design (Conditional)
 
-**SKIP this step if:**
+**SKIP this step if ANY of the following are true:**
 - `simpletask_get()` shows `spec.design` is already populated (has patterns, constraints, or references)
 - `simpletask_get()` shows `spec.quality_requirements` already configured
+- `.tasks/defaults.yml` exists AND contains design patterns or quality requirements (they were already auto-merged into the task file at creation time — no need to repeat analysis)
 
 **If design section is empty or missing, execute this mandatory codebase analysis:**
 
@@ -169,6 +170,19 @@ Use simpletask_quality() MCP tool to apply preset:
 ```
 
 **Available presets:** python, typescript, node, go, rust, java-maven, java-gradle
+
+**Save analysis results to project defaults (recommended):**
+
+If `.tasks/defaults.yml` does not yet exist, save the analysis results there too so future task files inherit them automatically:
+
+```
+simpletask_design(action="set", field="pattern", value="...", target="defaults")
+simpletask_design(action="set", field="constraint", value="...", target="defaults")
+simpletask_quality(action="preset", preset_name="python", target="defaults")
+# Repeat for all findings above
+```
+
+This is a one-time investment — future `/simpletask.plan` runs will skip this entire Step 1.5.
 
 **After completing Step 1.5, reload the task file:**
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simpletask"
-version = "0.30.0"
+version = "0.31.0"
 description = "CLI tool for managing AI-friendly task definitions in branch-based development workflows"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -1,0 +1,453 @@
+"""Unit tests for ProjectDefaults model and defaults.py module.
+
+Tests cover:
+- ProjectDefaults model validation
+- load_defaults() — file missing, valid, malformed, extra fields
+- save_defaults() — round-trip, creates dir if needed
+- merge_defaults_into_spec() — fill-gaps-only strategy, edge cases
+- list_tasks / list_tasks_by_mtime exclusion of defaults.yml
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+from simpletask.core.defaults import (
+    get_defaults_path,
+    load_defaults,
+    merge_defaults_into_spec,
+    save_defaults,
+)
+from simpletask.core.models import (
+    AcceptanceCriterion,
+    ArchitecturalPattern,
+    Design,
+    LintingConfig,
+    ProjectDefaults,
+    QualityRequirements,
+    SimpleTaskSpec,
+    TestingConfig,
+    ToolName,
+)
+from simpletask.core.project import Project
+from simpletask.core.yaml_parser import InvalidTaskFileError, write_task_file
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_project(root: Path) -> Project:
+    return Project(root=root)
+
+
+def _make_minimal_spec(branch: str = "test-branch") -> SimpleTaskSpec:
+    return SimpleTaskSpec(
+        schema_version="1.0",
+        branch=branch,
+        title="Test",
+        original_prompt="Test",
+        created=datetime.now(UTC),
+        acceptance_criteria=[
+            AcceptanceCriterion(id="AC1", description="Done", completed=False),
+        ],
+        constraints=None,
+        context=None,
+        tasks=None,
+    )
+
+
+def _make_design() -> Design:
+    return Design(
+        patterns=[ArchitecturalPattern.REPOSITORY],
+        reference_implementations=None,
+        architectural_constraints=["Use Pydantic"],
+        security=None,
+        error_handling=None,
+    )
+
+
+def _make_quality() -> QualityRequirements:
+    return QualityRequirements(
+        linting=LintingConfig(
+            enabled=True,
+            tool=ToolName.RUFF,
+            args=["check", "."],
+            timeout=300,
+        ),
+        type_checking=None,
+        testing=TestingConfig(
+            enabled=True,
+            tool=ToolName.PYTEST,
+            args=["--cov=cli/simpletask"],
+            timeout=600,
+        ),
+        security_check=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ProjectDefaults model
+# ---------------------------------------------------------------------------
+
+
+class TestProjectDefaultsModel:
+    """Tests for the ProjectDefaults Pydantic model."""
+
+    def test_all_fields_set(self):
+        """ProjectDefaults with all fields populated."""
+        defaults = ProjectDefaults(
+            design=_make_design(),
+            quality_requirements=_make_quality(),
+            constraints=["Be strict"],
+            context={"env": "test"},
+        )
+        assert defaults.design is not None
+        assert defaults.quality_requirements is not None
+        assert defaults.constraints == ["Be strict"]
+        assert defaults.context == {"env": "test"}
+
+    def test_extra_fields_rejected(self):
+        """extra='forbid' means unknown fields raise ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ProjectDefaults.model_validate({"unknown_field": "value"})
+
+
+# ---------------------------------------------------------------------------
+# load_defaults
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDefaults:
+    """Tests for load_defaults()."""
+
+    def test_returns_none_when_file_missing(self, tmp_project):
+        """Returns None when .tasks/defaults.yml does not exist."""
+        project = _make_project(tmp_project)
+        result = load_defaults(project)
+        assert result is None
+
+    def test_returns_project_defaults_when_valid(self, tmp_project):
+        """Returns ProjectDefaults when file is valid YAML."""
+        project = _make_project(tmp_project)
+        defaults = ProjectDefaults(constraints=["No magic numbers"])
+        save_defaults(project, defaults)
+
+        loaded = load_defaults(project)
+        assert loaded is not None
+        assert loaded.constraints == ["No magic numbers"]
+
+    def test_returns_empty_defaults_for_empty_file(self, tmp_project):
+        """Empty YAML file produces empty ProjectDefaults (not None)."""
+        project = _make_project(tmp_project)
+        project.ensure_tasks_dir()
+        get_defaults_path(project).write_text("", encoding="utf-8")
+
+        result = load_defaults(project)
+        assert result is not None
+        assert result.design is None
+        assert result.constraints is None
+
+    def test_raises_on_malformed_yaml(self, tmp_project):
+        """InvalidTaskFileError raised on bad YAML syntax."""
+        project = _make_project(tmp_project)
+        project.ensure_tasks_dir()
+        get_defaults_path(project).write_text("key: [unclosed", encoding="utf-8")
+
+        with pytest.raises(InvalidTaskFileError, match="Invalid YAML syntax"):
+            load_defaults(project)
+
+    def test_raises_on_extra_fields(self, tmp_project):
+        """InvalidTaskFileError raised when YAML has unknown fields."""
+        project = _make_project(tmp_project)
+        project.ensure_tasks_dir()
+        content = yaml.dump({"constraints": ["ok"], "bogus_field": "oops"})
+        get_defaults_path(project).write_text(content, encoding="utf-8")
+
+        with pytest.raises(InvalidTaskFileError):
+            load_defaults(project)
+
+    def test_raises_when_root_is_not_dict(self, tmp_project):
+        """InvalidTaskFileError raised when YAML root is not a dict."""
+        project = _make_project(tmp_project)
+        project.ensure_tasks_dir()
+        get_defaults_path(project).write_text("- item1\n- item2\n", encoding="utf-8")
+
+        with pytest.raises(InvalidTaskFileError, match="expected a dictionary"):
+            load_defaults(project)
+
+    def test_full_round_trip(self, tmp_project):
+        """Defaults with all fields save and load correctly."""
+        project = _make_project(tmp_project)
+        original = ProjectDefaults(
+            design=_make_design(),
+            quality_requirements=_make_quality(),
+            constraints=["Constraint A", "Constraint B"],
+            context={"version": "1.0"},
+        )
+        save_defaults(project, original)
+        loaded = load_defaults(project)
+
+        assert loaded is not None
+        assert loaded.constraints == ["Constraint A", "Constraint B"]
+        assert loaded.context == {"version": "1.0"}
+        assert loaded.design is not None
+        assert ArchitecturalPattern.REPOSITORY in (loaded.design.patterns or [])
+
+
+# ---------------------------------------------------------------------------
+# save_defaults
+# ---------------------------------------------------------------------------
+
+
+class TestSaveDefaults:
+    """Tests for save_defaults()."""
+
+    def test_creates_tasks_dir_if_missing(self, tmp_path):
+        """save_defaults creates the .tasks/ directory when it doesn't exist."""
+        import git
+
+        root = tmp_path / "new-project"
+        root.mkdir()
+        git.Repo.init(root)
+        project = _make_project(root)
+
+        # .tasks/ should not exist yet
+        assert not project.tasks_dir.exists()
+
+        defaults = ProjectDefaults(constraints=["Use Pydantic"])
+        save_defaults(project, defaults)
+
+        assert get_defaults_path(project).exists()
+
+    def test_writes_valid_yaml(self, tmp_project):
+        """Written file is valid YAML that can be parsed."""
+        project = _make_project(tmp_project)
+        defaults = ProjectDefaults(context={"key": "value"})
+        path = save_defaults(project, defaults)
+
+        content = path.read_text(encoding="utf-8")
+        data = yaml.safe_load(content)
+        assert isinstance(data, dict)
+        assert data.get("context") == {"key": "value"}
+
+    def test_overwrites_existing_file(self, tmp_project):
+        """save_defaults overwrites an existing defaults.yml."""
+        project = _make_project(tmp_project)
+        save_defaults(project, ProjectDefaults(constraints=["Old constraint"]))
+        save_defaults(project, ProjectDefaults(constraints=["New constraint"]))
+
+        loaded = load_defaults(project)
+        assert loaded is not None
+        assert loaded.constraints == ["New constraint"]
+
+    def test_exclude_none_fields_in_output(self, tmp_project):
+        """Fields that are None are not written to the YAML file."""
+        project = _make_project(tmp_project)
+        defaults = ProjectDefaults(constraints=["A"])
+        path = save_defaults(project, defaults)
+
+        content = path.read_text(encoding="utf-8")
+        assert "design" not in content
+        assert "quality_requirements" not in content
+        assert "context" not in content
+
+
+# ---------------------------------------------------------------------------
+# merge_defaults_into_spec
+# ---------------------------------------------------------------------------
+
+
+class TestMergeDefaultsIntoSpec:
+    """Tests for merge_defaults_into_spec() — fill-gaps-only strategy."""
+
+    def test_fills_none_constraints_from_defaults(self):
+        """spec.constraints=None is populated from defaults."""
+        spec = _make_minimal_spec()
+        defaults = ProjectDefaults(constraints=["No shell=True"])
+        result = merge_defaults_into_spec(spec, defaults)
+        assert result.constraints == ["No shell=True"]
+
+    def test_fills_none_context_from_defaults(self):
+        """spec.context=None is populated from defaults."""
+        spec = _make_minimal_spec()
+        defaults = ProjectDefaults(context={"env": "ci"})
+        result = merge_defaults_into_spec(spec, defaults)
+        assert result.context == {"env": "ci"}
+
+    def test_fills_none_design_from_defaults(self):
+        """spec.design=None is populated from defaults."""
+        spec = _make_minimal_spec()
+        design = _make_design()
+        defaults = ProjectDefaults(design=design)
+        result = merge_defaults_into_spec(spec, defaults)
+        assert result.design is not None
+        assert ArchitecturalPattern.REPOSITORY in (result.design.patterns or [])
+
+    def test_fills_none_quality_from_defaults(self):
+        """spec.quality_requirements=None is populated from defaults."""
+        spec = _make_minimal_spec()
+        q = _make_quality()
+        defaults = ProjectDefaults(quality_requirements=q)
+        result = merge_defaults_into_spec(spec, defaults)
+        assert result.quality_requirements is not None
+        assert result.quality_requirements.linting is not None
+
+    def test_does_not_overwrite_existing_constraints(self):
+        """Existing spec.constraints is NOT replaced by defaults."""
+        spec = _make_minimal_spec()
+        spec.constraints = ["Existing constraint"]
+        defaults = ProjectDefaults(constraints=["Default constraint"])
+        result = merge_defaults_into_spec(spec, defaults)
+        assert result.constraints == ["Existing constraint"]
+
+    def test_does_not_overwrite_existing_context(self):
+        """Existing spec.context is NOT replaced by defaults."""
+        spec = _make_minimal_spec()
+        spec.context = {"my_key": "my_value"}
+        defaults = ProjectDefaults(context={"default_key": "default_value"})
+        result = merge_defaults_into_spec(spec, defaults)
+        assert result.context == {"my_key": "my_value"}
+
+    def test_does_not_overwrite_existing_design(self):
+        """Existing spec.design is NOT replaced by defaults."""
+        spec = _make_minimal_spec()
+        existing_design = Design(
+            patterns=[ArchitecturalPattern.SERVICE_LAYER],
+            reference_implementations=None,
+            architectural_constraints=None,
+            security=None,
+            error_handling=None,
+        )
+        spec.design = existing_design
+        defaults_design = _make_design()  # has REPOSITORY pattern
+        defaults = ProjectDefaults(design=defaults_design)
+        result = merge_defaults_into_spec(spec, defaults)
+        assert result.design is existing_design
+        assert ArchitecturalPattern.SERVICE_LAYER in (result.design.patterns or [])
+        assert ArchitecturalPattern.REPOSITORY not in (result.design.patterns or [])
+
+    def test_empty_defaults_is_noop(self):
+        """All-None defaults produce no changes to the spec."""
+        spec = _make_minimal_spec()
+        spec.context = {"keep": "this"}
+        defaults = ProjectDefaults()
+        result = merge_defaults_into_spec(spec, defaults)
+        assert result.constraints is None
+        assert result.context == {"keep": "this"}
+        assert result.design is None
+        assert result.quality_requirements is None
+
+    def test_partial_defaults_fills_only_missing(self):
+        """Only unset spec fields are populated; present ones are untouched."""
+        spec = _make_minimal_spec()
+        spec.constraints = ["Keep me"]
+        defaults = ProjectDefaults(
+            constraints=["Should be ignored"],
+            context={"fill": "this"},
+        )
+        result = merge_defaults_into_spec(spec, defaults)
+        assert result.constraints == ["Keep me"]
+        assert result.context == {"fill": "this"}
+
+
+# ---------------------------------------------------------------------------
+# Integration: create_task_file merges defaults
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTaskFileWithDefaults:
+    """Integration tests verifying create_task_file uses project defaults."""
+
+    def test_new_task_gets_defaults_merged(self, tmp_project):
+        """create_task_file merges defaults.yml into the new task file."""
+        import git
+
+        project = _make_project(tmp_project)
+        # Set up a branch so task creation can proceed
+        repo = git.Repo(tmp_project)
+        branch = repo.create_head("feature/with-defaults")
+        branch.checkout()
+
+        # Write defaults
+        defaults = ProjectDefaults(
+            constraints=["Use Pydantic"],
+            context={"team": "backend"},
+        )
+        save_defaults(project, defaults)
+
+        # Create a task file
+        from simpletask.core.task_file_ops import create_task_file
+
+        spec = create_task_file(project, "feature/with-defaults", "Test Title", "Test prompt")
+        assert spec.constraints == ["Use Pydantic"]
+        assert spec.context == {"team": "backend"}
+
+    def test_new_task_no_defaults_is_unchanged(self, tmp_project):
+        """When no defaults.yml exists, task creation is unchanged."""
+        import git
+
+        project = _make_project(tmp_project)
+        repo = git.Repo(tmp_project)
+        branch = repo.create_head("feature/no-defaults")
+        branch.checkout()
+
+        # No defaults.yml exists
+        from simpletask.core.task_file_ops import create_task_file
+
+        spec = create_task_file(project, "feature/no-defaults", "T", "P")
+        assert spec.constraints is None
+        assert spec.context is None
+        assert spec.design is None
+
+
+# ---------------------------------------------------------------------------
+# list_tasks exclusion of defaults.yml
+# ---------------------------------------------------------------------------
+
+
+class TestListTasksDefaultsExclusion:
+    """Tests ensuring defaults.yml is excluded from task listings."""
+
+    def _write_defaults(self, project: Project) -> None:
+        defaults = ProjectDefaults(constraints=["Test"])
+        save_defaults(project, defaults)
+
+    def _write_task_file(self, project: Project, branch: str) -> None:
+        spec = _make_minimal_spec(branch=branch)
+        task_file = project.get_task_file(branch)
+        write_task_file(task_file, spec)
+
+    def test_list_tasks_excludes_defaults_yml(self, tmp_project):
+        """list_tasks() does not include defaults.yml in results."""
+        project = _make_project(tmp_project)
+        self._write_defaults(project)
+        self._write_task_file(project, "feature/my-task")
+
+        tasks = project.list_tasks()
+        assert "feature/my-task" in tasks
+        # defaults.yml has no 'branch' field so it won't be parsed as a task anyway,
+        # but our explicit check ensures it's skipped by filename before any parsing
+        assert len(tasks) == 1
+
+    def test_list_tasks_only_defaults_returns_empty(self, tmp_project):
+        """When only defaults.yml exists, list_tasks() returns empty list."""
+        project = _make_project(tmp_project)
+        self._write_defaults(project)
+
+        tasks = project.list_tasks()
+        assert tasks == []
+
+    def test_list_tasks_by_mtime_excludes_defaults_yml(self, tmp_project):
+        """list_tasks_by_mtime() does not include defaults.yml in results."""
+        project = _make_project(tmp_project)
+        self._write_defaults(project)
+        self._write_task_file(project, "feature/my-task")
+
+        tasks = project.list_tasks_by_mtime()
+        branches = [t[0] for t in tasks]
+        assert "feature/my-task" in branches
+        assert len(tasks) == 1

--- a/tests/unit/test_defaults_commands.py
+++ b/tests/unit/test_defaults_commands.py
@@ -1,0 +1,589 @@
+"""Unit tests for defaults CLI commands.
+
+Tests cover:
+- defaults show command: no file, with file, all sections
+- defaults clear command: full file, specific field
+- defaults design set command: all field types
+- defaults quality set and preset commands
+- defaults constraint add command
+- defaults context set command
+"""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+import yaml
+from simpletask.commands.defaults.commands import (
+    clear_command,
+    constraint_add_command,
+    context_set_command,
+    design_set_command,
+    quality_preset_command,
+    quality_set_command,
+    show_command,
+)
+from simpletask.core.defaults import load_defaults
+from simpletask.core.models import (
+    ArchitecturalPattern,
+    Design,
+    ErrorHandlingStrategy,
+    LintingConfig,
+    ProjectDefaults,
+    QualityRequirements,
+    SecurityCategory,
+    TestingConfig,
+    ToolName,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_project(tmp_path: Path) -> MagicMock:
+    """Return a mock Project whose tasks_dir points to a real temp directory."""
+    tasks_dir = tmp_path / ".tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    mock_project = MagicMock()
+    mock_project.tasks_dir = tasks_dir
+    mock_project.ensure_tasks_dir.return_value = tasks_dir
+    return mock_project
+
+
+def _write_defaults(tasks_dir: Path, defaults: ProjectDefaults) -> Path:
+    """Serialise and write a ProjectDefaults to the tasks directory."""
+    data: dict[str, Any] = defaults.model_dump(mode="json", exclude_none=True)
+    path = tasks_dir / "defaults.yml"
+    path.write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# TestShowCommand
+# ---------------------------------------------------------------------------
+
+
+class TestShowCommand:
+    """Tests for 'simpletask defaults show'."""
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_show_no_defaults_file(self, mock_ensure, tmp_path, capsys):
+        """Show prints a 'no defaults' message when defaults.yml is absent."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        show_command()
+
+        captured = capsys.readouterr()
+        assert "No project defaults configured" in captured.out
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_show_with_all_sections(self, mock_ensure, tmp_path, capsys):
+        """Show renders design, constraints, and context from a real file."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        defaults = ProjectDefaults(
+            design=Design(
+                patterns=[ArchitecturalPattern.REPOSITORY],
+                architectural_constraints=["Use Pydantic"],
+            ),
+            constraints=["No shell=True", "Use pathlib"],
+            context={"framework": "django", "db": "postgres"},
+        )
+        _write_defaults(tmp_path / ".tasks", defaults)
+
+        show_command()
+
+        captured = capsys.readouterr()
+        assert "repository" in captured.out
+        assert "Use Pydantic" in captured.out
+        assert "No shell=True" in captured.out
+        assert "Use pathlib" in captured.out
+        assert "framework" in captured.out
+        assert "django" in captured.out
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_show_empty_defaults_file(self, mock_ensure, tmp_path, capsys):
+        """Show displays an 'empty' message when the file exists but has no sections."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        _write_defaults(tmp_path / ".tasks", ProjectDefaults())
+
+        show_command()
+
+        captured = capsys.readouterr()
+        assert "empty" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# TestClearCommand
+# ---------------------------------------------------------------------------
+
+
+class TestClearCommand:
+    """Tests for 'simpletask defaults clear'."""
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_clear_all_removes_file(self, mock_ensure, tmp_path):
+        """Clear without --field deletes the entire defaults.yml."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        # Create the file
+        defaults_path = tmp_path / ".tasks" / "defaults.yml"
+        defaults_path.write_text("constraints:\n- test\n", encoding="utf-8")
+
+        clear_command(field=None)
+
+        assert not defaults_path.exists()
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_clear_all_no_file(self, mock_ensure, tmp_path, capsys):
+        """Clear without --field prints 'nothing to remove' when file is absent."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        clear_command(field=None)
+
+        captured = capsys.readouterr()
+        assert "No defaults file" in captured.out
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_clear_design_field(self, mock_ensure, tmp_path):
+        """Clear --field design removes only the design section."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        defaults = ProjectDefaults(
+            design=Design(patterns=[ArchitecturalPattern.REPOSITORY]),
+            constraints=["Keep this"],
+        )
+        _write_defaults(tmp_path / ".tasks", defaults)
+
+        clear_command(field="design")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.design is None
+        assert result.constraints == ["Keep this"]
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_clear_quality_field(self, mock_ensure, tmp_path):
+        """Clear --field quality removes only the quality section."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        defaults = ProjectDefaults(
+            quality_requirements=QualityRequirements(
+                linting=LintingConfig(enabled=True, tool=ToolName.RUFF, args=["check", "."]),
+                testing=TestingConfig(enabled=False, tool=ToolName.PYTEST, args=[]),
+            ),
+            constraints=["Keep this"],
+        )
+        _write_defaults(tmp_path / ".tasks", defaults)
+
+        clear_command(field="quality")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.quality_requirements is None
+        assert result.constraints == ["Keep this"]
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_clear_constraints_field(self, mock_ensure, tmp_path):
+        """Clear --field constraints removes only the constraints section."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        defaults = ProjectDefaults(
+            constraints=["c1", "c2"],
+            context={"k": "v"},
+        )
+        _write_defaults(tmp_path / ".tasks", defaults)
+
+        clear_command(field="constraints")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.constraints is None
+        assert result.context == {"k": "v"}
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_clear_context_field(self, mock_ensure, tmp_path):
+        """Clear --field context removes only the context section."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        defaults = ProjectDefaults(
+            constraints=["keep"],
+            context={"k": "v"},
+        )
+        _write_defaults(tmp_path / ".tasks", defaults)
+
+        clear_command(field="context")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.context is None
+        assert result.constraints == ["keep"]
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_clear_invalid_field(self, mock_ensure, tmp_path):
+        """Clear with an invalid --field name raises typer.Exit."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        with pytest.raises(typer.Exit):
+            clear_command(field="nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# TestDesignSetCommand
+# ---------------------------------------------------------------------------
+
+
+class TestDesignSetCommand:
+    """Tests for 'simpletask defaults design set'."""
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_pattern(self, mock_ensure, tmp_path):
+        """design set pattern writes pattern to defaults.yml."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        design_set_command(field="pattern", value="repository")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.design is not None
+        assert ArchitecturalPattern.REPOSITORY in result.design.patterns  # type: ignore[operator]
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_constraint(self, mock_ensure, tmp_path):
+        """design set constraint writes constraint to defaults.yml."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        design_set_command(field="constraint", value="Use Pydantic with extra='forbid'")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.design is not None
+        assert "Use Pydantic with extra='forbid'" in result.design.architectural_constraints  # type: ignore[operator]
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_reference(self, mock_ensure, tmp_path):
+        """design set reference writes reference to defaults.yml."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        design_set_command(
+            field="reference",
+            value="cli/simpletask/mcp/server.py",
+            reference_reason="MCP tool pattern",
+        )
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.design is not None
+        assert result.design.reference_implementations is not None
+        ref = result.design.reference_implementations[0]
+        assert ref.path == "cli/simpletask/mcp/server.py"
+        assert ref.reason == "MCP tool pattern"
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_reference_missing_reason(self, mock_ensure, tmp_path):
+        """design set reference without --reason raises typer.Exit."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        with pytest.raises(typer.Exit):
+            design_set_command(field="reference", value="src/module.py", reference_reason=None)
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_security(self, mock_ensure, tmp_path):
+        """design set security writes security requirement to defaults.yml."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        design_set_command(
+            field="security",
+            value="Validate all inputs",
+            security_category="input_validation",
+        )
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.design is not None
+        assert result.design.security is not None
+        req = result.design.security[0]
+        assert req.category == SecurityCategory.INPUT_VALIDATION
+        assert req.description == "Validate all inputs"
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_error_handling(self, mock_ensure, tmp_path):
+        """design set error-handling writes strategy to defaults.yml."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        design_set_command(field="error-handling", value="exceptions")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.design is not None
+        assert result.design.error_handling == ErrorHandlingStrategy.EXCEPTIONS
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_invalid_field(self, mock_ensure, tmp_path):
+        """design set with unknown field raises typer.Exit."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        with pytest.raises(typer.Exit):
+            design_set_command(field="nonexistent", value="anything")
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_invalid_pattern(self, mock_ensure, tmp_path):
+        """design set pattern with invalid value raises typer.Exit."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        with pytest.raises(typer.Exit):
+            design_set_command(field="pattern", value="not_a_valid_pattern")
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_appends_to_existing(self, mock_ensure, tmp_path):
+        """design set appends to existing defaults instead of overwriting."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        design_set_command(field="pattern", value="repository")
+        design_set_command(field="pattern", value="factory")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.design is not None
+        patterns = result.design.patterns or []
+        assert ArchitecturalPattern.REPOSITORY in patterns
+        assert ArchitecturalPattern.FACTORY in patterns
+
+
+# ---------------------------------------------------------------------------
+# TestQualitySetCommand
+# ---------------------------------------------------------------------------
+
+
+class TestQualitySetCommand:
+    """Tests for 'simpletask defaults quality set'."""
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_linting(self, mock_ensure, tmp_path):
+        """quality set linting writes linting config to defaults.yml."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        quality_set_command(
+            config_type="linting",  # type: ignore[arg-type]
+            tool=ToolName.RUFF,
+            args="check,.",
+            enable=True,
+            disable=False,
+            min_coverage=None,
+            timeout=None,
+        )
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.quality_requirements is not None
+        assert result.quality_requirements.linting is not None
+        linting = result.quality_requirements.linting
+        assert linting.tool == ToolName.RUFF
+        assert linting.enabled is True
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_testing_with_coverage(self, mock_ensure, tmp_path):
+        """quality set testing with min-coverage writes correct config."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        quality_set_command(
+            config_type="testing",  # type: ignore[arg-type]
+            tool=ToolName.PYTEST,
+            args=None,
+            enable=True,
+            disable=False,
+            min_coverage=80,
+            timeout=600,
+        )
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.quality_requirements is not None
+        assert result.quality_requirements.testing is not None
+        testing = result.quality_requirements.testing
+        assert testing.tool == ToolName.PYTEST
+        assert testing.min_coverage == 80
+        assert testing.timeout == 600
+
+
+# ---------------------------------------------------------------------------
+# TestQualityPresetCommand
+# ---------------------------------------------------------------------------
+
+
+class TestQualityPresetCommand:
+    """Tests for 'simpletask defaults quality preset'."""
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_preset_python_applies(self, mock_ensure, tmp_path):
+        """quality preset python populates defaults.yml quality section."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        quality_preset_command(preset_name="python", list_flag=False)
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.quality_requirements is not None
+        # python preset should set linting (ruff) and type checking (mypy) at minimum
+        assert result.quality_requirements.linting is not None
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_preset_missing_name_exits(self, mock_ensure, tmp_path):
+        """quality preset without name raises typer.Exit."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        with pytest.raises(typer.Exit):
+            quality_preset_command(preset_name=None, list_flag=False)
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_preset_list_flag(self, mock_ensure, tmp_path, capsys):
+        """quality preset --list prints available presets and exits cleanly."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        quality_preset_command(preset_name=None, list_flag=True)
+
+        captured = capsys.readouterr()
+        assert "python" in captured.out
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_preset_fills_gaps_only(self, mock_ensure, tmp_path):
+        """quality preset does not overwrite existing configuration."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        # Pre-populate linting config
+        existing = ProjectDefaults(
+            quality_requirements=QualityRequirements(
+                linting=LintingConfig(enabled=False, tool=ToolName.RUFF, args=["check", "src/"]),
+                testing=TestingConfig(enabled=False, tool=ToolName.PYTEST, args=[]),
+            )
+        )
+        _write_defaults(tmp_path / ".tasks", existing)
+
+        quality_preset_command(preset_name="python", list_flag=False)
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.quality_requirements is not None
+        # Existing linting should be kept (args preserved)
+        linting = result.quality_requirements.linting
+        assert linting is not None
+        assert linting.args == ["check", "src/"]
+
+
+# ---------------------------------------------------------------------------
+# TestConstraintAddCommand
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintAddCommand:
+    """Tests for 'simpletask defaults constraint add'."""
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_add_constraint(self, mock_ensure, tmp_path):
+        """constraint add writes constraint to defaults.yml."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        constraint_add_command(value="Use Pydantic with extra='forbid'")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.constraints is not None
+        assert "Use Pydantic with extra='forbid'" in result.constraints
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_add_multiple_constraints(self, mock_ensure, tmp_path):
+        """constraint add accumulates multiple constraints."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        constraint_add_command(value="constraint one")
+        constraint_add_command(value="constraint two")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.constraints is not None
+        assert len(result.constraints) == 2
+
+
+# ---------------------------------------------------------------------------
+# TestContextSetCommand
+# ---------------------------------------------------------------------------
+
+
+class TestContextSetCommand:
+    """Tests for 'simpletask defaults context set'."""
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_context(self, mock_ensure, tmp_path):
+        """context set writes key-value to defaults.yml."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        context_set_command(key="framework", value="django")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.context is not None
+        assert result.context["framework"] == "django"
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_set_multiple_context_keys(self, mock_ensure, tmp_path):
+        """context set accumulates multiple keys."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        context_set_command(key="framework", value="django")
+        context_set_command(key="database", value="postgres")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.context is not None
+        assert result.context["framework"] == "django"
+        assert result.context["database"] == "postgres"
+
+    @patch("simpletask.commands.defaults.commands.ensure_project")
+    def test_overwrite_existing_key(self, mock_ensure, tmp_path):
+        """context set overwrites an existing key with new value."""
+        mock_project = _make_project(tmp_path)
+        mock_ensure.return_value = mock_project
+
+        context_set_command(key="framework", value="flask")
+        context_set_command(key="framework", value="django")
+
+        result = load_defaults(mock_project)
+        assert result is not None
+        assert result.context is not None
+        assert result.context["framework"] == "django"

--- a/tests/unit/test_mcp_defaults_target.py
+++ b/tests/unit/test_mcp_defaults_target.py
@@ -1,0 +1,617 @@
+"""Unit tests for MCP tools with target='defaults' parameter."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from simpletask.mcp.server import constraint, context, design, quality
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def defaults_project(tmp_path: Path) -> tuple[Path, MagicMock]:
+    """Create a temp .tasks/ dir and a mock Project pointing at it.
+
+    Returns:
+        Tuple of (tasks_dir, mock_project)
+    """
+    tasks_dir = tmp_path / ".tasks"
+    tasks_dir.mkdir()
+
+    mock_project = MagicMock()
+    mock_project.tasks_dir = tasks_dir
+    mock_project.ensure_tasks_dir.return_value = tasks_dir
+
+    return tasks_dir, mock_project
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _patch_ensure_project(mock_project: MagicMock):
+    """Return a context manager that patches ensure_project in server.py."""
+    return patch("simpletask.mcp.server.ensure_project", return_value=mock_project)
+
+
+# ---------------------------------------------------------------------------
+# design() — target='defaults'
+# ---------------------------------------------------------------------------
+
+
+class TestDesignDefaultsTarget:
+    """Tests for design() MCP tool with target='defaults'."""
+
+    def test_get_returns_empty_when_no_defaults_file(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = design(action="get", target="defaults")
+
+        assert response.action == "design_get"
+        assert response.design is None
+        assert "defaults" in response.file_path
+
+    def test_set_pattern_creates_defaults_file(self, defaults_project):
+        tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = design(action="set", field="pattern", value="repository", target="defaults")
+
+        assert response.success is True
+        assert response.action == "design_set"
+        defaults_file = tasks_dir / "defaults.yml"
+        assert defaults_file.exists()
+
+    def test_set_pattern_roundtrips_via_get(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            design(action="set", field="pattern", value="repository", target="defaults")
+            response = design(action="get", target="defaults")
+
+        assert response.design is not None
+        assert response.design.patterns is not None
+        assert any(p.value == "repository" for p in response.design.patterns)
+
+    def test_set_constraint_writes_to_defaults(self, defaults_project):
+        tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = design(
+                action="set",
+                field="constraint",
+                value="Use Pydantic models with extra='forbid'",
+                target="defaults",
+            )
+
+        assert response.success is True
+        defaults_file = tasks_dir / "defaults.yml"
+        content = defaults_file.read_text()
+        assert "Pydantic" in content
+
+    def test_set_reference_requires_reason(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="reason"):
+                design(
+                    action="set",
+                    field="reference",
+                    value="cli/simpletask/mcp/server.py",
+                    target="defaults",
+                )
+
+    def test_set_reference_with_reason(self, defaults_project):
+        tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = design(
+                action="set",
+                field="reference",
+                value="cli/simpletask/mcp/server.py",
+                reason="MCP tool pattern to follow",
+                target="defaults",
+            )
+
+        assert response.success is True
+        content = (tasks_dir / "defaults.yml").read_text()
+        assert "server.py" in content
+
+    def test_set_security_requires_category(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="category"):
+                design(
+                    action="set",
+                    field="security",
+                    value="Validate all inputs",
+                    target="defaults",
+                )
+
+    def test_set_security_with_category(self, defaults_project):
+        tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = design(
+                action="set",
+                field="security",
+                value="Validate all inputs",
+                category="input_validation",
+                target="defaults",
+            )
+
+        assert response.success is True
+        content = (tasks_dir / "defaults.yml").read_text()
+        assert "input_validation" in content
+
+    def test_set_error_handling(self, defaults_project):
+        tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = design(
+                action="set",
+                field="error-handling",
+                value="exceptions",
+                target="defaults",
+            )
+
+        assert response.success is True
+        content = (tasks_dir / "defaults.yml").read_text()
+        assert "exceptions" in content
+
+    def test_remove_pattern_by_index(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            design(action="set", field="pattern", value="repository", target="defaults")
+            response = design(action="remove", field="pattern", index=0, target="defaults")
+
+        assert response.success is True
+
+    def test_remove_all_patterns(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            design(action="set", field="pattern", value="repository", target="defaults")
+            response = design(action="remove", field="pattern", all=True, target="defaults")
+            get_response = design(action="get", target="defaults")
+
+        assert response.success is True
+        assert get_response.design is None or get_response.design.patterns is None
+
+    def test_summary_shows_defaults_branch(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = design(action="get", target="defaults")
+
+        assert response.summary.branch == "defaults"
+        assert response.summary.title == "Project Defaults"
+
+    def test_set_invalid_field_raises(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="field"):
+                design(action="set", field="nonexistent", value="x", target="defaults")
+
+    def test_set_invalid_pattern_raises(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="pattern"):
+                design(
+                    action="set",
+                    field="pattern",
+                    value="nonexistent_pattern",
+                    target="defaults",
+                )
+
+
+# ---------------------------------------------------------------------------
+# quality() — target='defaults'
+# ---------------------------------------------------------------------------
+
+
+class TestQualityDefaultsTarget:
+    """Tests for quality() MCP tool with target='defaults'."""
+
+    def test_get_returns_none_when_no_defaults_file(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = quality(action="get", target="defaults")
+
+        assert response.action == "quality_get"
+        assert response.quality_requirements is None
+
+    def test_set_linting_creates_defaults_file(self, defaults_project):
+        tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = quality(
+                action="set",
+                config_type="linting",
+                tool="ruff",
+                args="check,.",
+                target="defaults",
+            )
+
+        assert response.success is True
+        assert (tasks_dir / "defaults.yml").exists()
+
+    def test_set_linting_roundtrips_via_get(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            quality(
+                action="set",
+                config_type="linting",
+                tool="ruff",
+                args="check,.",
+                target="defaults",
+            )
+            response = quality(action="get", target="defaults")
+
+        assert response.quality_requirements is not None
+        assert response.quality_requirements.linting is not None
+        assert response.quality_requirements.linting.tool.value == "ruff"
+
+    def test_check_action_raises_for_defaults_target(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="branch task files"):
+                quality(action="check", target="defaults")
+
+    def test_preset_applies_to_defaults(self, defaults_project):
+        tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = quality(action="preset", preset_name="python", target="defaults")
+
+        assert response.success is True
+        assert (tasks_dir / "defaults.yml").exists()
+        content = (tasks_dir / "defaults.yml").read_text()
+        assert "ruff" in content
+
+    def test_preset_fills_gaps_only(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            # Pre-set linting with a different tool
+            quality(
+                action="set",
+                config_type="linting",
+                tool="pylint",
+                args=".",
+                target="defaults",
+            )
+            # Apply preset — should not overwrite existing linting config
+            quality(action="preset", preset_name="python", target="defaults")
+            response = quality(action="get", target="defaults")
+
+        assert response.quality_requirements is not None
+        assert response.quality_requirements.linting is not None
+        # Existing linting config (pylint) should be preserved
+        assert response.quality_requirements.linting.tool.value == "pylint"
+
+    def test_summary_shows_defaults_branch(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = quality(action="get", target="defaults")
+
+        assert response.summary.branch == "defaults"
+
+    def test_invalid_config_type_raises(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="config_type"):
+                quality(action="set", config_type="invalid", tool="ruff", target="defaults")
+
+    def test_missing_preset_name_raises(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="preset_name"):
+                quality(action="preset", target="defaults")
+
+    def test_set_type_checking_from_none_raises(self, defaults_project):
+        """Setting type-checking on empty defaults raises ValueError to avoid phantom entries."""
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="preset"):
+                quality(
+                    action="set",
+                    config_type="type-checking",
+                    tool="mypy",
+                    target="defaults",
+                )
+
+    def test_set_security_from_none_raises(self, defaults_project):
+        """Setting security on empty defaults raises ValueError to avoid phantom entries."""
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="preset"):
+                quality(
+                    action="set",
+                    config_type="security",
+                    tool="bandit",
+                    target="defaults",
+                )
+
+    def test_set_type_checking_after_preset_works(self, defaults_project):
+        """After applying a preset, type-checking can be configured without phantom entries."""
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            quality(action="preset", preset_name="python", target="defaults")
+            response = quality(
+                action="set",
+                config_type="type-checking",
+                tool="mypy",
+                args=".,--strict",
+                target="defaults",
+            )
+
+        assert response.success is True
+        # Verify linting was NOT silently added as a phantom — it came from the preset
+        get_response = None
+        with _patch_ensure_project(mock_project):
+            get_response = quality(action="get", target="defaults")
+        assert get_response is not None
+        assert get_response.quality_requirements is not None
+        assert get_response.quality_requirements.type_checking is not None
+        assert get_response.quality_requirements.type_checking.tool.value == "mypy"
+
+
+# ---------------------------------------------------------------------------
+# constraint() — target='defaults'
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintDefaultsTarget:
+    """Tests for constraint() MCP tool with target='defaults'."""
+
+    def test_list_returns_none_when_no_file(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = constraint(action="list", target="defaults")
+
+        assert response.action == "constraint_list"
+        assert response.constraints is None
+
+    def test_add_creates_defaults_file(self, defaults_project):
+        tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = constraint(
+                action="add",
+                value="Use Pydantic models with extra='forbid'",
+                target="defaults",
+            )
+
+        assert response.success is True
+        assert (tasks_dir / "defaults.yml").exists()
+
+    def test_add_then_list_roundtrips(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            constraint(action="add", value="Constraint A", target="defaults")
+            constraint(action="add", value="Constraint B", target="defaults")
+            response = constraint(action="list", target="defaults")
+
+        assert response.constraints is not None
+        assert "Constraint A" in response.constraints
+        assert "Constraint B" in response.constraints
+
+    def test_remove_by_index(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            constraint(action="add", value="Keep this", target="defaults")
+            constraint(action="add", value="Remove this", target="defaults")
+            response = constraint(action="remove", index=1, target="defaults")
+            list_response = constraint(action="list", target="defaults")
+
+        assert response.success is True
+        assert list_response.constraints is not None
+        assert "Remove this" not in list_response.constraints
+        assert "Keep this" in list_response.constraints
+
+    def test_remove_all(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            constraint(action="add", value="Some constraint", target="defaults")
+            response = constraint(action="remove", all=True, target="defaults")
+            list_response = constraint(action="list", target="defaults")
+
+        assert response.success is True
+        assert list_response.constraints is None
+
+    def test_add_missing_value_raises(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="value"):
+                constraint(action="add", target="defaults")
+
+    def test_remove_without_index_or_all_raises(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            constraint(action="add", value="Something", target="defaults")
+            with pytest.raises(ValueError):
+                constraint(action="remove", target="defaults")
+
+    def test_remove_invalid_index_raises(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            constraint(action="add", value="Only one", target="defaults")
+            with pytest.raises(ValueError):
+                constraint(action="remove", index=99, target="defaults")
+
+    def test_summary_shows_defaults_branch(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = constraint(action="list", target="defaults")
+
+        assert response.summary.branch == "defaults"
+
+
+# ---------------------------------------------------------------------------
+# context() — target='defaults'
+# ---------------------------------------------------------------------------
+
+
+class TestContextDefaultsTarget:
+    """Tests for context() MCP tool with target='defaults'."""
+
+    def test_show_returns_none_when_no_file(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = context(action="show", target="defaults")
+
+        assert response.action == "context_show"
+        assert response.context is None
+
+    def test_set_creates_defaults_file(self, defaults_project):
+        tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = context(action="set", key="api_version", value="v2", target="defaults")
+
+        assert response.success is True
+        assert (tasks_dir / "defaults.yml").exists()
+
+    def test_set_then_show_roundtrips(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            context(action="set", key="api_version", value="v2", target="defaults")
+            context(action="set", key="db", value="postgres", target="defaults")
+            response = context(action="show", target="defaults")
+
+        assert response.context is not None
+        assert response.context["api_version"] == "v2"
+        assert response.context["db"] == "postgres"
+
+    def test_remove_by_key(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            context(action="set", key="keep", value="yes", target="defaults")
+            context(action="set", key="remove_me", value="no", target="defaults")
+            response = context(action="remove", key="remove_me", target="defaults")
+            show_response = context(action="show", target="defaults")
+
+        assert response.success is True
+        assert show_response.context is not None
+        assert "remove_me" not in show_response.context
+        assert show_response.context["keep"] == "yes"
+
+    def test_remove_all(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            context(action="set", key="key1", value="val1", target="defaults")
+            response = context(action="remove", all=True, target="defaults")
+            show_response = context(action="show", target="defaults")
+
+        assert response.success is True
+        assert show_response.context is None
+
+    def test_remove_nonexistent_key_raises(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="not found"):
+                context(action="remove", key="nonexistent", target="defaults")
+
+    def test_set_missing_key_raises(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="key"):
+                context(action="set", value="v2", target="defaults")
+
+    def test_set_missing_value_raises(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            with pytest.raises(ValueError, match="value"):
+                context(action="set", key="k", target="defaults")
+
+    def test_summary_shows_defaults_branch(self, defaults_project):
+        _tasks_dir, mock_project = defaults_project
+
+        with _patch_ensure_project(mock_project):
+            response = context(action="show", target="defaults")
+
+        assert response.summary.branch == "defaults"
+
+
+# ---------------------------------------------------------------------------
+# Verify target='branch' still works (no regression)
+# ---------------------------------------------------------------------------
+
+
+class TestBranchTargetNoRegression:
+    """Verify that target='branch' (default) still works as before."""
+
+    def test_design_get_branch_target(self, tmp_project_with_task):
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+            response = design(action="get", target="branch")
+
+        assert response.action == "design_get"
+        # summary should NOT be the fake defaults summary
+        assert response.summary.branch != "defaults"
+
+    def test_constraint_list_branch_target(self, tmp_project_with_task):
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+            response = constraint(action="list", target="branch")
+
+        assert response.action == "constraint_list"
+        assert response.summary.branch != "defaults"
+
+    def test_context_show_branch_target(self, tmp_project_with_task):
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+            response = context(action="show", target="branch")
+
+        assert response.action == "context_show"
+        assert response.summary.branch != "defaults"
+
+    def test_quality_get_branch_target(self, tmp_project_with_task):
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+            response = quality(action="get", target="branch")
+
+        assert response.action == "quality_get"
+        assert response.summary.branch != "defaults"


### PR DESCRIPTION
Closes #6

## Summary

- Adds `.tasks/defaults.yml` — stores `design`, `quality_requirements`, `constraints`, and `context` sections using the existing Pydantic models, all optional
- Fill-gaps-only merge at `simpletask new` / `simpletask_new()` time — defaults are injected once at task file creation; the resulting file is fully independent afterwards
- New `simpletask defaults` CLI subcommand group: `show`, `clear`, `design set`, `quality set/preset`, `constraint add`, `context set`
- Existing MCP tools (`design`, `quality`, `constraint`, `context`) extended with `target: "branch" | "defaults"` parameter — no new tools added
- `list_tasks()` and `list_tasks_by_mtime()` explicitly skip `defaults.yml` by filename
- AI workflow templates (`simpletask.plan`, `simpletask.split`) updated to prompt for defaults creation on first run and skip codebase re-analysis when defaults are already populated

## Review fixes (post-review iteration)

- **Extracted `remove_from_design` helper** (`design_ops.py`) that operates directly on a `Design` object — eliminates the dummy `SimpleTaskSpec` construction that was used in `server.py` to reuse `remove_design_field`
- **Fixed phantom `QualityRequirements` auto-init** (`quality_ops.py`) — `update_quality_requirements` now raises `ValueError` when `existing=None` and `config_type` is `"type-checking"` or `"security"`, preventing disabled placeholder linting/testing entries from blocking future fill-gaps-only preset merges
- **Renamed misnamed test** (`test_defaults.py`) — `test_new_task_caller_values_take_precedence` → `test_new_task_gets_defaults_when_spec_fields_are_none`

## Quality

937 tests passing, mypy clean, ruff clean.