### PR TITLE
feat(mcp): add response filtering to get tool to reduce context bloat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -778,7 +778,7 @@ The MCP server exposes 11 tools for task management:
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `get` | Get complete task specification with status summary | `validate` (bool, optional): Include schema validation (default: false) |
+| `get` | Get complete task specification with status summary | `validate` (bool, optional): Include schema validation (default: false)<br>`include_completed` (bool, optional): Include completed tasks in spec.tasks (default: false)<br>`include_design` (bool, optional): Include design section (default: false)<br>`include_quality` (bool, optional): Include quality_requirements section (default: false)<br>`status` (str, optional): Filter tasks by status value<br>`iteration` (int\|str, optional): Filter tasks by iteration ID<br>`full` (bool, optional): Return everything unfiltered, overrides all other filters (default: false) |
 | `list` | List all task file branch names in the project | None |
 | `new` | Create a new task file | `branch` (str): Branch identifier<br>`title` (str): Task title<br>`prompt` (str): Original user request<br>`criteria` (list[str] \| None, optional): Acceptance criteria |
 | `task` | Manage implementation tasks (add/update/remove/get/batch) | `action` (str): 'add', 'update', 'remove', 'get', or 'batch'<br>`task_id` (str, optional): Task ID (required for update/remove/get)<br>`name` (str, optional): Task name (required for add)<br>`goal` (str, optional): Task goal/description<br>`status` (str, optional): Status for update ('not_started', 'in_progress', 'completed', 'blocked', 'paused')<br>`steps` (list[str] \| None, optional): Task steps for add action. None or [] adds placeholder ['To be defined']<br>`done_when` (list[str] \| None, optional): Completion verification conditions<br>`prerequisites` (list[str] \| None, optional): Prerequisite task IDs<br>`files` (list[dict] \| None, optional): Files to create/modify/delete<br>`code_examples` (list[dict] \| None, optional): Code patterns to follow<br>`operations` (list[dict], optional): List of BatchTaskOperation dicts (required for batch action) |
@@ -794,24 +794,64 @@ The MCP server exposes 11 tools for task management:
 
 #### get
 
-Returns enriched task data with pre-computed status counts:
+Returns enriched task data with pre-computed status counts. By default, filters out completed tasks and omits the design and quality_requirements sections to reduce context size for AI consumers.
+
+**Default Behavior (no parameters):**
+- `spec.tasks` contains only non-completed tasks (excludes `completed` status)
+- `spec.design` is set to `null`
+- `spec.quality_requirements` is set to `null`
+- `summary` always reflects the **full unfiltered** spec regardless of filters
+- `filters_applied` dict is included showing what was filtered
 
 **Parameters:**
 - `validate` (optional): Whether to include schema validation result. Default is `false` to reduce overhead.
+- `include_completed` (bool, optional): Include completed tasks in `spec.tasks`. Default: `false`.
+- `include_design` (bool, optional): Include the design section in the response. Default: `false`.
+- `include_quality` (bool, optional): Include `quality_requirements` in the response. Default: `false`.
+- `status` (str, optional): Filter `spec.tasks` to only tasks with this status. Valid values: `not_started`, `in_progress`, `completed`, `blocked`, `paused`. Combined with `include_completed` filter.
+- `iteration` (int|str, optional): Filter `spec.tasks` to only tasks assigned to this iteration ID. Combined with other filters.
+- `full` (bool, optional): Return everything unfiltered — all tasks (including completed), design, quality_requirements. Overrides all other filter parameters. Sets `filters_applied` to `null`. Default: `false`.
+
+**Key Behaviors:**
+
+| Parameter | Default | Effect |
+|-----------|---------|--------|
+| `include_completed=False` | default | Excludes tasks with `status: completed` from `spec.tasks` |
+| `include_design=False` | default | Sets `spec.design` to `null` |
+| `include_quality=False` | default | Sets `spec.quality_requirements` to `null` |
+| `full=True` | — | Returns everything, `filters_applied=null` |
+| `status="in_progress"` | — | Returns only in-progress tasks (combined with completed filter) |
+| `iteration=2` | — | Returns only tasks assigned to iteration 2 |
+
+**Workflow-Specific Usage Patterns:**
+
+| Workflow | Recommended Call | Why |
+|----------|-----------------|-----|
+| `plan` | `get(full=True)` | Needs design + quality to check if analysis required |
+| `split` | `get(full=True)` | Needs all tasks + design + quality for codebase analysis |
+| `implement` | `get()` | Needs only actionable (non-completed) tasks |
+| `review` | `get(include_completed=True)` | Needs all tasks to verify completion status |
+| validate | `get(validate=True, full=True)` | Schema validation against full spec |
 
 **Note:** This tool always uses the current git branch. Branch auto-detection prevents MCP clients from incorrectly passing string values like "None".
 
 **Returns:** `SimpleTaskGetResponse` with:
-- `spec`: Full `SimpleTaskSpec` (branch, title, acceptance_criteria, tasks, etc.)
+- `spec`: Filtered `SimpleTaskSpec` (branch, title, acceptance_criteria, tasks, etc.)
 - `file_path`: Path to task YAML file
-- `summary`: Pre-computed `StatusSummary` with:
+- `summary`: Pre-computed `StatusSummary` with **unfiltered** counts — always reflects the complete task file:
   - `branch`, `title`
   - `overall_status`: Computed from task states (blocked > paused > in_progress > completed > not_started)
   - `criteria_total`, `criteria_completed`
   - `tasks_total`, `tasks_completed`, `tasks_in_progress`, `tasks_not_started`, `tasks_blocked`, `tasks_paused`
+- `filters_applied` (dict or null): When filtering is active (`full=False`), contains:
+  - `include_completed` (bool)
+  - `include_design` (bool)
+  - `include_quality` (bool)
+  - `tasks_returned` (int): count of tasks in filtered `spec.tasks`
+  - `tasks_excluded` (int): count of tasks removed by filters
 - `validation` (optional): `ValidationResult` with `valid` (bool) and `errors` (list)
 
