### PR TITLE
fix(mcp): task_id and criterion_id schema advertised as non-nullable strings

### DIFF
--- a/cli/simpletask/__init__.py
+++ b/cli/simpletask/__init__.py
@@ -1,6 +1,6 @@
 """simpletask: A Python CLI for managing AI-friendly task definition YAML files."""
 
-__version__ = "0.33.0"
+__version__ = "0.34.0"
 
 import typer
 

--- a/cli/simpletask/mcp/models.py
+++ b/cli/simpletask/mcp/models.py
@@ -2,11 +2,23 @@
 
 This module defines Pydantic models for MCP tool responses,
 including status summaries and validation results.
+
+WithJsonSchema Overrides (Architectural Debt):
+    This module defines three Annotated type aliases (TaskIdAnnotation, CriterionIdAnnotation,
+    OperationsAnnotation) that override the JSON Schema FastMCP advertises to MCP clients.
+
+    The overrides advertise stricter types ({type: string}, {type: array}) than the Python
+    runtime types (str | None, list[...] | None), intentionally omitting null from the
+    advertised schema to prevent weaker LLMs from inferring null is valid for contextually-
+    required parameters.
+
+    This is a known limitation and a form of schema deception. The correct long-term fix is
+    per-action tools or discriminated unions. See server.py module docstring for full context.
 """
 
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, WithJsonSchema, field_validator, model_validator
 
 from ..core.models import (
     AcceptanceCriterion,
@@ -23,7 +35,9 @@ from ..core.models import (
 
 __all__ = [
     "BatchTaskOperation",
+    "CriterionIdAnnotation",
     "IterationSummary",
+    "OperationsAnnotation",
     "QualityCheckResult",
     "SimpleTaskBatchResponse",
     "SimpleTaskConstraintResponse",
@@ -36,8 +50,37 @@ __all__ = [
     "SimpleTaskQualityResponse",
     "SimpleTaskWriteResponse",
     "StatusSummary",
+    "TaskIdAnnotation",
     "ValidationResult",
+    "compute_compact_status_summary",
     "compute_status_summary",
+]
+
+
+TaskIdAnnotation = Annotated[
+    str | None,
+    WithJsonSchema(
+        {
+            "type": "string",
+            "description": (
+                "Task ID string (e.g. 'T001'). Required for action='update', "
+                "'remove', 'get'. Omit for 'add' or 'batch'."
+            ),
+        }
+    ),
+]
+
+CriterionIdAnnotation = Annotated[
+    str | None,
+    WithJsonSchema(
+        {
+            "type": "string",
+            "description": (
+                "Criterion ID string (e.g. 'AC1'). Required for "
+                "action='complete', 'remove', 'get', 'update'. Omit for 'add'."
+            ),
+        }
+    ),
 ]
 
 
@@ -53,7 +96,7 @@ class BatchTaskOperation(BaseModel):
     action: Literal["add", "remove", "update"] = Field(
         ..., description="Operation type: 'add', 'remove', or 'update'"
     )
-    task_id: str | None = Field(None, description="Task ID (required for remove/update)")
+    task_id: TaskIdAnnotation = None
     name: str | None = Field(None, description="Task name (required for add)")
     goal: str | None = Field(None, description="Task goal/description")
     status: str | None = Field(None, description="Task status (for update)")
@@ -86,11 +129,126 @@ class BatchTaskOperation(BaseModel):
     @model_validator(mode="after")
     def validate_required_fields(self) -> "BatchTaskOperation":
         """Validate that required fields are present based on operation type."""
-        if self.action in ("remove", "update") and not self.task_id:
-            raise ValueError(f"task_id is required for {self.action} operation")
-        if self.action == "add" and not self.name:
-            raise ValueError("name is required for add operation")
+        if self.action in ("remove", "update"):
+            if self.task_id is None:
+                raise ValueError(
+                    f"task_id is required for {self.action} operation. "
+                    f'Example: {{"action": "{self.action}", "task_id": "T001"}}'
+                )
+            if not self.task_id:
+                raise ValueError(
+                    f"task_id cannot be empty for {self.action} operation. "
+                    f'Example: {{"action": "{self.action}", "task_id": "T001"}}'
+                )
+        if self.action == "add":
+            if self.name is None:
+                raise ValueError(
+                    'name is required for add operation. Example: {"action": "add", "name": "My Task"}'
+                )
+            if not self.name:
+                raise ValueError(
+                    'name cannot be empty for add operation. Example: {"action": "add", "name": "My Task"}'
+                )
         return self
+
+
+# Defined here (after BatchTaskOperation) so the concrete type is available —
+# avoids forward-ref string "BatchTaskOperation" which Pydantic cannot resolve
+# when FastMCP builds its internal taskArguments model in a separate namespace.
+OperationsAnnotation = Annotated[
+    list[BatchTaskOperation] | None,
+    WithJsonSchema(
+        {
+            "type": "array",
+            "minItems": 1,
+            "description": (
+                "Non-empty list of batch operations (required for action='batch'). "
+                'Example: [{"action": "update", "task_id": "T001", '
+                '"status": "completed"}, {"action": "add", "name": '
+                '"New Task"}]'
+            ),
+            "items": {
+                "type": "object",
+                "description": "A single batch operation (add, remove, or update)",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["add", "remove", "update"],
+                        "description": "Operation type",
+                    },
+                    "task_id": {
+                        "type": "string",
+                        "description": (
+                            "Task ID string (e.g. 'T001'). Required for "
+                            "action='remove' or 'update'. Omit for 'add'."
+                        ),
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Task name (required for add)",
+                    },
+                    "goal": {
+                        "type": "string",
+                        "description": "Task goal/description",
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Task status (for update)",
+                    },
+                    "steps": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Task steps (for add)",
+                    },
+                    "done_when": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Completion conditions",
+                    },
+                    "prerequisites": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Task IDs that must complete first",
+                    },
+                    "files": {
+                        "type": "array",
+                        "description": "Files to create/modify/delete",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "path": {"type": "string"},
+                                "action": {
+                                    "type": "string",
+                                    "enum": ["create", "modify", "delete"],
+                                },
+                            },
+                        },
+                    },
+                    "code_examples": {
+                        "type": "array",
+                        "description": "Code patterns to follow",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "language": {"type": "string"},
+                                "code": {"type": "string"},
+                                "description": {"type": "string"},
+                            },
+                        },
+                    },
+                    "iteration": {
+                        "type": ["integer", "string", "null"],
+                        "description": (
+                            "Iteration ID to assign task to (for add/update). "
+                            "Use null to unassign the iteration."
+                        ),
+                    },
+                },
+                "required": ["action"],
+            },
+        }
+    ),
+]
 
 
 class IterationSummary(BaseModel):

--- a/cli/simpletask/mcp/server.py
+++ b/cli/simpletask/mcp/server.py
@@ -1,6 +1,40 @@
 """MCP server implementation for simpletask.
 
 Exposes task file operations as MCP tools for AI editor integration.