-**Example Response Structure:**
+**Example Response Structure (default call):**
 
 ```json
 {
@@ -819,7 +859,9 @@ Returns enriched task data with pre-computed status counts:
     "branch": "feature/mcp-server",
     "title": "Add MCP server support",
     "acceptance_criteria": [...],
-    "tasks": [...]
+    "tasks": [...],
+    "design": null,
+    "quality_requirements": null
   },
   "file_path": ".tasks/feature-mcp-server.yml",
   "summary": {
@@ -834,6 +876,13 @@ Returns enriched task data with pre-computed status counts:
     "tasks_not_started": 5,
     "tasks_blocked": 0,
     "tasks_paused": 0
+  },
+  "filters_applied": {
+    "include_completed": false,
+    "include_design": false,
+    "include_quality": false,
+    "tasks_returned": 6,
+    "tasks_excluded": 5
   },
   "validation": null
 }

--- a/cli/simpletask/__init__.py
+++ b/cli/simpletask/__init__.py
@@ -1,6 +1,6 @@
 """simpletask: A Python CLI for managing AI-friendly task definition YAML files."""
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"
 
 import typer
 

--- a/cli/simpletask/mcp/models.py
+++ b/cli/simpletask/mcp/models.py
@@ -164,6 +164,14 @@ class SimpleTaskGetResponse(BaseModel):
     validation: ValidationResult | None = Field(
         None, description="Validation result (only when validate=true)"
     )
+    filters_applied: dict[str, Any] | None = Field(
+        None,
+        description=(
+            "Active filters applied to response (None when full=True or no filtering). "
+            "Contains keys: include_completed, include_design, include_quality, "
+            "tasks_returned, tasks_excluded."
+        ),
+    )
 
 
 class SimpleTaskWriteResponse(BaseModel):

--- a/cli/simpletask/mcp/server.py
+++ b/cli/simpletask/mcp/server.py
@@ -162,31 +162,73 @@ __all__ = [
 @mcp.tool()
 def get(
     validate: bool = False,
+    iteration: int | str | None = None,
+    status: str | None = None,
+    include_completed: bool = False,
+    include_design: bool = False,
+    include_quality: bool = False,
+    full: bool = False,
 ) -> SimpleTaskGetResponse:
     """Get complete task specification with status summary.
 
     Returns the full task specification from .tasks/<branch>.yml with
     pre-computed status counts. Optionally validates against JSON schema.
 
+    By default, the response is filtered to reduce context bloat for AI consumers:
+    - Only non-completed tasks are returned (exclude completed unless include_completed=True)
+    - design section is excluded (include with include_design=True)
+    - quality_requirements section is excluded (include with include_quality=True)
+    - summary always reflects the FULL unfiltered spec (all task counts)
+
+    Use full=True to bypass all filtering and retrieve the complete unmodified spec.
+    This is the equivalent of the pre-filter behavior.
+
     Args:
         validate: Whether to include schema validation result (default: False).
                   Opt-in to reduce overhead for simple queries.
+        iteration: Filter tasks to only those assigned to this iteration ID.
+                   Accepts int or string integer (e.g. "2") for Qwen CLI compatibility.
+                   Combined with include_completed filter (AND logic).
+                   Raises ValueError if the iteration ID does not exist in the spec.
+        status: Filter tasks to only those with this status value.
+                Valid values: not_started, in_progress, completed, blocked, paused.
+                Raises ValueError if the value is not a valid TaskStatus.
+        include_completed: Include completed tasks in the response (default: False).
+                           When False, tasks with status='completed' are excluded.
+        include_design: Include the design section in the response (default: False).
+                        When False, spec.design is set to None to reduce payload size.
+        include_quality: Include quality_requirements in the response (default: False).
+                         When False, spec.quality_requirements is set to None.
+        full: Return the complete unfiltered spec (default: False).
+              When True, all other filter parameters are ignored and filters_applied is None.
+              Equivalent to include_completed=True, include_design=True, include_quality=True
+              with no iteration or status filter.
 
     Returns:
-        SimpleTaskGetResponse with spec, file_path, summary, and optional validation.
+        SimpleTaskGetResponse with spec, file_path, summary, validation, and filters_applied.
 
     Raises:
         ValueError: If not in a git repository, or branch is None and not on a git branch.
+        ValueError: If status is not a valid TaskStatus value.
+        ValueError: If iteration ID does not exist in the spec.
         FileNotFoundError: If task file doesn't exist for the specified branch.
         InvalidTaskFileError: If YAML file is malformed or invalid.
     """
+    # Coerce iteration string to int (Qwen CLI compat)
+    iteration_int: int | None = None
+    if iteration is not None:
+        try:
+            iteration_int = int(iteration)
+        except (ValueError, TypeError):
+            raise ValueError(f"'iteration' must be an integer, got: {iteration!r}") from None
+
     # Get file path (normalizes branch name and validates git repo)
     file_path = get_current_task_file_path()
 
     # Parse task file
     spec = parse_task_file(file_path)
 
-    # Compute status summary
+    # Compute status summary BEFORE any filtering — summary always reflects full spec
     summary = compute_status_summary(spec)
 
     # Optionally validate
@@ -195,11 +237,67 @@ def get(
         errors = validate_task_file(file_path)
         validation = ValidationResult(valid=len(errors) == 0, errors=errors)
 
+    # Determine filtered spec and filters_applied metadata
+    if full:
+        # full=True: bypass all filtering, return spec as-is
+        filters_applied: dict[str, object] | None = None
+        filtered_spec = spec
+    else:
+        # Validate status parameter
+        status_enum: TaskStatus | None = None
+        if status is not None:
+            try:
+                status_enum = TaskStatus(status)
+            except ValueError:
+                valid = [s.value for s in TaskStatus]
+                raise ValueError(f"Invalid status '{status}'. Valid values: {valid}") from None
+
+        # Validate iteration parameter
+        if iteration_int is not None:
+            existing_ids = {it.id for it in spec.iterations} if spec.iterations else set()
+            if iteration_int not in existing_ids:
+                raise ValueError(
+                    f"Iteration {iteration_int!r} does not exist in the spec. "
+                    f"Existing iteration IDs: {sorted(existing_ids)}"
+                )
+
+        # Apply task filters (AND logic: all predicates must match)
+        total_tasks = len(spec.tasks) if spec.tasks else 0
+        filtered_tasks = spec.tasks or []
+
+        if not include_completed:
+            filtered_tasks = [t for t in filtered_tasks if t.status != TaskStatus.COMPLETED]
+        if status_enum is not None:
+            filtered_tasks = [t for t in filtered_tasks if t.status == status_enum]
+        if iteration_int is not None:
+            filtered_tasks = [t for t in filtered_tasks if t.iteration == iteration_int]
+
+        tasks_returned = len(filtered_tasks)
+        tasks_excluded = total_tasks - tasks_returned
+
+        # Build filtered copy without mutating original
+        filtered_spec = spec.model_copy(
+            update={
+                "tasks": filtered_tasks,
+                "design": spec.design if include_design else None,
+                "quality_requirements": spec.quality_requirements if include_quality else None,
+            }
+        )
+
+        filters_applied = {
+            "include_completed": include_completed,
+            "include_design": include_design,
+            "include_quality": include_quality,
+            "tasks_returned": tasks_returned,
+            "tasks_excluded": tasks_excluded,
+        }
+
     return SimpleTaskGetResponse(
-        spec=spec,
+        spec=filtered_spec,
         file_path=str(file_path),
         summary=summary,
         validation=validation,
+        filters_applied=filters_applied,
     )
 
 

--- a/cli/simpletask/templates/gemini/simpletask.plan.toml
+++ b/cli/simpletask/templates/gemini/simpletask.plan.toml
@@ -70,7 +70,7 @@ User input: {{args}}
    
    ```
    Use simpletask_get() MCP tool to check for existing task:
-   - Call simpletask_get() to use current git branch
+   - Call simpletask_get(full=True) to use current git branch
    - If successful, task file exists - analyze spec.tasks to see if empty/minimal
    - If error (FileNotFoundError), task file does not exist
    ```
@@ -243,7 +243,7 @@ tasks:
    
    ```
    Use simpletask_get() MCP tool with validation:
-   - Call simpletask_get(validate=True)
+   - Call simpletask_get(validate=True, full=True)
    - Check validation.valid in response
    - If validation.valid is False, check validation.errors for details
    ```
@@ -252,7 +252,7 @@ tasks:
    
    ```
    Use simpletask_get() MCP tool:
-   - Call simpletask_get()
+   - Call simpletask_get(full=True)
    - Display spec.branch, spec.title
    - Display summary.criteria_total, summary.tasks_total
    - List spec.acceptance_criteria and spec.tasks

--- a/cli/simpletask/templates/gemini/simpletask.review.toml
+++ b/cli/simpletask/templates/gemini/simpletask.review.toml
@@ -18,8 +18,9 @@ This review is strictly scoped to the original prompt and acceptance criteria de
    
    ```
    Use simpletask_get() MCP tool to retrieve task data:
-   - Call simpletask_get() to use current git branch (auto-detected)
+   - Call simpletask_get(include_completed=True) to use current git branch (auto-detected)
    - Returns SimpleTaskGetResponse with spec, file_path, and summary
+   - Note: use include_completed=True so completed tasks appear in spec.tasks for review
    - If error occurs, task file does not exist — abort and inform the user
    ```
    
@@ -32,6 +33,7 @@ This review is strictly scoped to the original prompt and acceptance criteria de
    ```
    Use simpletask_get() MCP tool to retrieve complete task data:
    - Returns SimpleTaskGetResponse with spec and summary
+   - Call simpletask_get(include_completed=True) so all tasks appear in spec.tasks
    - spec.tasks: array of all tasks with id, name, status, goal, steps, etc.
    - summary.tasks_total, tasks_completed, tasks_in_progress, tasks_not_started, tasks_blocked
    
@@ -335,7 +337,7 @@ If blocking issues exist:
    ```
    ```
    Use simpletask_get() MCP tool with validation:
-   - Call simpletask_get(validate=True)
+   - Call simpletask_get(validate=True, full=True)
    - Check validation.valid in response
    ```
    
@@ -372,6 +374,7 @@ If no blocking issues exist: report "No fix tasks needed." Do NOT create an iter
 ```
 Use simpletask_get() MCP tool to retrieve complete task data:
 - Returns SimpleTaskGetResponse with spec and summary
+- Call simpletask_get(include_completed=True) so all tasks appear in spec.tasks
 - spec.tasks: array of all tasks with full details
 - spec.acceptance_criteria: array of all criteria
 - summary: pre-computed status counts
@@ -416,7 +419,7 @@ simpletask task add "Fix: [description]" -g "[goal]" -i <iter_id>
 Use simpletask_get() MCP tool with validation:
 
 # Validate task file
-simpletask_get(validate=True)
+simpletask_get(validate=True, full=True)
 # Check validation.valid and validation.errors in response
 ```
 

--- a/cli/simpletask/templates/gemini/simpletask.split.toml
+++ b/cli/simpletask/templates/gemini/simpletask.split.toml
@@ -13,7 +13,7 @@ User input: {{args}}
 ## Step 1: Load Task File
 
 ```
-simpletask_get()  # Uses current git branch
+simpletask_get(full=True)  # Uses current git branch
 Returns: SimpleTaskGetResponse with spec, file_path, summary
 ```
 
@@ -24,8 +24,8 @@ If task file not found: Report "No task file found. Run /simpletask.plan first."
 ## Step 1.5: Codebase Analysis & Design (Conditional)
 
 **SKIP this step if ANY of the following are true:**
-- `simpletask_get()` shows `spec.design` is already populated (has patterns, constraints, or references)
-- `simpletask_get()` shows `spec.quality_requirements` already configured
+- `simpletask_get(full=True)` shows `spec.design` is already populated (has patterns, constraints, or references)
+- `simpletask_get(full=True)` shows `spec.quality_requirements` already configured
 - `.tasks/defaults.yml` exists AND contains design patterns or quality requirements (they were already auto-merged into the task file at creation time — no need to repeat analysis)
 
 **If design section is empty or missing, execute this mandatory codebase analysis:**
@@ -186,7 +186,7 @@ This is a one-time investment — future `/simpletask.plan` runs will skip this 
 
 **After completing Step 1.5, reload the task file:**
 ```
-simpletask_get()  # Refresh to see populated design section
+simpletask_get(full=True)  # Refresh to see populated design section
 ```
 
 ---
@@ -206,7 +206,7 @@ simpletask_get()  # Refresh to see populated design section
 
 **Process:**
 ```
-From simpletask_get() response:
+From simpletask_get(full=True) response:
 - Iterate spec.tasks array
 - Evaluate each against split criteria
 - Store complex tasks in complex_tasks list
@@ -339,7 +339,7 @@ result = simpletask_task(action="batch", operations=operations)
 
 **5.1: Load updated task file**
 ```
-simpletask_get()
+simpletask_get(full=True)
 ```
 
 **5.2: Create ID mapping**
@@ -369,7 +369,7 @@ Example: `prerequisites: [T015, T016]` → `prerequisites: [T003, T004]`
 
 **Validate schema:**
 ```
-simpletask_get(validate=True)
+simpletask_get(validate=True, full=True)
 # Check validation.valid and validation.errors
 ```
 

--- a/cli/simpletask/templates/opencode/agents/simpletask-plan.md
+++ b/cli/simpletask/templates/opencode/agents/simpletask-plan.md
@@ -61,7 +61,7 @@ User input: $ARGUMENTS
    
    ```
    Use simpletask_get() MCP tool to check for existing task:
-   - Call simpletask_get() to use current git branch
+   - Call simpletask_get(full=True) to use current git branch
    - If successful, task file exists - analyze spec.tasks to see if empty/minimal
    - If error (FileNotFoundError), task file does not exist
    ```
@@ -181,7 +181,7 @@ tasks:
    
    ```
    Use simpletask_get() MCP tool with validation:
-   - Call simpletask_get(validate=True)
+   - Call simpletask_get(validate=True, full=True)
    - Check validation.valid in response
    - If validation.valid is False, check validation.errors for details
    ```
@@ -190,7 +190,7 @@ tasks:
    
    ```
    Use simpletask_get() MCP tool:
-   - Call simpletask_get()
+   - Call simpletask_get(full=True)
    - Display spec.branch, spec.title
    - Display summary.criteria_total, summary.tasks_total
    - List spec.acceptance_criteria and spec.tasks

--- a/cli/simpletask/templates/opencode/simpletask.plan.md
+++ b/cli/simpletask/templates/opencode/simpletask.plan.md
@@ -71,7 +71,7 @@ User input: $ARGUMENTS
    
    ```
    Use simpletask_get() MCP tool to check for existing task:
-   - Call simpletask_get() to use current git branch
+   - Call simpletask_get(full=True) to use current git branch
    - If successful, task file exists - analyze spec.tasks to see if empty/minimal
    - If error (FileNotFoundError), task file does not exist
    ```
@@ -249,7 +249,7 @@ tasks:
    
    ```
    Use simpletask_get() MCP tool with validation:
-   - Call simpletask_get(validate=True)
+   - Call simpletask_get(validate=True, full=True)
    - Check validation.valid in response
    - If validation.valid is False, check validation.errors for details
    ```
@@ -258,7 +258,7 @@ tasks:
    
    ```
    Use simpletask_get() MCP tool:
-   - Call simpletask_get()
+   - Call simpletask_get(full=True)
    - Display spec.branch, spec.title
    - Display summary.criteria_total, summary.tasks_total
    - List spec.acceptance_criteria and spec.tasks

--- a/cli/simpletask/templates/opencode/simpletask.review.md
+++ b/cli/simpletask/templates/opencode/simpletask.review.md
@@ -19,7 +19,7 @@ This review is strictly scoped to the original prompt and acceptance criteria de
    
    ```
    Use simpletask_get() MCP tool to retrieve task data:
-   - Call simpletask_get() to use current git branch (auto-detected)
+   - Call simpletask_get(include_completed=True) to use current git branch (auto-detected)
    - Returns SimpleTaskGetResponse with spec, file_path, and summary
    - If error occurs, task file does not exist — abort and inform the user
    ```
@@ -42,6 +42,9 @@ This review is strictly scoped to the original prompt and acceptance criteria de
    - Filter spec.tasks where status == "not_started" (incomplete)
    - Filter spec.tasks where status == "blocked" (need attention)
    - Filter spec.tasks where status == "paused" (intentionally deferred)
+   ```
+   
+   Note: use get(include_completed=True) so completed tasks appear in spec.tasks for review.
    ```
    
    ```bash