+
+WithJsonSchema Usage (Architectural Debt):
+    This module uses Pydantic's WithJsonSchema to override the JSON Schema that FastMCP
+    advertises to MCP clients. This is a pragmatic but imperfect solution to a design issue:
+
+    DESIGN PROBLEM:
+      - The task() and criteria() tools use polymorphic dispatch (single function, action-
+        dependent parameters) for ergonomic API design in Python.
+      - This means some parameters are optional at the Python level (str | None) but are
+        contextually required based on the 'action' argument.
+      - Example: task(action='get', task_id='T001') requires task_id; task(action='add',
+        name='...') requires name but task_id is optional.
+
+    SCHEMA ADVERTISEMENT:
+      - Pydantic normally generates anyOf:[string, null] for str | None type hints.
+      - Weaker LLMs read "null is valid" and call task(action='get', task_id=None),
+        causing infinite retry loops when the error message doesn't fully explain the
+        context-dependent requirement.
+      - WithJsonSchema overrides advertise {type: string} (no null branch) to prevent
+        this confusion.
+
+    THE DECEPTION:
+      - The advertised schema ({type: string}) is stricter than the Python type (str | None).
+      - Clients that validate responses bidirectionally may see mismatches.
+      - This is a known limitation; the correct fix is per-action tools or discriminated
+        unions, which were rejected in favor of a simpler API surface.
+      - See GitHub issue #14 and related discussions for context.
+
+    RISK MITIGATION:
+      - Error messages include concrete call examples so models can self-correct.
+      - Runtime validation uses explicit is None / not x checks to handle both None and
+        empty strings with distinct error messages.
+      - Regression tests (TestSchemaOverrides) verify the advertised schema actually
+        reaches the MCP wire protocol.
 """
 
 import builtins  # noqa: I001
@@ -58,8 +92,10 @@ from ..core.task_ops import (
 from ..core.validation import validate_task_file
 from ..core.yaml_parser import parse_task_file, write_task_file
 from .models import (
-    BatchTaskOperation,
+    BatchTaskOperation,  # noqa: F401 — required in module namespace for Pydantic forward-ref resolution at @mcp.tool() registration
     CompactStatusSummary,
+    CriterionIdAnnotation,
+    OperationsAnnotation,
     QualityCheckResult,
     SimpleTaskBatchResponse,
     SimpleTaskConstraintResponse,
@@ -72,6 +108,7 @@ from .models import (
     SimpleTaskQualityResponse,
     SimpleTaskWriteResponse,
     StatusSummary,
+    TaskIdAnnotation,
     ValidationResult,
     compute_compact_status_summary,
     compute_status_summary,
@@ -359,10 +396,19 @@ def new(
     )
 
 
+# DESIGN NOTE: Polymorphic dispatch — single function, action-dependent required parameters.
+# task_id is optional at the Python level (str | None) so 'add' and 'batch' can omit it, but
+# 'update', 'remove', and 'get' treat it as required and raise ValueError if absent.
+# The WithJsonSchema override on task_id advertises {type: string} to MCP clients (rather than
+# anyOf:[string,null]) so weaker models cannot infer null is a valid value for those actions.
+# Long-term alternative: split into per-action tools or use discriminated unions — rejected
+# because it would create verbose tool names (simpletask_task_update, etc.) and break clients.
+
+
 @mcp.tool()
 def task(
     action: Literal["add", "update", "remove", "get", "batch"],
-    task_id: str | None = None,
+    task_id: TaskIdAnnotation = None,
     name: str | None = None,
     goal: str | None = None,
     status: str | None = None,
@@ -371,7 +417,7 @@ def task(
     prerequisites: _list[str] | None = None,
     files: _list[FileAction] | None = None,
     code_examples: _list[CodeExample] | None = None,
-    operations: _list[BatchTaskOperation] | None = None,
+    operations: OperationsAnnotation = None,
     iteration: int | str | None = None,
     unassign_iteration: bool = False,
 ) -> SimpleTaskWriteResponse | SimpleTaskItemResponse | SimpleTaskBatchResponse:
@@ -420,8 +466,17 @@ def task(
 
     match action:
         case "get":
+            # Dual guards distinguish None (missing) from "" (empty string) for better
+            # error messages. AC8 requires empty strings to be rejected distinctly.
+            if task_id is None:
+                raise ValueError(
+                    "'task_id' is required for action='get'. "
+                    "Example: task(action='get', task_id='T001')"
+                )
             if not task_id:
-                raise ValueError("'task_id' is required for action='get'")
+                raise ValueError(
+                    "'task_id' cannot be empty. Example: task(action='get', task_id='T001')"
+                )
             spec = parse_task_file(file_path)
             task = next((t for t in spec.tasks or [] if t.id == task_id), None)
             if not task:
@@ -465,8 +520,18 @@ def task(
             )
 
         case "update":
+            # Dual guards distinguish None (missing) from "" (empty string) for better
+            # error messages. AC8 requires empty strings to be rejected distinctly.
+            if task_id is None:
+                raise ValueError(
+                    "'task_id' is required for action='update'. "
+                    "Example: task(action='update', task_id='T001', status='completed')"
+                )
             if not task_id:
-                raise ValueError("'task_id' is required for action='update'")
+                raise ValueError(
+                    "'task_id' cannot be empty. "
+                    "Example: task(action='update', task_id='T001', status='completed')"
+                )
             task_status = None
             if status:
                 try:
@@ -513,8 +578,17 @@ def task(
             )
 
         case "remove":
+            # Dual guards distinguish None (missing) from "" (empty string) for better
+            # error messages. AC8 requires empty strings to be rejected distinctly.
+            if task_id is None:
+                raise ValueError(
+                    "'task_id' is required for action='remove'. "
+                    "Example: task(action='remove', task_id='T001')"
+                )
             if not task_id:
-                raise ValueError("'task_id' is required for action='remove'")
+                raise ValueError(
+                    "'task_id' cannot be empty. Example: task(action='remove', task_id='T001')"
+                )
             spec = remove_implementation_task(file_path, task_id)
             summary = compute_compact_status_summary(spec)
             return SimpleTaskWriteResponse(
@@ -527,8 +601,16 @@ def task(
             )
 
         case "batch":
+            if operations is None:
+                raise ValueError(
+                    "'operations' is required for action='batch'. Example: task(action='batch', "
+                    'operations=[{"action": "update", "task_id": "T001", "status": "completed"}])'
+                )
             if not operations:
-                raise ValueError("'operations' is required for action='batch'")
+                raise ValueError(
+                    "'operations' cannot be empty for action='batch'. Example: task(action='batch', "
+                    'operations=[{"action": "update", "task_id": "T001", "status": "completed"}])'
+                )
             # FastMCP deserializes list[BatchTaskOperation] automatically; operations are
             # already validated BatchTaskOperation instances at this point.
             # Execute batch operations atomically; returns (new_ids, updated spec)
@@ -544,10 +626,16 @@ def task(
             )
 
 
+# DESIGN NOTE: Same polymorphic dispatch pattern as task() above.
+# criterion_id is optional at the Python level so 'add' can omit it, but 'complete', 'remove',
+# 'get', and 'update' require it. WithJsonSchema advertises {type: string} to prevent models
+# from passing null for those actions.
+
+
 @mcp.tool()
 def criteria(
     action: Literal["add", "complete", "remove", "get", "update"],
-    criterion_id: str | None = None,
+    criterion_id: CriterionIdAnnotation = None,
     description: str | None = None,
     completed: bool = True,
 ) -> SimpleTaskWriteResponse | SimpleTaskItemResponse:
@@ -572,8 +660,18 @@ def criteria(
 
     match action:
         case "get":
+            # Dual guards distinguish None (missing) from "" (empty string) for better
+            # error messages. AC8 requires empty strings to be rejected distinctly.
+            if criterion_id is None:
+                raise ValueError(
+                    "'criterion_id' is required for action='get'. "
+                    "Example: criteria(action='get', criterion_id='AC1')"
+                )
             if not criterion_id:
-                raise ValueError("'criterion_id' is required for action='get'")
+                raise ValueError(
+                    "'criterion_id' cannot be empty. "
+                    "Example: criteria(action='get', criterion_id='AC1')"
+                )
             spec = parse_task_file(file_path)
             criterion = next((c for c in spec.acceptance_criteria if c.id == criterion_id), None)
             if not criterion:
@@ -605,8 +703,18 @@ def criteria(
             )
 
         case "complete":
+            # Dual guards distinguish None (missing) from "" (empty string) for better
+            # error messages. AC8 requires empty strings to be rejected distinctly.
+            if criterion_id is None:
+                raise ValueError(
+                    "'criterion_id' is required for action='complete'. "
+                    "Example: criteria(action='complete', criterion_id='AC1', completed=True)"
+                )
             if not criterion_id:
-                raise ValueError("'criterion_id' is required for action='complete'")
+                raise ValueError(
+                    "'criterion_id' cannot be empty. "
+                    "Example: criteria(action='complete', criterion_id='AC1', completed=True)"
+                )
             spec = mark_criterion_complete(file_path, criterion_id, completed)
             summary = compute_compact_status_summary(spec)
             status_word = "completed" if completed else "incomplete"
@@ -620,8 +728,18 @@ def criteria(
             )
 
         case "remove":
+            # Dual guards distinguish None (missing) from "" (empty string) for better
+            # error messages. AC8 requires empty strings to be rejected distinctly.
+            if criterion_id is None:
+                raise ValueError(
+                    "'criterion_id' is required for action='remove'. "
+                    "Example: criteria(action='remove', criterion_id='AC1')"
+                )
             if not criterion_id:
-                raise ValueError("'criterion_id' is required for action='remove'")
+                raise ValueError(
+                    "'criterion_id' cannot be empty. "
+                    "Example: criteria(action='remove', criterion_id='AC1')"
+                )
             spec = remove_acceptance_criterion(file_path, criterion_id)
             summary = compute_compact_status_summary(spec)
             return SimpleTaskWriteResponse(
@@ -634,8 +752,18 @@ def criteria(
             )
 
         case "update":
+            # Dual guards distinguish None (missing) from "" (empty string) for better
+            # error messages. AC8 requires empty strings to be rejected distinctly.
+            if criterion_id is None:
+                raise ValueError(
+                    "'criterion_id' is required for action='update'. "
+                    "Example: criteria(action='update', criterion_id='AC1', description='New description')"
+                )
             if not criterion_id:
-                raise ValueError("'criterion_id' is required for action='update'")
+                raise ValueError(
+                    "'criterion_id' cannot be empty. "
+                    "Example: criteria(action='update', criterion_id='AC1', description='New description')"
+                )
             if not description:
                 raise ValueError("'description' is required for action='update'")
             spec = update_acceptance_criterion(file_path, criterion_id, description)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simpletask"
-version = "0.33.0"
+version = "0.34.0"
 description = "CLI tool for managing AI-friendly task definitions in branch-based development workflows"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest fixtures for simpletask tests."""
 