@@ -68,6 +71,9 @@ This review is strictly scoped to the original prompt and acceptance criteria de
    From the response:
    - Filter spec.acceptance_criteria where completed == True (marked complete)
    - Filter spec.acceptance_criteria where completed == False (remain incomplete)
+   ```
+   
+   Note: acceptance_criteria are always returned regardless of filtering.
    ```
    
    # List acceptance criteria status
@@ -349,7 +355,7 @@ If blocking issues exist:
    
    ```
    Use simpletask_get() MCP tool with validation:
-   - Call simpletask_get(validate=True)
+   - Call simpletask_get(validate=True, full=True)
    - Check validation.valid in response
    ```
    
@@ -384,9 +390,9 @@ If no blocking issues exist: report "No fix tasks needed." Do NOT create an iter
 ### View Task Information
 
 ```
-Use simpletask_get() MCP tool to retrieve complete task data:
+Use simpletask_get(include_completed=True) MCP tool to retrieve complete task data:
 - Returns SimpleTaskGetResponse with spec and summary
-- spec.tasks: array of all tasks with full details
+- spec.tasks: array of all tasks with full details (including completed)
 - spec.acceptance_criteria: array of all criteria
 - summary: pre-computed status counts
 
@@ -435,7 +441,7 @@ simpletask task add "Fix: [description]" -g "[goal]" -i <iter_id>
 Use simpletask_get() MCP tool with validation:
 
 # Validate task file
-simpletask_get(validate=True)
+simpletask_get(validate=True, full=True)
 # Check validation.valid and validation.errors in response
 ```
 

--- a/cli/simpletask/templates/opencode/simpletask.split.md
+++ b/cli/simpletask/templates/opencode/simpletask.split.md
@@ -13,7 +13,7 @@ User input: $ARGUMENTS
 ## Step 1: Load Task File
 
 ```
-simpletask_get()  # Uses current git branch
+simpletask_get(full=True)  # Uses current git branch
 Returns: SimpleTaskGetResponse with spec, file_path, summary
 ```
 
@@ -24,8 +24,8 @@ If task file not found: Report "No task file found. Run /simpletask.plan first."
 ## Step 1.5: Codebase Analysis & Design (Conditional)
 
 **SKIP this step if ANY of the following are true:**
-- `simpletask_get()` shows `spec.design` is already populated (has patterns, constraints, or references)
-- `simpletask_get()` shows `spec.quality_requirements` already configured
+- `simpletask_get(full=True)` shows `spec.design` is already populated (has patterns, constraints, or references)
+- `simpletask_get(full=True)` shows `spec.quality_requirements` already configured
 - `.tasks/defaults.yml` exists AND contains design patterns or quality requirements (they were already auto-merged into the task file at creation time — no need to repeat analysis)
 
 **If design section is empty or missing, execute this mandatory codebase analysis:**
@@ -191,7 +191,7 @@ Use simpletask_quality() MCP tool to apply preset:
 
 **After completing Step 1.5, reload the task file:**
 ```
-simpletask_get()  # Refresh to see populated design section
+simpletask_get(full=True)  # Refresh to see populated design section
 ```
 
 ---
@@ -211,7 +211,7 @@ simpletask_get()  # Refresh to see populated design section
 
 **Process:**
 ```
-From simpletask_get() response:
+From simpletask_get(full=True) response:
 - Iterate spec.tasks array
 - Evaluate each against split criteria
 - Store complex tasks in complex_tasks list
@@ -344,7 +344,7 @@ result = simpletask_task(action="batch", operations=operations)
 
 **5.1: Load updated task file**
 ```
-simpletask_get()
+simpletask_get(full=True)
 ```
 
 **5.2: Create ID mapping**
@@ -374,7 +374,7 @@ Example: `prerequisites: [T015, T016]` → `prerequisites: [T003, T004]`
 
 **Validate schema:**
 ```
-simpletask_get(validate=True)
+simpletask_get(validate=True, full=True)
 # Check validation.valid and validation.errors
 ```
 

--- a/cli/simpletask/templates/qwen/simpletask.plan.md
+++ b/cli/simpletask/templates/qwen/simpletask.plan.md
@@ -71,7 +71,7 @@ User input: $ARGUMENTS
    
    ```
    Use simpletask_get() MCP tool to check for existing task:
-   - Call simpletask_get() to use current git branch
+   - Call simpletask_get(full=True) to use current git branch
    - If successful, task file exists - analyze spec.tasks to see if empty/minimal
    - If error (FileNotFoundError), task file does not exist
    ```
@@ -233,7 +233,7 @@ tasks:
    
    ```
    Use simpletask_get() MCP tool with validation:
-   - Call simpletask_get(validate=True)
+   - Call simpletask_get(validate=True, full=True)
    - Check validation.valid in response
    - If validation.valid is False, check validation.errors for details
    ```
@@ -242,7 +242,7 @@ tasks:
    
    ```
    Use simpletask_get() MCP tool:
-   - Call simpletask_get()
+   - Call simpletask_get(full=True)
    - Display spec.branch, spec.title
    - Display summary.criteria_total, summary.tasks_total
    - List spec.acceptance_criteria and spec.tasks

--- a/cli/simpletask/templates/qwen/simpletask.review.md
+++ b/cli/simpletask/templates/qwen/simpletask.review.md
@@ -19,8 +19,9 @@ This review is strictly scoped to the original prompt and acceptance criteria de
    
    ```
    Use simpletask_get() MCP tool to retrieve task data:
-   - Call simpletask_get() to use current git branch (auto-detected)
+   - Call simpletask_get(include_completed=True) to use current git branch (auto-detected)
    - Returns SimpleTaskGetResponse with spec, file_path, and summary
+   - Note: use include_completed=True so completed tasks appear in spec.tasks for review
    - If error occurs, task file does not exist — abort and inform the user
    ```
    
@@ -33,6 +34,7 @@ This review is strictly scoped to the original prompt and acceptance criteria de
    ```
    Use simpletask_get() MCP tool to retrieve complete task data:
    - Returns SimpleTaskGetResponse with spec and summary
+   - Call simpletask_get(include_completed=True) so all tasks appear in spec.tasks
    - spec.tasks: array of all tasks with id, name, status, goal, steps, etc.
    - summary.tasks_total, tasks_completed, tasks_in_progress, tasks_not_started, tasks_blocked
    
@@ -339,7 +341,7 @@ If blocking issues exist:
    ```
    ```
    Use simpletask_get() MCP tool with validation:
-   - Call simpletask_get(validate=True)
+   - Call simpletask_get(validate=True, full=True)
    - Check validation.valid in response
    ```
    
@@ -376,6 +378,7 @@ If no blocking issues exist: report "No fix tasks needed." Do NOT create an iter
 ```
 Use simpletask_get() MCP tool to retrieve complete task data:
 - Returns SimpleTaskGetResponse with spec and summary
+- Call simpletask_get(include_completed=True) so all tasks appear in spec.tasks
 - spec.tasks: array of all tasks with full details
 - spec.acceptance_criteria: array of all criteria
 - summary: pre-computed status counts
@@ -420,7 +423,7 @@ simpletask task add "Fix: [description]" -g "[goal]" -i <iter_id>
 Use simpletask_get() MCP tool with validation:
 
 # Validate task file
-simpletask_get(validate=True)
+simpletask_get(validate=True, full=True)
 # Check validation.valid and validation.errors in response
 ```
 

--- a/cli/simpletask/templates/qwen/simpletask.split.md
+++ b/cli/simpletask/templates/qwen/simpletask.split.md
@@ -13,7 +13,7 @@ User input: $ARGUMENTS
 ## Step 1: Load Task File
 
 ```
-simpletask_get()  # Uses current git branch
+simpletask_get(full=True)  # Uses current git branch
 Returns: SimpleTaskGetResponse with spec, file_path, summary
 ```
 
@@ -24,8 +24,8 @@ If task file not found: Report "No task file found. Run /simpletask.plan first."
 ## Step 1.5: Codebase Analysis & Design (Conditional)
 
 **SKIP this step if ANY of the following are true:**
-- `simpletask_get()` shows `spec.design` is already populated (has patterns, constraints, or references)
-- `simpletask_get()` shows `spec.quality_requirements` already configured
+- `simpletask_get(full=True)` shows `spec.design` is already populated (has patterns, constraints, or references)
+- `simpletask_get(full=True)` shows `spec.quality_requirements` already configured
 - `.tasks/defaults.yml` exists AND contains design patterns or quality requirements (they were already auto-merged into the task file at creation time — no need to repeat analysis)
 
 **If design section is empty or missing, execute this mandatory codebase analysis:**
@@ -186,7 +186,7 @@ This is a one-time investment — future `/simpletask.plan` runs will skip this 
 
 **After completing Step 1.5, reload the task file:**
 ```
-simpletask_get()  # Refresh to see populated design section
+simpletask_get(full=True)  # Refresh to see populated design section
 ```
 
 ---
@@ -206,7 +206,7 @@ simpletask_get()  # Refresh to see populated design section
 
 **Process:**
 ```
-From simpletask_get() response:
+From simpletask_get(full=True) response:
 - Iterate spec.tasks array
 - Evaluate each against split criteria
 - Store complex tasks in complex_tasks list
@@ -339,7 +339,7 @@ result = simpletask_task(action="batch", operations=operations)
 
 **5.1: Load updated task file**
 ```
-simpletask_get()
+simpletask_get(full=True)
 ```
 
 **5.2: Create ID mapping**
@@ -369,7 +369,7 @@ Example: `prerequisites: [T015, T016]` → `prerequisites: [T003, T004]`
 
 **Validate schema:**
 ```
-simpletask_get(validate=True)
+simpletask_get(validate=True, full=True)
 # Check validation.valid and validation.errors
 ```
 

--- a/cli/simpletask/templates/vibe/simpletask-plan/SKILL.md
+++ b/cli/simpletask/templates/vibe/simpletask-plan/SKILL.md
@@ -42,7 +42,7 @@ user-invocable: true
 
    ```
    Use simpletask_get() MCP tool to check for existing task:
-   - Call simpletask_get() to use current git branch
+   - Call simpletask_get(full=True) to use current git branch
    - If successful, task file exists - analyze spec.tasks to see if empty/minimal
    - If error (FileNotFoundError), task file does not exist
    ```
@@ -150,7 +150,7 @@ Then assign tasks: simpletask_task(action="add", name="...", iteration=1)
 
    ```
    Use simpletask_get() MCP tool with validation:
-   - Call simpletask_get(validate=True)
+   - Call simpletask_get(validate=True, full=True)
    - Check validation.valid in response
    ```
 

--- a/cli/simpletask/templates/vibe/simpletask-review/SKILL.md
+++ b/cli/simpletask/templates/vibe/simpletask-review/SKILL.md
@@ -19,20 +19,21 @@ This review is strictly scoped to the original prompt and acceptance criteria de
 
    ```
    Use simpletask_get() MCP tool to retrieve task data:
-   - Call simpletask_get() to use current git branch (auto-detected)
+   - Call simpletask_get(include_completed=True) to use current git branch (auto-detected)
    - Returns SimpleTaskGetResponse with spec, file_path, and summary
+   - Note: use include_completed=True so completed tasks appear in spec.tasks for review
    - If error occurs, task file does not exist - abort and inform the user
    ```
 
 **Step 2: Analyze Task Completion**
 
-From the `simpletask_get()` response:
+From the `simpletask_get(include_completed=True)` response:
 - Filter `spec.tasks` by status: completed, in_progress, not_started, blocked, paused
 - Use `summary` fields for quick counts
 
 **Step 3: Check Acceptance Criteria**
 
-From the `simpletask_get()` response:
+From the `simpletask_get(include_completed=True)` response:
 - Check `spec.acceptance_criteria` array for `completed` status
 - Use `summary.criteria_total` and `summary.criteria_completed` for counts
 
@@ -136,7 +137,7 @@ If Critical/High severity blocking issues exist:
 
 1. Create iteration: `simpletask_iteration(action="add", label="review fixes")`
 2. Add fix tasks: `simpletask_task(action="add", name="Fix: [issue]", goal="[remediation]", iteration=<id>)`
-3. Validate: `simpletask_get(validate=True)`
+3. Validate: `simpletask_get(validate=True, full=True)`
 
 If no blocking issues: report "No fix tasks needed."
 
@@ -149,4 +150,4 @@ Before marking as "READY TO MERGE":
 2. All criteria met
 3. No blocking issues
 4. Tests pass
-5. Schema valid: `simpletask_get(validate=True)`
+5. Schema valid: `simpletask_get(validate=True, full=True)`

--- a/cli/simpletask/templates/vibe/simpletask-split/SKILL.md
+++ b/cli/simpletask/templates/vibe/simpletask-split/SKILL.md
@@ -13,7 +13,7 @@ user-invocable: true
 ## Step 1: Load Task File
 
 ```
-simpletask_get()  # Uses current git branch
+simpletask_get(full=True)  # Uses current git branch
 Returns: SimpleTaskGetResponse with spec, file_path, summary
 ```
 
@@ -24,8 +24,8 @@ If task file not found: Report "No task file found. Run /simpletask-plan first."
 ## Step 1.5: Codebase Analysis & Design (Conditional)
 
 **SKIP this step if:**
-- `simpletask_get()` shows `spec.design` is already populated (has patterns, constraints, or references)
-- `simpletask_get()` shows `spec.quality_requirements` already configured
+- `simpletask_get(full=True)` shows `spec.design` is already populated (has patterns, constraints, or references)
+- `simpletask_get(full=True)` shows `spec.quality_requirements` already configured
 
 **If design section is empty or missing, execute this mandatory codebase analysis:**
 
@@ -108,7 +108,7 @@ Call simpletask_quality(
 
 **After completing Step 1.5, reload the task file:**
 ```
-simpletask_get()  # Refresh to see populated design section
+simpletask_get(full=True)  # Refresh to see populated design section
 ```
 
 ---
@@ -191,18 +191,18 @@ Task IDs are already sequential after a batch operation. If further renumbering 
 (e.g. to close gaps), use additional batch operations via MCP — never edit `.tasks/` YAML
 directly, as that bypasses schema validation and can corrupt the task file.
 
-1. Load updated task file with `simpletask_get()`
+1. Load updated task file with `simpletask_get(full=True)`
 2. Identify any ID gaps or out-of-order IDs
 3. Use `simpletask_task(action='batch', operations=[...])` with update operations to
    rename tasks and fix prerequisite references
-4. Validate the result: `simpletask_get(validate=True)`
+4. Validate the result: `simpletask_get(validate=True, full=True)`
 
 ---
 
 ## Step 6: Validate and Report
 
 ```