+import asyncio
 from collections.abc import Generator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -22,6 +23,18 @@ from simpletask.core.models import (
     TypeCheckConfig,
 )
 from simpletask.core.yaml_parser import write_task_file
+
+
+@pytest.fixture(scope="session")
+def mcp_tools_list():
+    """Cache the FastMCP tools list to avoid per-method asyncio.run() overhead.
+
+    This session-scoped fixture runs mcp.list_tools() once per test session,
+    avoiding the creation and destruction of an event loop per test method.
+    """
+    from simpletask.mcp.server import mcp
+
+    return asyncio.run(mcp.list_tools())
 
 
 @pytest.fixture

--- a/tests/unit/test_mcp_models.py
+++ b/tests/unit/test_mcp_models.py
@@ -256,6 +256,15 @@ class TestBatchTaskOperation:
                 goal="Task goal",
             )
 
+    def test_add_operation_empty_name_raises(self):
+        """Test add operation with empty string name raises ValidationError."""
+        with pytest.raises(ValidationError, match="name cannot be empty for add operation"):
+            BatchTaskOperation(
+                action="add",
+                name="",
+                goal="Task goal",
+            )
+
     def test_remove_operation_valid(self):
         """Test valid remove operation with required task_id."""
         op = BatchTaskOperation(
@@ -270,6 +279,11 @@ class TestBatchTaskOperation:
         """Test remove operation without task_id raises ValidationError."""
         with pytest.raises(ValidationError, match="task_id is required for remove operation"):
             BatchTaskOperation(action="remove")
+
+    def test_remove_operation_empty_task_id_raises(self):
+        """Test remove operation with empty string task_id raises ValidationError."""
+        with pytest.raises(ValidationError, match="task_id cannot be empty for remove operation"):
+            BatchTaskOperation(action="remove", task_id="")
 
     def test_update_operation_valid(self):
         """Test valid update operation with required task_id."""
@@ -289,6 +303,15 @@ class TestBatchTaskOperation:
         with pytest.raises(ValidationError, match="task_id is required for update operation"):
             BatchTaskOperation(
                 action="update",
+                status="completed",
+            )
+
+    def test_update_operation_empty_task_id_raises(self):
+        """Test update operation with empty string task_id raises ValidationError."""
+        with pytest.raises(ValidationError, match="task_id cannot be empty for update operation"):
+            BatchTaskOperation(
+                action="update",
+                task_id="",
                 status="completed",
             )
 

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -14,6 +14,7 @@ from simpletask.core.models import (
 )
 from simpletask.core.quality_ops import run_quality_checks
 from simpletask.core.yaml_parser import InvalidTaskFileError
+from simpletask.mcp.server import criteria as criteria_tool
 from simpletask.mcp.server import get, iteration, list, quality, task
 
 
@@ -250,7 +251,12 @@ class TestMCPServerRegistration:
 
 
 class TestMCPIterationTool:
-    """Tests for the iteration MCP tool."""
+    """Tests for the iteration MCP tool and quality() filter flags.
+
+    This class covers:
+    - Iteration management (list, add, get, remove)
+    - Quality check filter flags (lint_only, test_only, type_only, security_only)
+    """
 
     def test_list_returns_empty_when_no_iterations(self, tmp_project_with_task):
         """Test listing iterations when none exist returns empty list."""
@@ -363,6 +369,23 @@ class TestMCPIterationTool:
         t001 = next(t for t in get_result.spec.tasks if t.id == "T001")
         assert unassign_result.success is True
         assert unassign_result.action == "task_updated"
+        assert t001.iteration is None
+
+    def test_task_batch_update_unassigns_iteration_with_null(self, tmp_project_with_task):
+        """Test that batch update can unassign a task from an iteration via iteration=None."""
+        _project_root, task_file = tmp_project_with_task
+        with patch("simpletask.mcp.server.get_current_task_file_path", return_value=task_file):
+            add_result = iteration(action="add", label="Sprint 1")
+            new_id = int(add_result.new_item_ids[0])
+            task(action="update", task_id="T001", iteration=new_id)
+            batch_result = task(
+                action="batch",
+                operations=[{"action": "update", "task_id": "T001", "iteration": None}],
+            )
+            get_result = get()
+        t001 = next(t for t in get_result.spec.tasks if t.id == "T001")
+        assert batch_result.success is True
+        assert batch_result.action == "batch_tasks_applied"
         assert t001.iteration is None
 
     def test_task_update_omitting_iteration_preserves_existing(self, tmp_project_with_task):
@@ -487,8 +510,6 @@ class TestMCPIterationTool:
         with patch("simpletask.mcp.server.get_current_task_file_path", return_value=task_file):
             with pytest.raises(ValueError, match="iteration"):
                 task(action="update", task_id="T001", iteration="not-a-number")
-
-    """Tests for quality() MCP tool filter flags."""
 
     def _make_mock_spec(self, tmp_project_with_task):
         """Return (task_file, mock_spec) with a non-None quality_requirements."""
@@ -942,3 +963,417 @@ class TestRunQualityChecksMutualExclusivity:
             result = run_quality_checks(reqs, **{flag_name: True})
             getattr(mock_checker, checker_method).assert_called_once()
             assert result == ([], True)
+
+
+class TestSchemaOverrides:
+    """Tests that WithJsonSchema overrides reach the FastMCP wire schema."""
+
+    def _get_wire_tool_schema(self, tool_name: str, mcp_tools_list) -> dict:
+        """Return the inputSchema dict advertised by FastMCP for a named tool.
+
+        Args:
+            tool_name: Name of the tool to look up
+            mcp_tools_list: Fixture providing cached FastMCP tools list
+
+        Returns:
+            The inputSchema dict for the tool
+        """
+        tool = next((t for t in mcp_tools_list if t.name == tool_name), None)
+        assert tool is not None, f"Tool '{tool_name}' not found in mcp.list_tools()"
+        return tool.inputSchema
+
+    def test_task_id_wire_schema_is_string_not_nullable(self, mcp_tools_list):
+        """Verify FastMCP advertises task_id as {type: string} (no anyOf) on the wire."""
+        schema = self._get_wire_tool_schema("task", mcp_tools_list)
+        task_id_schema = schema.get("properties", {}).get("task_id", {})
+        assert task_id_schema.get("type") == "string", (
+            f"task_id schema should be {{type: string}}, got: {task_id_schema}"
+        )
+        assert "anyOf" not in task_id_schema, (
+            f"task_id schema must not contain anyOf; got: {task_id_schema}"
+        )
+
+    def test_criterion_id_wire_schema_is_string_not_nullable(self, mcp_tools_list):
+        """Verify FastMCP advertises criterion_id as {type: string} (no anyOf) on the wire."""
+        schema = self._get_wire_tool_schema("criteria", mcp_tools_list)
+        criterion_id_schema = schema.get("properties", {}).get("criterion_id", {})
+        assert criterion_id_schema.get("type") == "string", (
+            f"criterion_id schema should be {{type: string}}, got: {criterion_id_schema}"
+        )
+        assert "anyOf" not in criterion_id_schema, (
+            f"criterion_id schema must not contain anyOf; got: {criterion_id_schema}"
+        )
+
+    def test_batch_task_operation_task_id_schema_is_string_not_nullable(self):
+        """Verify BatchTaskOperation.task_id schema is {type: string} not anyOf."""
+        from simpletask.mcp.models import BatchTaskOperation
+
+        schema = BatchTaskOperation.model_json_schema()
+        task_id_schema = schema["properties"]["task_id"]
+
+        # Should be {type: string} not {anyOf: [...]}
+        assert task_id_schema.get("type") == "string"
+        assert "anyOf" not in task_id_schema
+
+    def test_operations_wire_schema_has_items(self, mcp_tools_list):
+        """Verify FastMCP advertises operations as {type: array, items: ...} with structure."""
+        schema = self._get_wire_tool_schema("task", mcp_tools_list)
+        operations_schema = schema.get("properties", {}).get("operations", {})
+
+        # Should have type: array
+        assert operations_schema.get("type") == "array", (
+            f"operations schema should be {{type: array}}, got: {operations_schema}"
+        )
+
+        # Should have items subschema describing BatchTaskOperation structure
+        assert "items" in operations_schema, (
+            f"operations schema must have items subschema; got: {operations_schema}"
+        )
+
+        # Items should have BatchTaskOperation properties
+        items_schema = operations_schema.get("items", {})
+        assert "properties" in items_schema or "type" in items_schema, (
+            f"operations items must define structure; got: {items_schema}"
+        )
+        assert operations_schema.get("minItems") == 1, (
+            f"operations schema should require at least one item; got: {operations_schema}"
+        )
+
+
+class TestTaskErrorMessages:
+    """Tests that task() error messages include concrete examples."""
+
+    def test_task_get_error_has_example(self, tmp_project_with_task):
+        """Verify task get action error includes Example call."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                task(action="get")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "task(action='get', task_id='T001')" in error_msg
+
+    def test_task_update_error_has_example(self, tmp_project_with_task):
+        """Verify task update action error includes Example call."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                task(action="update")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "task(action='update', task_id='T001'" in error_msg
+
+    def test_task_remove_error_has_example(self, tmp_project_with_task):
+        """Verify task remove action error includes Example call."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                task(action="remove")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "task(action='remove', task_id='T001')" in error_msg
+
+    def test_task_get_error_with_empty_string(self, tmp_project_with_task):
+        """Verify task get action rejects empty-string task_id with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                task(action="get", task_id="")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "task(action='get', task_id='T001')" in error_msg
+            assert "cannot be empty" in error_msg
+
+    def test_task_update_error_with_empty_string(self, tmp_project_with_task):
+        """Verify task update action rejects empty-string task_id with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                task(action="update", task_id="")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "task(action='update', task_id='T001'" in error_msg
+            assert "cannot be empty" in error_msg
+
+    def test_task_remove_error_with_empty_string(self, tmp_project_with_task):
+        """Verify task remove action rejects empty-string task_id with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                task(action="remove", task_id="")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "task(action='remove', task_id='T001')" in error_msg
+            assert "cannot be empty" in error_msg
+
+    def test_task_batch_error_has_example(self, tmp_project_with_task):
+        """Verify task batch action error includes Example call."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                task(action="batch")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "task(action='batch', operations=" in error_msg
+            assert "'operations' is required" in error_msg
+
+    def test_task_batch_error_with_empty_operations(self, tmp_project_with_task):
+        """Verify task batch action rejects empty operations list with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                task(action="batch", operations=[])
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "task(action='batch', operations=" in error_msg
+            assert "cannot be empty" in error_msg
+
+    def test_task_get_error_with_explicit_none(self, tmp_project_with_task):
+        """Verify task get action with explicit None rejects with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                task(action="get", task_id=None)  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "task(action='get', task_id='T001')" in error_msg
+
+    def test_task_update_error_with_explicit_none(self, tmp_project_with_task):
+        """Verify task update action with explicit None rejects with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                task(action="update", task_id=None)  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "task(action='update', task_id='T001'" in error_msg
+
+    def test_task_remove_error_with_explicit_none(self, tmp_project_with_task):
+        """Verify task remove action with explicit None rejects with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                task(action="remove", task_id=None)  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "task(action='remove', task_id='T001')" in error_msg
+
+
+class TestCriteriaErrorMessages:
+    """Tests that criteria() error messages include concrete examples."""
+
+    def test_criteria_get_error_has_example(self, tmp_project_with_task):
+        """Verify criteria get action error includes Example call."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                criteria_tool(action="get")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "criteria(action='get', criterion_id='AC1')" in error_msg
+
+    def test_criteria_complete_error_has_example(self, tmp_project_with_task):
+        """Verify criteria complete action error includes Example call."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                criteria_tool(action="complete")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "criteria(action='complete'" in error_msg
+
+    def test_criteria_remove_error_has_example(self, tmp_project_with_task):
+        """Verify criteria remove action error includes Example call."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                criteria_tool(action="remove")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "criteria(action='remove', criterion_id='AC1')" in error_msg
+
+    def test_criteria_update_error_has_example(self, tmp_project_with_task):
+        """Verify criteria update action error includes Example call."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                criteria_tool(action="update")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "criteria(action='update', criterion_id='AC1'" in error_msg
+
+    def test_criteria_get_error_with_empty_string(self, tmp_project_with_task):
+        """Verify criteria get action rejects empty-string criterion_id with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                criteria_tool(action="get", criterion_id="")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "criteria(action='get', criterion_id='AC1')" in error_msg
+            assert "cannot be empty" in error_msg
+
+    def test_criteria_complete_error_with_empty_string(self, tmp_project_with_task):
+        """Verify criteria complete action rejects empty-string criterion_id with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                criteria_tool(action="complete", criterion_id="")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "criteria(action='complete'" in error_msg
+            assert "cannot be empty" in error_msg
+
+    def test_criteria_remove_error_with_empty_string(self, tmp_project_with_task):
+        """Verify criteria remove action rejects empty-string criterion_id with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                criteria_tool(action="remove", criterion_id="")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "criteria(action='remove', criterion_id='AC1')" in error_msg
+            assert "cannot be empty" in error_msg
+
+    def test_criteria_update_error_with_empty_string(self, tmp_project_with_task):
+        """Verify criteria update action rejects empty-string criterion_id with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                criteria_tool(action="update", criterion_id="")  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "criteria(action='update', criterion_id='AC1'" in error_msg
+            assert "cannot be empty" in error_msg
+
+    def test_criteria_get_error_with_explicit_none(self, tmp_project_with_task):
+        """Verify criteria get action with explicit None rejects with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                criteria_tool(action="get", criterion_id=None)  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "criteria(action='get', criterion_id='AC1')" in error_msg
+
+    def test_criteria_complete_error_with_explicit_none(self, tmp_project_with_task):
+        """Verify criteria complete action with explicit None rejects with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                criteria_tool(action="complete", criterion_id=None)  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "criteria(action='complete'" in error_msg
+
+    def test_criteria_remove_error_with_explicit_none(self, tmp_project_with_task):
+        """Verify criteria remove action with explicit None rejects with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                criteria_tool(action="remove", criterion_id=None)  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "criteria(action='remove', criterion_id='AC1')" in error_msg
+
+    def test_criteria_update_error_with_explicit_none(self, tmp_project_with_task):
+        """Verify criteria update action with explicit None rejects with Example message."""
+        _project_root, task_file = tmp_project_with_task
+
+        with patch("simpletask.mcp.server.get_current_task_file_path") as mock_path:
+            mock_path.return_value = task_file
+
+            with pytest.raises(ValueError) as exc_info:
+                criteria_tool(action="update", criterion_id=None)  # type: ignore
+
+            error_msg = str(exc_info.value)
+            assert "Example:" in error_msg
+            assert "criteria(action='update', criterion_id='AC1'" in error_msg


### PR DESCRIPTION
Closes #14
Closes #21

## Problem

FastMCP advertised `anyOf: [string, null]` for `task_id` in `simpletask_task` and `criterion_id` in `simpletask_criteria`. Weaker models reading that schema inferred null was a valid value and passed it for `update`/`remove`/`get` actions, triggering a `ValueError` that gave no guidance on how to recover — causing them to loop indefinitely.

The same class of problem (#21) exists for the `operations` field in `simpletask_task`: FastMCP advertised `anyOf: [array, null]` with `default: null`, so models never produced the required array for `action='batch'` — retrying with `null` indefinitely.

## Changes

### Schema overrides
- Apply `Annotated[str | None, WithJsonSchema({"type": "string", ...})]` to `task_id` in `task()` and `criterion_id` in `criteria()` — overrides the MCP wire schema without changing Python runtime types (`add`/`batch` can still omit the field legitimately)
- Same override on `BatchTaskOperation.task_id` in `models.py`
- Apply `Annotated[list[BatchTaskOperation] | None, WithJsonSchema({"type": "array", ...})]` to `operations` in `task()` — overrides `anyOf: [array, null]` so models cannot infer null is valid for `action='batch'`

### Guard correctness (AC8)
- Replace all truthiness guards (`not task_id`, `not criterion_id`, `not self.task_id`) with explicit `is None` checks so `task_id=""` yields a distinct validation error rather than the misleading "is required" message

### Error messages (AC5)
- All 7 error paths (`task()` get/update/remove + `criteria()` get/complete/remove/update) now include a concrete `Example:` call snippet so a model that receives the error can self-correct on the next attempt
- `BatchTaskOperation` add/update/remove errors also include example snippets
- `task()` batch action error includes example snippet

### Tests (AC6 + AC7)
- `TestSchemaOverrides` — uses `asyncio.run(mcp.list_tools())` to assert the wire-level `inputSchema` for `task_id`, `criterion_id`, and `operations` contains no `anyOf`; `BatchTaskOperation.model_json_schema()` check for the model-level schema
- `TestTaskErrorMessages` / `TestCriteriaErrorMessages` — verify all error messages contain `Example:` and the correct call snippet
- Removed orphaned docstring inside `TestMCPIterationTool`

### Documentation
- Inline design comments above `task()` and `criteria()` explaining the polymorphic dispatch pattern, why `WithJsonSchema` is needed, and the long-term alternative (per-action tools / discriminated unions)
- Explanatory comment on the `WithJsonSchema` import in `server.py`

## Test results

977 tests passed · mypy clean (77 source files) · ruff lint + format clean · coverage 78%