-simpletask_get(validate=True)
+simpletask_get(validate=True, full=True)
 ```
 
 Generate split summary showing: original state, splitting results, cognitive load reduction, and validation status.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simpletask"
-version = "0.32.0"
+version = "0.33.0"
 description = "CLI tool for managing AI-friendly task definitions in branch-based development workflows"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,18 @@ import git
 import pytest
 from simpletask.core.models import (
     AcceptanceCriterion,
+    ArchitecturalPattern,
+    Design,
+    DesignReference,
+    Iteration,
+    LintingConfig,
+    QualityRequirements,
     SimpleTaskSpec,
     Task,
     TaskStatus,
+    TestingConfig,
+    ToolName,
+    TypeCheckConfig,
 )
 from simpletask.core.yaml_parser import write_task_file
 
@@ -490,6 +499,177 @@ def sample_spec_only_paused() -> SimpleTaskSpec:
                 code_examples=None,
                 prerequisites=None,
                 files=None,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def sample_spec_filterable() -> SimpleTaskSpec:
+    """Comprehensive spec for testing all filtering dimensions.
+
+    Contains:
+    - 3 iterations with tasks distributed across them (and one unassigned)
+    - All 5 task statuses represented: not_started (2), in_progress (2), completed (3),
+      blocked (1), paused (1) — 9 tasks total
+    - Populated design section with patterns and constraints
+    - Populated quality_requirements (linting and testing)
+    - 3 acceptance criteria (1 completed)
+    - Notes and constraints
+    """
+    now = datetime.now(UTC)
+    return SimpleTaskSpec(
+        schema_version="1.0",
+        branch="test-filterable",
+        title="Filterable Test Feature",
+        original_prompt="A comprehensive spec for testing filter combinations",
+        created=now,
+        acceptance_criteria=[
+            AcceptanceCriterion(id="AC1", description="Core feature works", completed=True),
+            AcceptanceCriterion(id="AC2", description="Tests pass", completed=False),
+            AcceptanceCriterion(id="AC3", description="Docs updated", completed=False),
+        ],
+        constraints=["Use Pydantic models with extra='forbid'", "No shell=True in subprocess"],
+        context={"language": "python", "framework": "fastapi"},
+        notes=["Root note 1", "Root note 2"],
+        iterations=[
+            Iteration(id=1, label="Core Models", created=now),
+            Iteration(id=2, label="API Layer", created=now),
+            Iteration(id=3, label="Polish", created=now),
+        ],
+        design=Design(
+            patterns=[ArchitecturalPattern.REPOSITORY, ArchitecturalPattern.SERVICE_LAYER],
+            reference_implementations=[
+                DesignReference(
+                    path="cli/simpletask/mcp/server.py",
+                    reason="MCP tool pattern to follow",
+                )
+            ],
+            architectural_constraints=[
+                "Use Pydantic models with extra='forbid'",
+                "No direct database access from views",
+            ],
+            security=None,
+            error_handling=None,
+        ),
+        quality_requirements=QualityRequirements(
+            linting=LintingConfig(enabled=True, tool=ToolName.RUFF, args=["check", "."]),
+            type_checking=TypeCheckConfig(enabled=True, tool=ToolName.MYPY, args=["cli/"]),
+            testing=TestingConfig(enabled=True, tool=ToolName.PYTEST, args=[], min_coverage=80),
+            security_check=None,
+        ),
+        tasks=[
+            # Iteration 1: Core Models — 3 tasks (2 completed, 1 in_progress)
+            Task(
+                id="T001",
+                name="Create model A",
+                status=TaskStatus.COMPLETED,
+                goal="Define model A",
+                steps=["Write model"],
+                done_when=None,
+                code_examples=None,
+                prerequisites=None,
+                files=None,
+                iteration=1,
+            ),
+            Task(
+                id="T002",
+                name="Create model B",
+                status=TaskStatus.COMPLETED,
+                goal="Define model B",
+                steps=["Write model"],
+                done_when=None,
+                code_examples=None,
+                prerequisites=None,
+                files=None,
+                iteration=1,
+            ),
+            Task(
+                id="T003",
+                name="Write model tests",
+                status=TaskStatus.IN_PROGRESS,
+                goal="Test models",
+                steps=["Write tests"],
+                done_when=None,
+                code_examples=None,
+                prerequisites=["T001", "T002"],
+                files=None,
+                iteration=1,
+            ),
+            # Iteration 2: API Layer — 3 tasks (1 completed, 1 blocked, 1 in_progress)
+            Task(
+                id="T004",
+                name="Create API router",
+                status=TaskStatus.COMPLETED,
+                goal="Set up API routing",
+                steps=["Define routes"],
+                done_when=None,
+                code_examples=None,
+                prerequisites=None,
+                files=None,
+                iteration=2,
+            ),
+            Task(
+                id="T005",
+                name="Implement endpoint logic",
+                status=TaskStatus.BLOCKED,
+                goal="Business logic for endpoints",
+                steps=["Implement handlers"],
+                done_when=None,
+                code_examples=None,
+                prerequisites=["T004"],
+                files=None,
+                iteration=2,
+            ),
+            Task(
+                id="T006",
+                name="Add middleware",
+                status=TaskStatus.IN_PROGRESS,
+                goal="Auth and logging middleware",
+                steps=["Write middleware"],
+                done_when=None,
+                code_examples=None,
+                prerequisites=["T004"],
+                files=None,
+                iteration=2,
+            ),
+            # Iteration 3: Polish — 2 tasks (not_started + paused)
+            Task(
+                id="T007",
+                name="Write integration tests",
+                status=TaskStatus.NOT_STARTED,
+                goal="End-to-end testing",
+                steps=["Write e2e tests"],
+                done_when=None,
+                code_examples=None,
+                prerequisites=None,
+                files=None,
+                iteration=3,
+            ),
+            Task(
+                id="T008",
+                name="Update documentation",
+                status=TaskStatus.PAUSED,
+                goal="Docs and examples",
+                steps=["Write docs"],
+                done_when=None,
+                code_examples=None,
+                prerequisites=None,
+                files=None,
+                iteration=3,
+            ),
+            # Unassigned — 1 task (not_started, no iteration)
+            Task(
+                id="T009",
+                name="Performance profiling",
+                status=TaskStatus.NOT_STARTED,
+                goal="Profile and optimize",
+                steps=["Run profiler"],
+                done_when=None,
+                code_examples=None,
+                prerequisites=None,
+                files=None,
+                iteration=None,
             ),
         ],
     )

--- a/tests/unit/test_mcp_models.py
+++ b/tests/unit/test_mcp_models.py
@@ -158,6 +158,78 @@ class TestSimpleTaskGetResponse:
 
         assert response.validation is None
 
+    def test_filters_applied_none_by_default(self, sample_spec: SimpleTaskSpec):
+        """filters_applied defaults to None when not provided."""
+        summary = compute_status_summary(sample_spec)
+
+        response = SimpleTaskGetResponse(
+            spec=sample_spec,
+            file_path="/path/to/task.yml",
+            summary=summary,
+        )
+
+        assert response.filters_applied is None
+
+    def test_filters_applied_accepts_dict(self, sample_spec: SimpleTaskSpec):
+        """filters_applied accepts and serializes a dict[str, Any] correctly."""
+        summary = compute_status_summary(sample_spec)
+        filters: dict[str, object] = {
+            "include_completed": False,
+            "include_design": False,
+            "include_quality": False,
+            "tasks_returned": 3,
+            "tasks_excluded": 2,
+        }
+
+        response = SimpleTaskGetResponse(
+            spec=sample_spec,
+            file_path="/path/to/task.yml",
+            summary=summary,
+            filters_applied=filters,
+        )
+
+        assert response.filters_applied is not None
+        assert response.filters_applied["include_completed"] is False
+        assert response.filters_applied["include_design"] is False
+        assert response.filters_applied["include_quality"] is False
+        assert response.filters_applied["tasks_returned"] == 3
+        assert response.filters_applied["tasks_excluded"] == 2
+
+    def test_filters_applied_serializes_to_json(self, sample_spec: SimpleTaskSpec):
+        """filters_applied round-trips through model_dump correctly."""
+        summary = compute_status_summary(sample_spec)
+        filters: dict[str, object] = {
+            "include_completed": True,
+            "tasks_returned": 5,
+            "tasks_excluded": 0,
+        }
+
+        response = SimpleTaskGetResponse(
+            spec=sample_spec,
+            file_path="/path/to/task.yml",
+            summary=summary,
+            filters_applied=filters,
+        )
+
+        dumped = response.model_dump()
+        assert dumped["filters_applied"]["include_completed"] is True
+        assert dumped["filters_applied"]["tasks_returned"] == 5
+        assert dumped["filters_applied"]["tasks_excluded"] == 0
+
+    def test_filters_applied_extra_fields_forbidden(self, sample_spec: SimpleTaskSpec):
+        """Verify extra='forbid' still applies to the response model itself."""
+        from pydantic import ValidationError
+
+        summary = compute_status_summary(sample_spec)
+
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            SimpleTaskGetResponse(
+                spec=sample_spec,
+                file_path="/path/to/task.yml",
+                summary=summary,
+                unknown_field="value",  # type: ignore[call-arg]
+            )
+
 
 class TestBatchTaskOperation:
     """Tests for BatchTaskOperation model validation."""

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -8,6 +8,7 @@ from simpletask.core.models import (
     LintingConfig,
     QualityRequirements,
     SimpleTaskSpec,
+    TaskStatus,
     TestingConfig,
     ToolName,
 )
@@ -639,6 +640,258 @@ class TestMCPIterationTool:
             with patch("simpletask.mcp.server.parse_task_file", return_value=mock_spec):
                 with pytest.raises(ValueError, match="mutually exclusive"):
                     quality(action="check", lint_only=True, test_only=True)
+
+
+class TestSimpletaskGetFiltering:
+    """Tests for get() tool response filtering behavior."""
+
+    def _mock_get(self, sample_spec_filterable, **kwargs):
+        """Helper: call get() with parse_task_file mocked to return sample_spec_filterable."""
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = "/fake/.tasks/test-filterable.yml"
+            with patch(
+                "simpletask.mcp.server.parse_task_file", return_value=sample_spec_filterable
+            ):
+                # validate_task_file is only called when validate=True, so no mock needed by default
+                return get(**kwargs)
+
+    # ------------------------------------------------------------------
+    # Default behavior (no parameters)
+    # ------------------------------------------------------------------
+
+    def test_get_default_excludes_completed_tasks(self, sample_spec_filterable):
+        """Default get() must exclude completed tasks from spec.tasks."""
+        response = self._mock_get(sample_spec_filterable)
+        assert response.spec.tasks is not None
+        statuses = [t.status for t in response.spec.tasks]
+        assert TaskStatus.COMPLETED not in statuses
+
+    def test_get_default_excludes_design(self, sample_spec_filterable):
+        """Default get() must set spec.design to None."""
+        response = self._mock_get(sample_spec_filterable)
+        assert response.spec.design is None
+
+    def test_get_default_excludes_quality_requirements(self, sample_spec_filterable):
+        """Default get() must set spec.quality_requirements to None."""
+        response = self._mock_get(sample_spec_filterable)
+        assert response.spec.quality_requirements is None
+
+    def test_get_default_non_completed_task_count(self, sample_spec_filterable):
+        """Default get() returns 6 non-completed tasks (9 total minus 3 completed)."""
+        response = self._mock_get(sample_spec_filterable)
+        # sample_spec_filterable has 3 completed (T001, T002, T004); 6 non-completed
+        assert response.spec.tasks is not None
+        assert len(response.spec.tasks) == 6
+
+    # ------------------------------------------------------------------
+    # full=True escape hatch
+    # ------------------------------------------------------------------
+
+    def test_get_full_returns_all_tasks(self, sample_spec_filterable):
+        """get(full=True) must return all tasks including completed ones."""
+        response = self._mock_get(sample_spec_filterable, full=True)
+        assert response.spec.tasks is not None
+        statuses = [t.status for t in response.spec.tasks]
+        assert TaskStatus.COMPLETED in statuses
+        assert len(response.spec.tasks) == 9  # all 9 tasks
+
+    def test_get_full_returns_design(self, sample_spec_filterable):
+        """get(full=True) must return the design section."""
+        response = self._mock_get(sample_spec_filterable, full=True)
+        assert response.spec.design is not None
+        assert response.spec.design.patterns is not None
+
+    def test_get_full_returns_quality_requirements(self, sample_spec_filterable):
+        """get(full=True) must return quality_requirements."""
+        response = self._mock_get(sample_spec_filterable, full=True)
+        assert response.spec.quality_requirements is not None
+
+    def test_get_full_has_filters_applied_none(self, sample_spec_filterable):
+        """get(full=True) must set filters_applied to None."""
+        response = self._mock_get(sample_spec_filterable, full=True)
+        assert response.filters_applied is None
+
+    # ------------------------------------------------------------------
+    # Individual filter parameters
+    # ------------------------------------------------------------------
+
+    def test_get_include_completed_returns_completed(self, sample_spec_filterable):
+        """get(include_completed=True) must include completed tasks."""
+        response = self._mock_get(sample_spec_filterable, include_completed=True)
+        statuses = [t.status for t in response.spec.tasks]
+        assert TaskStatus.COMPLETED in statuses
+
+    def test_get_include_design_returns_design(self, sample_spec_filterable):
+        """get(include_design=True) must include the design section."""
+        response = self._mock_get(sample_spec_filterable, include_design=True)
+        assert response.spec.design is not None
+
+    def test_get_include_quality_returns_quality(self, sample_spec_filterable):
+        """get(include_quality=True) must include quality_requirements."""
+        response = self._mock_get(sample_spec_filterable, include_quality=True)
+        assert response.spec.quality_requirements is not None
+
+    def test_get_status_filter_in_progress(self, sample_spec_filterable):
+        """get(status='in_progress') returns only in_progress tasks."""
+        response = self._mock_get(sample_spec_filterable, status="in_progress")
+        assert response.spec.tasks is not None
+        assert all(t.status == TaskStatus.IN_PROGRESS for t in response.spec.tasks)
+        # sample_spec_filterable has 2 in_progress tasks (T003, T006)
+        assert len(response.spec.tasks) == 2
+
+    def test_get_status_filter_not_started(self, sample_spec_filterable):
+        """get(status='not_started') returns only not_started tasks."""
+        response = self._mock_get(sample_spec_filterable, status="not_started")
+        assert response.spec.tasks is not None
+        assert all(t.status == TaskStatus.NOT_STARTED for t in response.spec.tasks)
+        # sample_spec_filterable has 2 not_started tasks (T007, T009)
+        assert len(response.spec.tasks) == 2
+
+    def test_get_status_filter_completed_with_include(self, sample_spec_filterable):
+        """get(status='completed', include_completed=True) returns only completed tasks."""
+        response = self._mock_get(
+            sample_spec_filterable, status="completed", include_completed=True
+        )
+        assert response.spec.tasks is not None
+        assert all(t.status == TaskStatus.COMPLETED for t in response.spec.tasks)
+        assert len(response.spec.tasks) == 3  # T001, T002, T004
+
+    def test_get_iteration_filter(self, sample_spec_filterable):
+        """get(iteration=1) returns only tasks assigned to iteration 1 (non-completed)."""
+        response = self._mock_get(sample_spec_filterable, iteration=1)
+        assert response.spec.tasks is not None
+        # Iteration 1: T001 (completed, excluded), T002 (completed, excluded), T003 (in_progress)
+        assert len(response.spec.tasks) == 1
+        assert response.spec.tasks[0].id == "T003"
+
+    def test_get_iteration_filter_with_include_completed(self, sample_spec_filterable):
+        """get(iteration=1, include_completed=True) returns all tasks in iteration 1."""
+        response = self._mock_get(sample_spec_filterable, iteration=1, include_completed=True)
+        assert response.spec.tasks is not None
+        # Iteration 1 has T001, T002, T003
+        assert len(response.spec.tasks) == 3
+        assert {t.id for t in response.spec.tasks} == {"T001", "T002", "T003"}
+
+    def test_get_iteration_string_coerced_to_int(self, sample_spec_filterable):
+        """get(iteration='2') coerces string to int (Qwen CLI compat)."""
+        response = self._mock_get(sample_spec_filterable, iteration="2")
+        # Iteration 2 has T004 (completed, excluded), T005 (blocked), T006 (in_progress)
+        assert response.spec.tasks is not None
+        task_ids = {t.id for t in response.spec.tasks}
+        assert "T005" in task_ids
+        assert "T006" in task_ids
+        assert "T004" not in task_ids  # completed
+
+    # ------------------------------------------------------------------
+    # Filter combinations
+    # ------------------------------------------------------------------
+
+    def test_get_iteration_and_status_combined(self, sample_spec_filterable):
+        """get(iteration=2, status='blocked') returns only blocked tasks in iteration 2."""
+        response = self._mock_get(sample_spec_filterable, iteration=2, status="blocked")
+        assert response.spec.tasks is not None
+        assert len(response.spec.tasks) == 1
+        assert response.spec.tasks[0].id == "T005"
+        assert response.spec.tasks[0].status == TaskStatus.BLOCKED
+
+    def test_get_status_completed_without_include_returns_empty(self, sample_spec_filterable):
+        """get(status='completed') with default include_completed=False returns no tasks.
+
+        Since include_completed=False is applied first (removing completed), then
+        status='completed' filter finds nothing. Result: empty list.
+        """
+        response = self._mock_get(sample_spec_filterable, status="completed")
+        # First exclude completed (none left for status filter), then filter by completed status
+        assert response.spec.tasks is not None
+        assert len(response.spec.tasks) == 0
+
+    # ------------------------------------------------------------------
+    # Summary integrity — always unfiltered
+    # ------------------------------------------------------------------
+
+    def test_get_summary_always_reflects_full_spec(self, sample_spec_filterable):
+        """Summary counts must reflect the full unfiltered spec regardless of filters."""
+        # With heavy filtering
+        response = self._mock_get(sample_spec_filterable, iteration=1, status="in_progress")
+        # Summary should still show all 9 tasks
+        assert response.summary.tasks_total == 9
+        assert response.summary.tasks_completed == 3
+        assert response.summary.tasks_in_progress == 2
+        assert response.summary.tasks_not_started == 2
+        assert response.summary.tasks_blocked == 1
+        assert response.summary.tasks_paused == 1
+
+    def test_get_full_summary_matches_default_summary(self, sample_spec_filterable):
+        """get(full=True) and get() must produce identical summaries."""
+        full_response = self._mock_get(sample_spec_filterable, full=True)
+        default_response = self._mock_get(sample_spec_filterable)
+        assert full_response.summary.tasks_total == default_response.summary.tasks_total
+        assert full_response.summary.tasks_completed == default_response.summary.tasks_completed
+
+    # ------------------------------------------------------------------
+    # filters_applied dict correctness
+    # ------------------------------------------------------------------
+
+    def test_get_filters_applied_contains_required_keys(self, sample_spec_filterable):
+        """filters_applied dict must contain all 5 required keys."""
+        response = self._mock_get(sample_spec_filterable)
+        assert response.filters_applied is not None
+        required_keys = {
+            "include_completed",
+            "include_design",
+            "include_quality",
+            "tasks_returned",
+            "tasks_excluded",
+        }
+        assert required_keys.issubset(response.filters_applied.keys())
+
+    def test_get_filters_applied_task_counts_are_correct(self, sample_spec_filterable):
+        """filters_applied tasks_returned + tasks_excluded must equal total tasks in spec."""
+        response = self._mock_get(sample_spec_filterable)
+        assert response.filters_applied is not None
+        total = (
+            response.filters_applied["tasks_returned"] + response.filters_applied["tasks_excluded"]
+        )
+        assert total == 9  # sample_spec_filterable has 9 tasks total
+
+    def test_get_filters_applied_default_values(self, sample_spec_filterable):
+        """filters_applied default flag values match the parameter defaults."""
+        response = self._mock_get(sample_spec_filterable)
+        assert response.filters_applied is not None
+        assert response.filters_applied["include_completed"] is False
+        assert response.filters_applied["include_design"] is False
+        assert response.filters_applied["include_quality"] is False
+
+    def test_get_filters_applied_none_when_full(self, sample_spec_filterable):
+        """filters_applied is None when full=True."""
+        response = self._mock_get(sample_spec_filterable, full=True)
+        assert response.filters_applied is None
+
+    # ------------------------------------------------------------------
+    # Error handling
+    # ------------------------------------------------------------------
+
+    def test_get_invalid_status_raises_valueerror(self, sample_spec_filterable):
+        """get(status='invalid') must raise ValueError with descriptive message."""
+        with pytest.raises(ValueError, match="Invalid status"):
+            self._mock_get(sample_spec_filterable, status="invalid_value")
+
+    def test_get_invalid_iteration_raises_valueerror(self, sample_spec_filterable):
+        """get(iteration=999) must raise ValueError for non-existent iteration."""
+        with pytest.raises(ValueError, match="Iteration"):
+            self._mock_get(sample_spec_filterable, iteration=999)
+
+    def test_get_invalid_iteration_string_raises_valueerror(self, sample_spec_filterable):
+        """get(iteration='not-a-number') must raise ValueError."""
+        with pytest.raises(ValueError, match="iteration"):
+            self._mock_get(sample_spec_filterable, iteration="not-a-number")
+
+    def test_get_valid_statuses_accepted(self, sample_spec_filterable):
+        """All valid TaskStatus values must be accepted without error."""
+        valid_statuses = ["not_started", "in_progress", "completed", "blocked", "paused"]
+        for s in valid_statuses:
+            # Should not raise (combine with include_completed to allow 'completed' to pass through)
+            self._mock_get(sample_spec_filterable, status=s, include_completed=True)
 
 
 class TestRunQualityChecksMutualExclusivity:


### PR DESCRIPTION
## Summary

- Adds six filter parameters to `simpletask_get`: `include_completed`, `include_design`, `include_quality`, `full`, `status`, and `iteration`
- By default, the tool now excludes completed tasks, the design section, and quality_requirements — reducing token overhead for AI consumers that only need actionable work
- `full=True` bypasses all filtering for callers (plan/split workflows) that need the complete spec
- Response includes a `filters_applied` dict showing what was excluded; summary always reflects the unfiltered spec

## Changes

- `cli/simpletask/mcp/models.py` — Added `filters_applied: dict[str, Any] | None` field to `SimpleTaskGetResponse`
- `cli/simpletask/mcp/server.py` — Rewrote `get()` with filtering logic and 6 new parameters
- All AI workflow templates updated across opencode, qwen, gemini, and vibe editors
- `AGENTS.md` updated with new parameter table, default behavior, key behaviors table, and workflow-specific usage patterns
- 21 new unit tests; all 967 tests pass

Closes #11