### PR TITLE
feat(ai): add Pi editor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,32 @@ The recommended workflow uses slash commands in supported AI editors. These guid
 
 **Supported AI tools:**
 
-- **[OpenCode](https://opencode.ai)**, **[Qwen](https://github.com/QwenLM/qwen-code)**, **[Gemini CLI](https://github.com/google-gemini/gemini-cli)**, and **[Mistral Vibe](https://mistral.ai/news/vibe-coding)** - Install workflow commands:
+- **[OpenCode](https://opencode.ai)**, **[Qwen](https://github.com/QwenLM/qwen-code)**, **[Gemini CLI](https://github.com/google-gemini/gemini-cli)**, and **[Mistral Vibe](https://mistral.ai/news/vibe-coding)** - Install full workflow commands:
   ```sh
-  simpletask ai install              # All four editors
+  simpletask ai install              # All four full integrations
   simpletask ai install --opencode   # OpenCode only
   simpletask ai install --qwen       # Qwen only
   simpletask ai install --gemini     # Gemini CLI only
   simpletask ai install --vibe       # Mistral Vibe only
   simpletask ai install --local      # Project-local installation
   ```
+
+- **[Pi](https://pi.dev/)** - Install all 4 Pi prompts:
+  ```sh
+  simpletask ai install --pi         # Global Pi prompts install
+  simpletask ai install --pi --local # Project-local Pi prompts install
+  ```
+
+  Pi uses a CLI-only workflow (no MCP tools) that works with Pi's local or remote models.
+  All 4 workflow prompts are available after a single install:
+  - `/simpletask-plan` — Create task specification and implementation plan
+  - `/simpletask-split` — Analyze codebase and split complex tasks into atomic subtasks
+  - `/simpletask-implement` — Execute tasks step-by-step with quality checks
+  - `/simpletask-review` — Review implementation against acceptance criteria
+
+  Install locations:
+  - Global: `~/.pi/agent/prompts/`
+  - Local: `.pi/prompts/`
 
 The workflow commands are:
 - `/simpletask.plan` - Create specification and implementation plan
@@ -254,6 +271,9 @@ ajv validate -s schema/simpletask.schema.json -d .tasks/my-task.yml --spec=draft
 ### MCP Server for AI Editors
 
 simpletask includes a Model Context Protocol (MCP) server for integration with AI editors like OpenCode, Qwen-CLI, Gemini CLI, and Mistral Vibe. The MCP server exposes task file operations as structured tools that AI assistants can use to read task definitions, check status, and understand project context.
+
+Pi uses a CLI-only workflow (no MCP tools) and works with Pi's local or remote models. All 4
+workflow prompts are installed with a single `simpletask ai install --pi` command.
 
 **Benefits:**
 - **Structured responses**: AI gets typed JSON instead of parsing CLI output

--- a/cli/simpletask/commands/ai/install.py
+++ b/cli/simpletask/commands/ai/install.py
@@ -1,4 +1,4 @@
-"""Install OpenCode, Qwen, Gemini, and Vibe CLI command templates and agents."""
+"""Install OpenCode, Qwen, Gemini, Pi, and Vibe AI templates and agents."""
 
 import typer
 
@@ -7,15 +7,18 @@ from simpletask.core.ai_templates import (
     get_global_agents_dir,
     get_global_commands_dir,
     get_global_gemini_commands_dir,
+    get_global_pi_commands_dir,
     get_global_qwen_commands_dir,
     get_global_vibe_commands_dir,
     get_local_agents_dir,
     get_local_commands_dir,
     get_local_gemini_commands_dir,
+    get_local_pi_commands_dir,
     get_local_qwen_commands_dir,
     get_local_vibe_commands_dir,
     install_agents,
     install_gemini_templates,
+    install_pi_templates,
     install_qwen_templates,
     install_templates,
     install_vibe_templates,
@@ -118,38 +121,47 @@ def install_command(
         "--gemini",
         help="Install Gemini CLI templates only",
     ),
+    pi: bool = typer.Option(
+        False,
+        "--pi",
+        help="Install Pi templates only",
+    ),
     vibe: bool = typer.Option(
         False,
         "--vibe",
         help="Install Mistral Vibe skills only",
     ),
 ) -> None:
-    """Install OpenCode, Qwen, Gemini, and Vibe CLI command templates and agents.
+    """Install OpenCode, Qwen, Gemini, Pi, and Vibe AI templates and agents.
 
-    By default, installs ALL templates (OpenCode, Qwen, Gemini CLI, and Vibe) globally. OpenCode
-    agents are installed alongside OpenCode command templates.
-    Use --opencode, --qwen, --gemini, or --vibe to install only specific editor templates.
+    By default, installs all five integrations (OpenCode, Qwen, Gemini CLI, Pi, and Vibe)
+    globally. OpenCode agents are installed alongside OpenCode command templates.
+
+    Use --opencode, --qwen, --gemini, --pi, or --vibe to install only specific editor templates.
 
     Examples:
-        simpletask ai install                 # Install all four editors globally
-        simpletask ai install --local         # Install all four editors locally
+        simpletask ai install                 # Install all five editors globally
+        simpletask ai install --local         # Install all five editors locally
         simpletask ai install --opencode      # Install OpenCode only
         simpletask ai install --qwen          # Install Qwen only
         simpletask ai install --gemini        # Install Gemini CLI only
+        simpletask ai install --pi            # Install Pi only
         simpletask ai install --vibe          # Install Mistral Vibe only
-        simpletask ai install --opencode --qwen --gemini --vibe --local  # All four, locally
+        simpletask ai install --pi --local    # Install Pi locally
     """
-    # If no flags specified, install all four (implicit mode)
-    none_specified = not opencode and not qwen and not gemini and not vibe
+    # If no flags specified, install all five integrations
+    none_specified = not opencode and not qwen and not gemini and not pi and not vibe
     install_opencode = opencode or none_specified
     install_qwen = qwen or none_specified
     install_gemini = gemini or none_specified
+    install_pi = pi or none_specified
     install_vibe = vibe or none_specified
 
     # Track whether each editor was explicitly requested by the user
     opencode_explicit = bool(opencode)
     qwen_explicit = bool(qwen)
     gemini_explicit = bool(gemini)
+    pi_explicit = bool(pi)
     vibe_explicit = bool(vibe)
 
     any_skipped = False
@@ -217,6 +229,26 @@ def install_command(
             warning(f"Skipping Gemini installation: {e}")
         except Exception as e:
             error(f"Unexpected error installing Gemini: {e}")
+
+    # Install Pi prompts
+    if install_pi and _should_install("pi", "Pi", pi_explicit, local):
+        try:
+            target_dir = get_local_pi_commands_dir() if local else get_global_pi_commands_dir()
+
+            info(f"Installing Pi prompts to {target_dir}")
+
+            installed, skipped, overwritten = install_pi_templates(
+                target_dir=target_dir,
+                no_overwrite=no_overwrite,
+            )
+
+            any_skipped = (
+                _report_installation_results(installed, skipped, overwritten) or any_skipped
+            )
+        except FileNotFoundError as e:
+            warning(f"Skipping Pi installation: {e}")
+        except Exception as e:
+            error(f"Unexpected error installing Pi: {e}")
 
     # Install Vibe skills
     if install_vibe and _should_install("vibe", "Mistral Vibe", vibe_explicit, local):

--- a/cli/simpletask/commands/ai/list.py
+++ b/cli/simpletask/commands/ai/list.py
@@ -1,4 +1,4 @@
-"""List OpenCode, Qwen, Gemini, and Vibe CLI command templates."""
+"""List OpenCode, Qwen, Gemini, Pi, and Vibe AI templates."""
 
 from pathlib import Path
 
@@ -9,6 +9,7 @@ from simpletask.core.ai_templates import (
     get_agents_installed_status,
     get_bundled_agents,
     get_bundled_gemini_templates,
+    get_bundled_pi_templates,
     get_bundled_qwen_templates,
     get_bundled_templates,
     get_bundled_vibe_templates,
@@ -16,14 +17,17 @@ from simpletask.core.ai_templates import (
     get_global_agents_dir,
     get_global_commands_dir,
     get_global_gemini_commands_dir,
+    get_global_pi_commands_dir,
     get_global_qwen_commands_dir,
     get_global_vibe_commands_dir,
     get_installed_status,
     get_local_agents_dir,
     get_local_commands_dir,
     get_local_gemini_commands_dir,
+    get_local_pi_commands_dir,
     get_local_qwen_commands_dir,
     get_local_vibe_commands_dir,
+    get_pi_installed_status,
     get_qwen_installed_status,
     get_vibe_installed_status,
 )
@@ -66,7 +70,7 @@ def _render_editor_table(
 
 
 def list_command() -> None:
-    """List available and installed OpenCode, Qwen, Gemini, and Vibe CLI commands.
+    """List available and installed OpenCode, Qwen, Gemini, Pi, and Vibe resources.
 
     Shows which command templates are bundled with simpletask
     and whether they are installed globally or locally.
@@ -91,6 +95,10 @@ def list_command() -> None:
         gemini_templates = get_bundled_gemini_templates()
         gemini_status = get_gemini_installed_status()
 
+        # Get Pi prompt templates
+        pi_templates = get_bundled_pi_templates()
+        pi_status = get_pi_installed_status()
+
         # Get Vibe skills
         vibe_templates = get_bundled_vibe_templates()
         vibe_status = get_vibe_installed_status()
@@ -100,6 +108,7 @@ def list_command() -> None:
             and not opencode_agents
             and not qwen_templates
             and not gemini_templates
+            and not pi_templates
             and not vibe_templates
         ):
             console.print("[dim]No templates or agents found[/dim]")
@@ -157,6 +166,19 @@ def list_command() -> None:
             console.print(f"\n[bold]{EDITOR_CONFIGS['gemini'].display_name} Locations:[/bold]")
             console.print(f"  Global: {get_global_gemini_commands_dir()}")
             console.print(f"  Local:  {get_local_gemini_commands_dir()}\n")
+
+        # Pi prompts table
+        if pi_templates:
+            _render_editor_table(
+                title="Pi Prompts",
+                editor_name=EDITOR_CONFIGS["pi"].display_name,
+                templates=pi_templates,
+                status=pi_status,
+                name_label="Prompt",
+            )
+            console.print(f"\n[bold]{EDITOR_CONFIGS['pi'].display_name} Locations:[/bold]")
+            console.print(f"  Global: {get_global_pi_commands_dir()}")
+            console.print(f"  Local:  {get_local_pi_commands_dir()}\n")
 
         # Vibe skills table
         if vibe_templates:

--- a/cli/simpletask/core/ai_templates.py
+++ b/cli/simpletask/core/ai_templates.py
@@ -1,4 +1,4 @@
-"""AI template management for OpenCode, Qwen, Gemini, and Vibe CLI command files."""
+"""AI template management for OpenCode, Qwen, Gemini, Pi, and Vibe resources."""
 
 import importlib.resources
 import shutil
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-EditorType = Literal["opencode", "qwen", "gemini", "vibe"]
+EditorType = Literal["opencode", "qwen", "gemini", "pi", "vibe"]
 
 
 @dataclass(frozen=True)
@@ -51,6 +51,17 @@ EDITOR_CONFIGS: dict[EditorType, EditorConfig] = {
         local_config_dir=(".gemini", "commands"),
         global_base_dir=(".gemini",),
     ),
+    "pi": EditorConfig(
+        display_name="Pi",
+        template_subdir="pi",
+        file_extension=".md",
+        # Global Pi uses ~/.pi/agent/prompts/ (3 segments) because Pi organises its global
+        # prompt library under an 'agent' sub-level. Local project installs use the
+        # shorter .pi/prompts/ path (2 segments) — Pi resolves project-local prompts there.
+        global_config_dir=(".pi", "agent", "prompts"),
+        local_config_dir=(".pi", "prompts"),
+        global_base_dir=(".pi",),
+    ),
     "vibe": EditorConfig(
         display_name="Mistral Vibe",
         template_subdir="vibe",
@@ -67,7 +78,7 @@ def _get_templates_dir(editor: EditorType) -> Path:
     """Get path to bundled templates directory for an editor.
 
     Args:
-        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
+        editor: Editor type ("opencode", "qwen", "gemini", "pi", or "vibe")
 
     Returns:
         Path to the templates directory within the package.
@@ -94,7 +105,7 @@ def _get_bundled_templates(editor: EditorType) -> list[Path]:
     skill directory paths (each containing a SKILL.md).
 
     Args:
-        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
+        editor: Editor type ("opencode", "qwen", "gemini", "pi", or "vibe")
 
     Returns:
         List of Path objects for each template file or skill directory.
@@ -116,7 +127,7 @@ def _get_global_commands_dir(editor: EditorType) -> Path:
     """Get global commands directory for an editor.
 
     Args:
-        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
+        editor: Editor type ("opencode", "qwen", "gemini", "pi", or "vibe")
 
     Returns:
         Path to global commands directory.
@@ -129,7 +140,7 @@ def _get_local_commands_dir(editor: EditorType) -> Path:
     """Get local commands directory for an editor.
 
     Args:
-        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
+        editor: Editor type ("opencode", "qwen", "gemini", "pi", or "vibe")
 
     Returns:
         Path to local commands directory in current working directory.
@@ -145,7 +156,7 @@ def get_editor_base_dir(editor: EditorType) -> Path:
     editor is installed on the machine (e.g. ~/.config/opencode for OpenCode).
 
     Args:
-        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
+        editor: Editor type ("opencode", "qwen", "gemini", "pi", or "vibe")
 
     Returns:
         Path to the editor's global base directory.
@@ -160,7 +171,7 @@ def is_editor_installed(editor: EditorType) -> bool:
     An editor is considered installed if its global base directory exists.
 
     Args:
-        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
+        editor: Editor type ("opencode", "qwen", "gemini", "pi", or "vibe")
 
     Returns:
         True if the editor's global base directory exists, False otherwise.
@@ -263,7 +274,7 @@ def _install_templates(
     _install_skill_dirs() for directory-based editors.
 
     Args:
-        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
+        editor: Editor type ("opencode", "qwen", "gemini", "pi", or "vibe")
         target_dir: Directory to install templates into
         no_overwrite: If True, skip existing files/directories instead of overwriting
 
@@ -292,7 +303,7 @@ def _get_installed_status(editor: EditorType) -> dict[str, dict[str, bool]]:
     file existence.
 
     Args:
-        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
+        editor: Editor type ("opencode", "qwen", "gemini", "pi", or "vibe")
 
     Returns:
         Dict mapping template name to {"global": bool, "local": bool}
@@ -427,6 +438,115 @@ def _get_agents_installed_status(editor: EditorType) -> dict[str, dict[str, bool
     }
 
 
+class EditorAPI:
+    """Unified API for all editor-specific operations.
+
+    Wraps the private generic functions so new editors only need an entry
+    in ``EDITOR_CONFIGS`` — no new public wrapper functions are required.
+
+    Usage::
+
+        api = get_editor_api("pi")
+        api.templates_dir()
+        api.bundled_templates()
+        api.global_commands_dir()
+        api.local_commands_dir()
+        api.install(target_dir)
+        api.installed_status()
+        api.bundled_agents()
+        api.global_agents_dir()
+        api.local_agents_dir()
+        api.install_agents(target_dir)
+        api.agents_installed_status()
+    """
+
+    def __init__(self, editor: EditorType) -> None:
+        self._editor = editor
+
+    def templates_dir(self) -> Path:
+        """Return the bundled templates directory for this editor."""
+        return _get_templates_dir(self._editor)
+
+    def bundled_templates(self) -> list[Path]:
+        """Return bundled template files or skill dirs for this editor."""
+        return _get_bundled_templates(self._editor)
+
+    def global_commands_dir(self) -> Path:
+        """Return the global commands directory for this editor."""
+        return _get_global_commands_dir(self._editor)
+
+    def local_commands_dir(self) -> Path:
+        """Return the local commands directory for this editor."""
+        return _get_local_commands_dir(self._editor)
+
+    def install(
+        self, target_dir: Path, no_overwrite: bool = False
+    ) -> tuple[list[str], list[str], list[str]]:
+        """Install templates to *target_dir*.
+
+        Returns:
+            Tuple of (installed, skipped, overwritten) names.
+        """
+        return _install_templates(self._editor, target_dir, no_overwrite)
+
+    def installed_status(self) -> dict[str, dict[str, bool]]:
+        """Return installation status of each template for this editor."""
+        return _get_installed_status(self._editor)
+
+    def bundled_agents(self) -> list[Path]:
+        """Return bundled agent files for this editor (empty list if unsupported)."""
+        return _get_bundled_agents(self._editor)
+
+    def global_agents_dir(self) -> Path:
+        """Return the global agents directory for this editor.
+
+        Raises:
+            ValueError: If this editor does not support agents.
+        """
+        return _get_global_agents_dir(self._editor)
+
+    def local_agents_dir(self) -> Path:
+        """Return the local agents directory for this editor.
+
+        Raises:
+            ValueError: If this editor does not support agents.
+        """
+        return _get_local_agents_dir(self._editor)
+
+    def install_agents(
+        self, target_dir: Path, no_overwrite: bool = False
+    ) -> tuple[list[str], list[str], list[str]]:
+        """Install agents to *target_dir*.
+
+        Returns:
+            Tuple of (installed, skipped, overwritten) file names.
+
+        Raises:
+            FileNotFoundError: If no agents found or editor has no agent support.
+        """
+        return _install_agents(self._editor, target_dir, no_overwrite)
+
+    def agents_installed_status(self) -> dict[str, dict[str, bool]]:
+        """Return installation status of each agent for this editor."""
+        return _get_agents_installed_status(self._editor)
+
+
+def get_editor_api(editor: EditorType) -> EditorAPI:
+    """Return an :class:`EditorAPI` for the given editor.
+
+    This is the preferred way to interact with an editor's templates and
+    agents.  Adding a new editor only requires an entry in
+    :data:`EDITOR_CONFIGS` — no new public wrapper functions are needed.
+
+    Args:
+        editor: Editor type ("opencode", "qwen", "gemini", "pi", or "vibe").
+
+    Returns:
+        An :class:`EditorAPI` instance for *editor*.
+    """
+    return EditorAPI(editor)
+
+
 def get_templates_dir() -> Path:
     """Get path to bundled OpenCode templates directory.
 
@@ -452,6 +572,15 @@ def get_gemini_templates_dir() -> Path:
         Path to the templates/gemini directory within the package.
     """
     return _get_templates_dir("gemini")
+
+
+def get_pi_templates_dir() -> Path:
+    """Get path to bundled Pi templates directory.
+
+    Returns:
+        Path to the templates/pi directory within the package.
+    """
+    return _get_templates_dir("pi")
 
 
 def get_bundled_templates() -> list[Path]:
@@ -481,6 +610,15 @@ def get_bundled_gemini_templates() -> list[Path]:
     return _get_bundled_templates("gemini")
 
 
+def get_bundled_pi_templates() -> list[Path]:
+    """Get list of Pi prompt template files bundled with the package.
+
+    Returns:
+        List of Path objects for each prompt template file.
+    """
+    return _get_bundled_templates("pi")
+
+
 def get_global_commands_dir() -> Path:
     """Get global OpenCode commands directory.
 
@@ -508,6 +646,15 @@ def get_global_gemini_commands_dir() -> Path:
     return _get_global_commands_dir("gemini")
 
 
+def get_global_pi_commands_dir() -> Path:
+    """Get global Pi prompts directory.
+
+    Returns:
+        Path to ~/.pi/agent/prompts/
+    """
+    return _get_global_commands_dir("pi")
+
+
 def get_local_commands_dir() -> Path:
     """Get local OpenCode commands directory.
 
@@ -533,6 +680,15 @@ def get_local_gemini_commands_dir() -> Path:
         Path to .gemini/commands/ in current directory.
     """
     return _get_local_commands_dir("gemini")
+
+
+def get_local_pi_commands_dir() -> Path:
+    """Get local Pi prompts directory.
+
+    Returns:
+        Path to .pi/prompts/ in current directory.
+    """
+    return _get_local_commands_dir("pi")
 
 
 def install_templates(
@@ -592,6 +748,25 @@ def install_gemini_templates(
     return _install_templates("gemini", target_dir, no_overwrite)
 
 
+def install_pi_templates(
+    target_dir: Path,
+    no_overwrite: bool = False,
+) -> tuple[list[str], list[str], list[str]]:
+    """Install Pi prompt templates to target directory.
+
+    Args:
+        target_dir: Directory to install prompts into
+        no_overwrite: If True, skip existing files instead of overwriting
+
+    Returns:
+        Tuple of (installed, skipped, overwritten) file names.
+
+    Raises:
+        FileNotFoundError: If templates directory doesn't exist
+    """
+    return _install_templates("pi", target_dir, no_overwrite)
+
+
 def get_installed_status() -> dict[str, dict[str, bool]]:
     """Get installation status of each OpenCode template.
 
@@ -617,6 +792,15 @@ def get_gemini_installed_status() -> dict[str, dict[str, bool]]:
         Dict mapping template name to {"global": bool, "local": bool}
     """
     return _get_installed_status("gemini")
+
+
+def get_pi_installed_status() -> dict[str, dict[str, bool]]:
+    """Get installation status of each Pi prompt template.
+
+    Returns:
+        Dict mapping prompt template name to {"global": bool, "local": bool}
+    """
+    return _get_installed_status("pi")
 
 
 def get_bundled_agents() -> list[Path]:

--- a/cli/simpletask/templates/pi/simpletask-implement.md
+++ b/cli/simpletask/templates/pi/simpletask-implement.md
@@ -1,0 +1,87 @@
+---
+description: Execute the current simpletask implementation workflow in Pi using CLI commands.
+argument-hint: "[task-id ...]"
+---
+
+User input: $ARGUMENTS
+
+Invoking `/simpletask-implement` is itself the user's request to perform implementation work now.
+If no task IDs or extra arguments are provided, treat the current branch task file as the work to
+execute. Do not wait for the user to provide a "first task" unless the task file is missing or
+invalid.
+
+Use this prompt for implementation work only. Do not create or rewrite the plan unless the task
+file is clearly missing or invalid.
+
+Mandates:
+- Create exactly one final Conventional Commit when all requested work is done. Do not create
+  multiple commits.
+- Run quality checks before marking any task `completed`.
+- Do not skip quality checks, implement tasks with unmet prerequisites, or create multiple commits.
+
+Response contract:
+- Do not reply with an acknowledgement-only message such as "Understood", "I have read the
+  instructions", "I am ready", or "please provide the first task".
+- In normal mode, do not restate the workflow. Start immediately with `git branch --show-current`.
+- If a system reminder says plan mode or read-only mode is active, do not try to execute or
+  acknowledge.
+- In that read-only case, inspect using read-only tools only and respond with `Plan:` followed by a
+  numbered list for exactly one executable task.
+- In that `Plan:` output, include the selected task ID, the files to inspect or change later, and
+  the verification commands to run during execution mode.
+- End the read-only response with exactly one short line: `Choose Execute the plan to continue.`
+- During read-only plan mode, do not insist on `simpletask` CLI if it is blocked by the
+  environment allowlist; use direct task-file and source-file reads instead. Once execution mode
+  is available, switch back to `simpletask` CLI for task management.
+
+1. Identify the current branch:
+   - `git branch --show-current`
+2. Show the current task summary:
+   - `simpletask show --format json`
+3. Inspect implementation state before editing code:
+   - `simpletask task list --flat --format json`
+   - `simpletask criteria list --format json`
+   - `simpletask quality show --format json`
+   - For full task detail (steps, done_when, prerequisites, files, notes), run:
+     `simpletask show --format json`
+4. If the user specified task IDs, restrict work to those IDs. Otherwise, select exactly one
+   executable task at a time:
+   - prefer a task already in `in_progress`; finish it before starting another
+   - otherwise select a task whose status is `not_started`
+   - all prerequisites are already completed
+5. Before changing code, mark only the selected task in progress for the current work:
+   - `simpletask task update T001 --status in_progress --format json`
+   - do not move a second task to `in_progress` until the current task leaves that state
+6. Implement using the task's `goal`, `steps`, `done_when`, `files`, `constraints`, `design`, and
+   the current codebase context.
+7. Record only meaningful blockers or decisions:
+   - `simpletask note add "..." --task T001 --format json`
+8. Before marking a task complete:
+   - confirm every `done_when` condition is satisfied
+   - run `simpletask quality check --format json`
+9. As soon as the implementation attempt is done, update the task status immediately:
+   - success after `done_when` verification and quality checks: `simpletask task update T001 --status completed --format json`
+   - blocked: `simpletask task update T001 --status blocked --format json`
+   - intentionally deferred: `simpletask task update T001 --status paused --format json`
+   - do not leave finished work in `in_progress`
+10. Mark any satisfied acceptance criteria:
+   - `simpletask criteria complete AC1 --format json`
+11. When the requested implementation work is done, validate the task file:
+   - `simpletask schema validate --format json`
+12. If all requested tasks completed successfully, create one Conventional Commit:
+   - `git add -A`
+   - `git commit -m "type(scope): description"`
+   - Use the correct type (`feat`, `fix`, `refactor`, `test`, `docs`, `chore`) based on the work.
+   - Do NOT include simpletask IDs (e.g. T001, AC1) or issue tracker numbers (e.g. #123) in the commit message.
+   - Skip the commit if any task ended `blocked` or `paused` — unstable work should not be committed.
+13. Report completed tasks, blocked or paused tasks, completed criteria, quality-check result, and
+   commit details.
+
+Rules:
+- Use `simpletask` CLI commands for task management.
+- Always pass `--format json` to every simpletask CLI command for structured, ANSI-free output.
+- Do not start tasks with unmet prerequisites.
+- Keep at most one task in `in_progress` at a time.
+- Do not mark a task completed before quality checks pass.
+- Keep code changes minimal and focused on the selected task.
+- If quality configuration is missing or the task file is invalid, stop and explain the blocker.

--- a/cli/simpletask/templates/pi/simpletask-plan.md
+++ b/cli/simpletask/templates/pi/simpletask-plan.md
@@ -1,0 +1,178 @@
+---
+description: Create specification and implementation plan from feature description using simpletask CLI.
+argument-hint: "<feature description>"
+---
+
+User input: $ARGUMENTS
+
+**CRITICAL: This is a PLANNING phase. DO NOT implement code or execute tasks. Your job is to create/update the task file with acceptance criteria and task breakdown — then STOP.**
+
+Response contract:
+- Do not reply with an acknowledgement-only message such as "Understood" or "I am ready".
+- Start immediately with branch name analysis and confirmation.
+- If plan mode or read-only mode is active, inspect using read-only tools only and respond with a
+  summary of the proposed plan.
+- Do not use MCP tools. Use only `simpletask` CLI commands and standard shell commands.
+
+---
+
+## Step 0: Determine Branch Name
+
+1. Analyze the user prompt to determine branch type prefix:
+
+   | If prompt contains... | Suggest prefix |
+   |----------------------|----------------|
+   | "fix", "bug", "error", "issue", "broken", "crash" | `fix/` |
+   | "refactor", "cleanup", "improve", "optimize" | `refactor/` |
+   | "test", "spec", "coverage" | `test/` |
+   | "doc", "readme", "documentation" | `docs/` |
+   | "chore", "config", "update deps", "upgrade", "bump" | `chore/` |
+   | Default (new functionality) | `feature/` |
+
+2. Generate slug from description:
+   - Convert to lowercase, remove stop words, take first 3-4 meaningful words, join with hyphens.
+   - Examples: "Add user authentication" → `user-authentication`
+
+3. Construct suggested branch name as `[prefix]/[slug]`.
+
+4. **ASK USER TO CONFIRM OR CUSTOMIZE** the suggested branch name before proceeding.
+
+5. Store the confirmed branch name as `[branch-name]` for subsequent steps.
+
+---
+
+## Step 1: Check for Existing Task File
+
+```bash
+git branch --show-current
+simpletask show --format json 2>&1
+```
+
+- If `simpletask show` succeeds: task file exists. If tasks are empty/minimal, proceed to Step 3.
+- If it reports a file-not-found error: proceed to Step 2.
+- Branch names with slashes (e.g., `feature/user-auth`) are normalized to filenames with hyphens
+  (e.g., `.tasks/feature-user-auth.yml`) automatically.
+
+---
+
+## Step 2: Create Git Branch (if needed)
+
+```bash
+git checkout -b [branch-name]
+```
+
+---
+
+## Step 3: Create or Update Task File
+
+If task file does NOT exist, create it:
+
+```bash
+simpletask new "[branch-name]" "[brief title]" "[original user prompt verbatim]" --format json
+```
+
+If task file exists but is minimal, proceed to Step 4 to add criteria and tasks.
+
+---
+
+## Step 3.5: Project Defaults — MANDATORY — DO NOT SKIP
+
+```bash
+ls .tasks/defaults.yml 2>/dev/null && echo "exists" || echo "missing"
+```
+
+- **If `defaults.yml` exists:** Inform the user that project defaults were auto-merged. No action needed.
+- **If `defaults.yml` does NOT exist:** Ask the user:
+
+  > "No project defaults found (`.tasks/defaults.yml` is missing). Would you like to run a
+  > codebase analysis now to set up project-level defaults? (yes / no)"
+
+  **Wait for the user's response before continuing.**
+
+  If yes: run the codebase analysis from Step 1.5 of `/simpletask-split` and write results using
+  `simpletask design set` and `simpletask quality preset` CLI commands.
+
+  If no: skip — the user can set up defaults later with `simpletask defaults`.
+
+---
+
+## Step 4: Add Acceptance Criteria
+
+Add testable, specific acceptance criteria:
+
+```bash
+simpletask criteria add "[criterion description]" --format json
+# Repeat for each criterion (typically 3-6)
+```
+
+**Write correctness invariants, not implementation descriptions.**
+
+Criteria must describe *what must remain true* after the feature lands. Ask: "If this criterion is
+satisfied, can I be confident the feature is correct?"
+
+| Weak (avoid) | Strong (prefer) |
+|---|---|
+| "Posts to the endpoint" | "Constructed URL resolves to a valid endpoint given the configured base URL" |
+| "Config file is parsed" | "All required keys are present; missing or malformed keys produce a descriptive error" |
+
+**Required criteria by feature type:**
+- Multi-file features crossing component boundaries: at least one cross-component correctness criterion.
+- Features processing external input: at least one robustness criterion for malformed/missing values.
+- Always include one user-observable outcome and one quality criterion (tests pass, schema validates).
+
+**Self-check before proceeding:**
+1. Multi-file cross-component behavior? → cross-component criterion present?
+2. External input? → robustness criterion present?
+3. No restatements of task names?
+4. At least one externally observable user outcome?
+
+Do NOT proceed to Step 5 until all four checks pass.
+
+---
+
+## Step 5: Plan Implementation Tasks
+
+Add implementation tasks. Each task should be completable in 5-30 minutes:
+
+```bash
+simpletask task add "[short descriptive name]" \
+  --goal "[one sentence explaining what this accomplishes]" \
+  --steps "First specific action" "Second specific action" "Third specific action" \
+  --format json
+# Repeat for each task
+```
+
+---
+
+## Step 6: Validate and Summarize
+
+```bash
+simpletask schema validate --format json
+simpletask show --format json
+```
+
+Report completion:
+```
+Task file created/updated: .tasks/[normalized-branch-name].yml
+
+Summary:
+- Branch: [branch-name]
+- Title: [title]
+- Acceptance Criteria: [count]
+- Implementation Tasks: [count]
+- Status: not_started
+
+Next steps:
+- For complex features, run /simpletask-split to analyze codebase and split tasks
+- For simple features, run /simpletask-implement to execute tasks
+```
+
+---
+
+**STOP HERE. Do NOT proceed to implementation.**
+
+The planning phase is complete when:
+1. Task file exists at `.tasks/[normalized-branch-name].yml`
+2. All acceptance criteria are defined
+3. All implementation tasks are detailed with name, goal, and steps
+4. `simpletask schema validate` passes

--- a/cli/simpletask/templates/pi/simpletask-review.md
+++ b/cli/simpletask/templates/pi/simpletask-review.md
@@ -1,0 +1,282 @@
+---
+description: Scope-bounded code review against acceptance criteria using simpletask CLI.
+argument-hint: ""
+---
+
+User input: $ARGUMENTS
+
+**IMPORTANT: Scope constraint**
+
+This review is strictly scoped to the original prompt and acceptance criteria defined in the task
+file. Verify that the implementation satisfies those requirements — nothing more. Do NOT suggest
+features, refactoring, or improvements beyond what was explicitly requested. Do NOT flag issues in
+code outside the git diff.
+
+Response contract:
+- Do not reply with an acknowledgement-only message.
+- Start immediately with loading the task file.
+- Do not use MCP tools. Use only `simpletask` CLI commands and standard shell commands.
+
+---
+
+## Step 1: Identify Task File
+
+```bash
+git branch --show-current
+simpletask show --format json
+```
+
+If the task file does not exist, abort and inform the user.
+
+---
+
+## Step 2: Analyze Task Completion
+
+```bash
+simpletask task list --flat --format json
+simpletask task list --status completed --format json
+simpletask task list --status not_started --format json
+simpletask task list --status in_progress --format json
+simpletask task list --status blocked --format json
+simpletask task list --status paused --format json
+```
+
+---
+
+## Step 3: Check Acceptance Criteria
+
+```bash
+simpletask criteria list --format json
+simpletask criteria list --completed --format json
+simpletask criteria list --incomplete --format json
+```
+
+---
+
+## Step 4: Verify Implementation Against Criteria and Diff
+
+Scope: only the files in `git diff --name-only main..HEAD` (or `master..HEAD`).
+
+Also read implementation notes for context:
+
+```bash
+simpletask note list --format json
+```
+
+For each acceptance criterion, check whether the diff actually satisfies it. Look for:
+
+### Criteria Satisfaction
+- Does the diff contain code that implements each criterion?
+- Are criteria marked complete with no corresponding changes in the diff?
+- Are criteria still marked incomplete that are actually implemented?
+
+### Security (within diff scope only)
+- Exposed credentials or secrets introduced by the diff
+- Input validation gaps relevant to the feature
+- Injection vulnerabilities (SQL, XSS, command injection) in new code only
+
+### Correctness
+- Logic errors in changed code that prevent acceptance criteria from being met
+- Missing edge cases for paths described in the acceptance criteria
+- Error handling gaps in new code that cause user-visible failures
+
+**Do NOT flag:** code style, naming conventions, performance of unchanged code, documentation
+outside feature scope, or architectural patterns in unmodified files.
+
+---
+
+## Step 5: Analyze Git Changes
+
+```bash
+git log --oneline main..HEAD 2>/dev/null || git log --oneline master..HEAD
+git diff --stat main..HEAD 2>/dev/null || git diff --stat master..HEAD
+git diff --name-only main..HEAD 2>/dev/null || git diff --name-only master..HEAD
+```
+
+- Count commits on feature branch
+- Note files modified, lines added/removed
+- Flag any modified files unrelated to the original prompt (scope creep signal)
+
+---
+
+## Step 6: Cross-Cutting Design Notes
+
+Scope: only the git diff. Design notes are **informational only** — they do NOT block merge and do
+NOT create fix tasks.
+
+Ask these 4 questions against the diff:
+
+| # | Question | What to look for |
+|---|----------|-----------------|
+| 1 | **Data flow across files** | Does data mutate as it crosses file boundaries in ways that could silently lose information? |
+| 2 | **Robustness under unexpected inputs** | Are there input shapes or missing keys that could cause silent failures in new code? |
+| 3 | **Error semantics** | Do error paths in the diff propagate enough context for callers to act correctly? |
+| 4 | **Test fidelity** | Do new/changed tests actually exercise the behavior in the acceptance criteria? |
+
+Produce **zero to 5 design notes**. Zero is correct if no observation is well-supported by the
+diff. Each note **must**:
+- Be prefixed with `[DATA_FLOW]`, `[ROBUSTNESS]`, `[ERROR_SEM]`, or `[TEST_FIDELITY]`
+- Reference a specific `file:line` from the diff
+- Be 1-2 sentences — informational only, no fix required
+
+**Before persisting notes, clear prior auto-generated notes to avoid duplicates:**
+
+```bash
+simpletask note remove --all --format json
+```
+
+Then persist each design note:
+
+```bash
+simpletask note add "[CATEGORY] file:line — observation" --format json
+# Repeat for each note (max 5)
+```
+
+If 3 or more notes share the same category, append to the summary:
+`CRITERIA GAP DETECTED: [N]/[total] design notes concern [CATEGORY].`
+
+---
+
+## Step 7: Generate Scoped, Actionable Feedback
+
+Only report issues that:
+- Prevent an acceptance criterion from being met, OR
+- Are Critical/High severity security or correctness issues in the changed code
+
+```
+[SEVERITY: Critical/High]
+File: path/to/file.py:123
+Criterion: [ACx — criterion description, or "regression risk"]
+Issue: [Clear description of the problem]
+Why it matters: [How this breaks the stated requirement]
+Fix: [Specific, actionable remediation]
+```
+
+Categories: **UNMET CRITERIA**, **SECURITY**, **CORRECTNESS**, **SCOPE CREEP** (informational)
+
+Medium/Low observations are noted in the summary but do NOT trigger fix tasks.
+
+---
+
+## Step 8: Determine PR Readiness
+
+### READY TO MERGE
+- All tasks have `status: completed`
+- All acceptance criteria have `completed: true`
+- No Critical or High severity blocking issues
+- Changes are scoped to the original prompt
+
+### NEEDS CHANGES
+- All tasks complete and all criteria done
+- BUT has Critical/High severity issues fixable without major rework
+
+### NOT READY
+- Tasks remain `not_started` or `in_progress`
+- Acceptance criteria remain with `completed: false`
+- Critical flaws prevent the feature from working as specified
+
+---
+
+## Step 9: Display Review Summary
+
+```
+╭─────────────────────────────────────────────────────────────╮
+│ Code Review: [branch-name]                                  │
+╰─────────────────────────────────────────────────────────────╯
+
+ORIGINAL PROMPT
+  [original_prompt from task file — one line summary]
+
+TASK COMPLETION
+  Tasks: X/Y completed (Z%)
+  - Completed: [count]
+  - In Progress: [count]
+  - Not Started: [count]
+  - Blocked: [count]
+  - Paused: [count]
+
+ACCEPTANCE CRITERIA
+  Criteria: X/Y met (Z%)
+  Unmet: AC1: [description], AC2: [description]
+
+GIT CHANGES
+  Branch: [branch-name]
+  Commits: N commits ahead of main
+  Changes: M files modified, +A/-R lines
+  Scope: [FOCUSED | CONTAINS OUT-OF-SCOPE CHANGES]
+
+BLOCKING ISSUES (require fix tasks)
+  [Critical/High] UNMET CRITERIA (X issues)
+    - ACX: file.py:123 — [issue description]
+  [Critical/High] SECURITY / CORRECTNESS (X issues)
+    - file.py:789 — [issue description]
+
+DESIGN NOTES (informational — no tasks created)
+  - [DATA_FLOW] file.py:42 — [note]
+  - [ROBUSTNESS] other.py:17 — [note]
+
+OBSERVATIONS (minor — informational, no tasks created)
+  - [Low/Medium severity notes about the diff, if any]
+
+───────────────────────────────────────────────────────────────
+PR READINESS: [READY TO MERGE | NEEDS CHANGES | NOT READY]
+
+[Assessment with justification referencing specific criteria]
+───────────────────────────────────────────────────────────────
+```
+
+---
+
+## Step 10: Auto-Inject Fix Tasks (blocking issues only)
+
+Only create fix tasks for **Critical or High severity** issues that prevent acceptance criteria from
+being met or introduce security/correctness regressions. Do NOT create tasks for Medium/Low issues.
+
+If blocking issues exist:
+
+```bash
+# Create a review-fixes iteration
+simpletask iteration add "review fixes" --format json
+
+# Add fix tasks (use the iteration ID returned above)
+simpletask task add "Fix: [issue summary]" \
+  --goal "[detailed goal with file path and remediation]" \
+  --iteration [iter_id] \
+  --format json
+# Repeat for each blocking issue
+```
+
+After adding fix tasks:
+
+```bash
+simpletask schema validate --format json
+```
+
+If no blocking issues: report "No fix tasks needed." Do NOT create an iteration or any tasks.
+
+---
+
+## Review Workflow
+
+```
+/simpletask-plan      → Creates task file with tasks and criteria
+        ↓
+/simpletask-implement → Executes tasks, updates status
+        ↓
+/simpletask-review    → Verifies implementation against criteria
+        ↓
+    Blocking issues? → /simpletask-implement (fix tasks only) → /simpletask-review
+        ↓
+    No → Ready for PR
+```
+
+---
+
+## Rules
+
+- Do not use MCP tools. Use `simpletask` CLI commands and shell commands only.
+- Always pass `--format json` to every simpletask CLI command.
+- Only review files in the git diff — do not audit the whole codebase.
+- Only flag issues that violate acceptance criteria or introduce blocking regressions.
+- Be specific: include file paths, function names, and line numbers.
+- Every fix task must have a clear, implementable goal referencing the exact criterion.

--- a/cli/simpletask/templates/pi/simpletask-split.md
+++ b/cli/simpletask/templates/pi/simpletask-split.md
@@ -1,0 +1,305 @@
+---
+description: Analyze codebase and split complex tasks into atomic subtasks using simpletask CLI.
+argument-hint: ""
+---
+
+User input: $ARGUMENTS
+
+**Purpose:** Ensure AI models have minimal context per task by splitting complex tasks into
+ultra-atomic units (1-2 steps, 5-10 minutes each). This eliminates ambiguity and decision-making
+during implementation.
+
+**CRITICAL: This is a TASK REFINEMENT phase. Automatically split ALL complex tasks, remove
+originals, add subtasks, renumber IDs, and update the task file. No preview, no confirmation —
+execute immediately.**
+
+Response contract:
+- Do not reply with an acknowledgement-only message.
+- Start immediately with loading the task file.
+- Do not use MCP tools. Use only `simpletask` CLI commands, direct file reads, and shell commands.
+
+---
+
+## Step 1: Load Task File
+
+```bash
+git branch --show-current
+simpletask show --format json
+simpletask task list --flat --format json
+```
+
+If task file not found: Report "No task file found. Run /simpletask-plan first." and STOP.
+
+---
+
+## Step 1.5: Codebase Analysis & Design (Conditional)
+
+**SKIP this step if ANY of the following are true:**
+- `simpletask show --format json` shows a populated `design` section (has patterns, constraints, or
+  references)
+- `simpletask quality show --format json` shows quality requirements already configured
+- `.tasks/defaults.yml` exists and contains design patterns or quality requirements
+
+**If design section is empty or missing, execute this mandatory codebase analysis:**
+
+### 1.5.1: Find Reference Implementations
+
+Search the codebase directly for similar existing code:
+
+```bash
+# Find files by keyword
+find . -name "*.py" | xargs grep -l "[feature keyword]" 2>/dev/null | head -10
+
+# Read relevant files
+cat [path/to/reference/file]
+
+# Check architecture docs
+cat AGENTS.md 2>/dev/null | head -80
+cat README.md 2>/dev/null | head -40
+```
+
+Document findings:
+
+```bash
+simpletask design set reference "[file path]" "[why this is relevant]" --format json
+# Repeat for each reference
+```
+
+### 1.5.2: Document Patterns to Follow
+
+Read existing modules to identify patterns:
+
+```bash
+# Check project config for tech stack
+cat pyproject.toml 2>/dev/null | head -40
+cat package.json 2>/dev/null | head -20
+
+# Read similar modules to identify conventions
+cat [path/to/similar/module]
+```
+
+```bash
+simpletask design set pattern "[pattern name or description]" --format json
+# Repeat for each pattern
+```
+
+### 1.5.3: Define Architectural Constraints
+
+```bash
+# Inspect directory structure and imports
+ls -la src/ 2>/dev/null || ls -la cli/ 2>/dev/null
+grep -r "from \." [src_dir]/ 2>/dev/null | head -20
+```
+
+```bash
+simpletask design set constraint "[constraint description]" --format json
+# Repeat for each constraint
+```
+
+### 1.5.4: Identify Security Considerations
+
+```bash
+# Check existing validation patterns
+grep -rn "validate\|sanitize\|escape" [src_dir]/ 2>/dev/null | head -10
+```
+
+```bash
+simpletask design set security --category input_validation "[description]" --format json
+```
+
+### 1.5.5: Define Error Handling Pattern
+
+```bash
+# Check existing error handling
+grep -rn "raise \|except \|try:" [src_dir]/ 2>/dev/null | head -15
+```
+
+```bash
+simpletask design set error-handling "[pattern: exceptions|result_type|error_codes]" --format json
+```
+
+### 1.5.6: Define Quality Requirements
+
+Apply a quality preset based on the tech stack:
+
+```bash
+simpletask quality preset [python|typescript|node|go|rust|java-maven|java-gradle] --format json
+```
+
+**Available presets:** python, typescript, node, go, rust, java-maven, java-gradle
+
+After Step 1.5, reload the task file:
+
+```bash
+simpletask show --format json
+```
+
+---
+
+## Step 2: Identify Tasks to Split
+
+**A task MUST be split if it meets ANY criterion:**
+- **>2 steps** in the steps array
+- **>1 file** in the files array
+- **>3 conditions** in `done_when`
+- **>100 characters** in goal description
+
+**SKIP splitting (already atomic) if:**
+- Exactly 1 step AND step <50 characters
+- Task name contains: "Add import", "Update version", "Fix typo", "Remove unused"
+- Task name starts with "Fix:" (bug fixes need full context)
+
+Read the full task file to evaluate:
+
+```bash
+cat .tasks/$(git branch --show-current | sed 's|/|-|g').yml
+```
+
+---
+
+## Step 3: Analyze and Generate Subtasks
+
+For EACH complex task, generate atomic subtasks using these patterns:
+
+### Pattern Recognition Guide
+
+**1. Model/Class Creation** — Split by method/field:
+- Subtask 1: Create file with skeleton
+- Subtask 2+: Add each field/method separately
+
+**2. API Endpoint** — Split by concern:
+- Create route file → endpoint skeleton → validation → business logic → error handling
+
+**3. Multi-File Feature** — Each file = one subtask (create → modify → delete order)
+
+**4. Testing** — Each test case = one subtask (happy path → error cases → edge cases)
+
+**5. Configuration + Implementation** — config → setup → implementation → integration
+
+### Subtask Generation Rules
+
+Each subtask MUST have:
+- 1-2 steps maximum (preferably 1)
+- Single clear objective completable in 5-10 minutes
+- No ambiguity or decisions left to the implementer
+
+**Naming:** Action verb + specific target (max 60 chars)
+- ✅ "Create User model file with base structure"
+- ❌ "Work on User model" (too vague)
+
+**Goal:** One sentence (30-80 chars) describing a specific outcome.
+
+**Steps:** 1-2 concrete actions with specific paths and names.
+
+### Distribute Task Attributes
+
+- **Prerequisites:** First subtask inherits all original prerequisites. Each subsequent subtask
+  depends on the previous one.
+- **Files:** Distribute 1 file per subtask where possible.
+- **done_when:** 1-2 specific verifiable conditions per subtask.
+- **code_examples:** Attach to the most relevant subtask.
+
+---
+
+## Step 4: Apply Changes — Remove Complex Tasks, Add Subtasks
+
+Remove each complex task, then add its subtasks:
+
+```bash
+# Remove complex tasks
+simpletask task remove [T00X] --format json
+
+# Add each subtask
+simpletask task add "[subtask name]" \
+  --goal "[specific outcome]" \
+  --steps "Step 1" "Step 2" \
+  --format json
+# Repeat for each subtask
+```
+
+> Note: Add all subtasks before removing complex tasks if their IDs are needed for prerequisites.
+
+---
+
+## Step 5: Renumber Task IDs Sequentially
+
+After all changes, task IDs may have gaps. Renumber sequentially (T001, T002, T003…):
+
+```bash
+# Read current state
+cat .tasks/$(git branch --show-current | sed 's|/|-|g').yml
+```
+
+Edit the YAML file directly to renumber IDs and update all prerequisite references:
+- Map old IDs → new sequential IDs
+- Update every `id:` field
+- Update every item in `prerequisites:` arrays
+
+```bash
+# Verify after editing
+simpletask schema validate --format json
+```
+
+---
+
+## Step 6: Validate and Report
+
+```bash
+simpletask schema validate --format json
+simpletask task list --flat --format json
+```
+
+Generate a split summary:
+
+```
+╭─────────────────────────────────────────────────────────────╮
+│ Task Splitting Complete                                     │
+╰─────────────────────────────────────────────────────────────╯
+
+ORIGINAL STATE
+  Total Tasks: X
+  Complex Tasks (>2 steps): Y
+  Atomic Tasks (kept as-is): Z
+
+SPLITTING RESULTS
+  Tasks Removed: Y
+  Subtasks Generated: N
+  New Total Tasks: M
+
+SPLIT DETAILS
+  ✓ T001 "Create User model" (4 steps)
+    → T001 "Create User model file with base structure" (1 step)
+    → T002 "Add User model fields" (1 step)
+    ...
+
+VALIDATION
+  Schema: ✓ Valid
+  Task IDs: ✓ Sequential
+  Prerequisites: ✓ All valid references
+
+───────────────────────────────────────────────────────────────
+READY FOR IMPLEMENTATION
+
+Next steps:
+  - Review split tasks: simpletask show
+  - Start implementation: /simpletask-implement
+───────────────────────────────────────────────────────────────
+```
+
+---
+
+## Edge Cases
+
+- **No complex tasks found:** Report "No complex tasks found. All tasks are already atomic." and stop.
+- **Multiple prerequisites:** First subtask inherits ALL; subsequent subtasks depend only on previous.
+- **Split creates >10 subtasks:** Proceed — add a warning: "⚠ Task 'X' split into 12+ subtasks".
+- **Long prerequisite chains:** Linear chains are expected and correct — do NOT try to parallelize.
+
+---
+
+## Rules
+
+- Do not use MCP tools. Use `simpletask` CLI commands and direct file reads only.
+- Always pass `--format json` to every simpletask CLI command.
+- Read task YAML files directly when CLI output is not detailed enough.
+- Do not modify code files — only the task file and codebase analysis are in scope.

--- a/tests/integration/test_ai_install_cli.py
+++ b/tests/integration/test_ai_install_cli.py
@@ -22,26 +22,30 @@ class TestAiInstallCLI:
     @patch("simpletask.commands.ai.install.get_global_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_qwen_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_gemini_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_pi_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_agents_dir")
-    def test_default_installs_all_four_editors(
+    def test_default_installs_all_five_editors(
         self,
         mock_agents_dir,
         mock_vibe_dir,
+        mock_pi_dir,
         mock_gemini_dir,
         mock_qwen_dir,
         mock_opencode_dir,
         tmp_path: Path,
     ):
-        """Should install all four editors (OpenCode, Qwen, Gemini, Vibe) by default."""
+        """Should install all five editors (OpenCode, Qwen, Gemini, Pi, Vibe) by default."""
         opencode_dir = tmp_path / "opencode"
         qwen_dir = tmp_path / "qwen"
         gemini_dir = tmp_path / "gemini"
+        pi_dir = tmp_path / "pi"
         vibe_dir = tmp_path / "vibe"
         agents_dir = tmp_path / "agents"
         mock_opencode_dir.return_value = opencode_dir
         mock_qwen_dir.return_value = qwen_dir
         mock_gemini_dir.return_value = gemini_dir
+        mock_pi_dir.return_value = pi_dir
         mock_vibe_dir.return_value = vibe_dir
         mock_agents_dir.return_value = agents_dir
 
@@ -51,9 +55,10 @@ class TestAiInstallCLI:
         assert "Installing OpenCode commands" in result.stdout
         assert "Installing Qwen commands" in result.stdout
         assert "Installing Gemini CLI commands" in result.stdout
+        assert "Installing Pi prompts" in result.stdout
         assert "Installing Mistral Vibe skills" in result.stdout
 
-        # Verify all four sets of files were created
+        # Verify all five sets of files were created
         assert (opencode_dir / "simpletask.plan.md").exists()
         assert (opencode_dir / "simpletask.implement.md").exists()
         assert (opencode_dir / "simpletask.review.md").exists()
@@ -63,6 +68,10 @@ class TestAiInstallCLI:
         assert (gemini_dir / "simpletask.plan.toml").exists()
         assert (gemini_dir / "simpletask.implement.toml").exists()
         assert (gemini_dir / "simpletask.review.toml").exists()
+        assert (pi_dir / "simpletask-implement.md").exists()
+        assert (pi_dir / "simpletask-plan.md").exists()
+        assert (pi_dir / "simpletask-split.md").exists()
+        assert (pi_dir / "simpletask-review.md").exists()
         assert (vibe_dir / "simpletask-plan").is_dir()
         assert (vibe_dir / "simpletask-plan" / "SKILL.md").exists()
 
@@ -332,14 +341,16 @@ class TestAiInstallAgentsCLI:
         assert (agents_dir / "simpletask-plan.md").exists()
 
     @patch("simpletask.commands.ai.install.get_global_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_pi_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_agents_dir")
     def test_default_install_includes_agents(
-        self, mock_agents_dir, mock_commands_dir, tmp_path: Path
+        self, mock_agents_dir, mock_pi_dir, mock_commands_dir, tmp_path: Path
     ):
         """Should install OpenCode agents by default when no flags specified."""
         commands_dir = tmp_path / "commands"
         agents_dir = tmp_path / "agents"
         mock_commands_dir.return_value = commands_dir
+        mock_pi_dir.return_value = tmp_path / "pi"
         mock_agents_dir.return_value = agents_dir
 
         result = runner.invoke(app, ["ai", "install"])
@@ -453,26 +464,30 @@ class TestAiInstallVibeCLI:
     @patch("simpletask.commands.ai.install.get_global_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_qwen_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_gemini_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_pi_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_agents_dir")
-    def test_default_installs_all_four_editors(
+    def test_default_installs_all_five_editors(
         self,
         mock_agents_dir,
         mock_vibe_dir,
+        mock_pi_dir,
         mock_gemini_dir,
         mock_qwen_dir,
         mock_opencode_dir,
         tmp_path: Path,
     ):
-        """Should install all four editors (including Vibe) by default."""
+        """Should install all five editors (including Pi and Vibe) by default."""
         opencode_dir = tmp_path / "opencode"
         qwen_dir = tmp_path / "qwen"
         gemini_dir = tmp_path / "gemini"
+        pi_dir = tmp_path / "pi"
         vibe_dir = tmp_path / "vibe"
         agents_dir = tmp_path / "agents"
         mock_opencode_dir.return_value = opencode_dir
         mock_qwen_dir.return_value = qwen_dir
         mock_gemini_dir.return_value = gemini_dir
+        mock_pi_dir.return_value = pi_dir
         mock_vibe_dir.return_value = vibe_dir
         mock_agents_dir.return_value = agents_dir
 
@@ -482,9 +497,12 @@ class TestAiInstallVibeCLI:
         assert "Installing OpenCode commands" in result.stdout
         assert "Installing Qwen commands" in result.stdout
         assert "Installing Gemini CLI commands" in result.stdout
+        assert "Installing Pi prompts" in result.stdout
         assert "Installing Mistral Vibe skills" in result.stdout
 
-        # Verify Vibe skill directories were created
+        # Verify Pi and Vibe files were created
+        assert (pi_dir / "simpletask-implement.md").exists()
+        assert (pi_dir / "simpletask-plan.md").exists()
         assert (vibe_dir / "simpletask-plan").is_dir()
         assert (vibe_dir / "simpletask-plan" / "SKILL.md").exists()
 
@@ -563,12 +581,14 @@ class TestInstallEditorDetection:
     @patch("simpletask.commands.ai.install.get_global_qwen_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_gemini_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_pi_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_agents_dir")
     @patch("simpletask.commands.ai.install.is_editor_installed", return_value=False)
     def test_default_skips_missing_editors(
         self,
         mock_installed,
         mock_agents_dir,
+        mock_pi_dir,
         mock_vibe_dir,
         mock_gemini_dir,
         mock_qwen_dir,
@@ -581,6 +601,7 @@ class TestInstallEditorDetection:
             (mock_qwen_dir, "qwen"),
             (mock_gemini_dir, "gemini"),
             (mock_vibe_dir, "vibe"),
+            (mock_pi_dir, "pi"),
             (mock_agents_dir, "agents"),
         ]:
             mock.return_value = tmp_path / name
@@ -594,6 +615,7 @@ class TestInstallEditorDetection:
         assert not (tmp_path / "qwen").exists()
         assert not (tmp_path / "gemini").exists()
         assert not (tmp_path / "vibe").exists()
+        assert not (tmp_path / "pi").exists()
 
     @patch("simpletask.commands.ai.install.get_global_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_agents_dir")
@@ -638,12 +660,14 @@ class TestInstallEditorDetection:
     @patch("simpletask.commands.ai.install.get_local_qwen_commands_dir")
     @patch("simpletask.commands.ai.install.get_local_gemini_commands_dir")
     @patch("simpletask.commands.ai.install.get_local_vibe_commands_dir")
+    @patch("simpletask.commands.ai.install.get_local_pi_commands_dir")
     @patch("simpletask.commands.ai.install.get_local_agents_dir")
     @patch("simpletask.commands.ai.install.is_editor_installed", return_value=False)
     def test_local_flag_bypasses_detection(
         self,
         mock_installed,
         mock_agents_dir,
+        mock_pi_dir,
         mock_vibe_dir,
         mock_gemini_dir,
         mock_qwen_dir,
@@ -656,6 +680,7 @@ class TestInstallEditorDetection:
             (mock_qwen_dir, "qwen"),
             (mock_gemini_dir, "gemini"),
             (mock_vibe_dir, "vibe"),
+            (mock_pi_dir, "pi"),
             (mock_agents_dir, "agents"),
         ]:
             mock.return_value = tmp_path / name
@@ -667,17 +692,20 @@ class TestInstallEditorDetection:
         assert (tmp_path / "qwen" / "simpletask.plan.md").exists()
         assert (tmp_path / "gemini" / "simpletask.plan.toml").exists()
         assert (tmp_path / "vibe" / "simpletask-plan").is_dir()
+        assert (tmp_path / "pi" / "simpletask-plan.md").exists()
 
     @patch("simpletask.commands.ai.install.get_global_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_qwen_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_gemini_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_pi_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_agents_dir")
     @patch("simpletask.commands.ai.install.is_editor_installed", return_value=True)
     def test_default_installs_all_detected_editors(
         self,
         mock_installed,
         mock_agents_dir,
+        mock_pi_dir,
         mock_vibe_dir,
         mock_gemini_dir,
         mock_qwen_dir,
@@ -690,6 +718,7 @@ class TestInstallEditorDetection:
             (mock_qwen_dir, "qwen"),
             (mock_gemini_dir, "gemini"),
             (mock_vibe_dir, "vibe"),
+            (mock_pi_dir, "pi"),
             (mock_agents_dir, "agents"),
         ]:
             mock.return_value = tmp_path / name
@@ -701,3 +730,126 @@ class TestInstallEditorDetection:
         assert (tmp_path / "qwen" / "simpletask.plan.md").exists()
         assert (tmp_path / "gemini" / "simpletask.plan.toml").exists()
         assert (tmp_path / "vibe" / "simpletask-plan").is_dir()
+        assert (tmp_path / "pi" / "simpletask-plan.md").exists()
+
+
+class TestAiInstallPiCLI:
+    """Integration tests for Pi prompt installation via 'simpletask ai install'."""
+
+    @patch("simpletask.commands.ai.install.get_global_pi_commands_dir")
+    def test_pi_flag_only(self, mock_pi_dir, tmp_path: Path):
+        """Should install only Pi prompt with --pi flag."""
+        pi_dir = tmp_path / "pi"
+        mock_pi_dir.return_value = pi_dir
+
+        result = runner.invoke(app, ["ai", "install", "--pi"])
+
+        assert result.exit_code == 0
+        assert "Installing Pi prompts" in result.stdout
+        assert "Installing OpenCode commands" not in result.stdout
+        assert "Installing Qwen commands" not in result.stdout
+        assert "Installing Gemini CLI commands" not in result.stdout
+        assert "Installing Mistral Vibe skills" not in result.stdout
+        assert "Installing OpenCode agents" not in result.stdout
+
+        assert (pi_dir / "simpletask-implement.md").exists()
+        assert (pi_dir / "simpletask-plan.md").exists()
+        assert (pi_dir / "simpletask-split.md").exists()
+        assert (pi_dir / "simpletask-review.md").exists()
+
+    @patch("simpletask.commands.ai.install.get_local_pi_commands_dir")
+    def test_pi_local_flag(self, mock_pi_dir, tmp_path: Path):
+        """Should install Pi prompt to local directory with --local flag."""
+        pi_dir = tmp_path / "pi_local"
+        mock_pi_dir.return_value = pi_dir
+
+        result = runner.invoke(app, ["ai", "install", "--pi", "--local"])
+
+        assert result.exit_code == 0
+        assert "Installing Pi prompts" in result.stdout
+        assert str(pi_dir) in result.stdout
+        assert (pi_dir / "simpletask-implement.md").exists()
+        assert (pi_dir / "simpletask-plan.md").exists()
+        assert (pi_dir / "simpletask-split.md").exists()
+        assert (pi_dir / "simpletask-review.md").exists()
+
+    @patch("simpletask.commands.ai.install.get_global_pi_commands_dir")
+    def test_pi_no_overwrite_skips_existing(self, mock_pi_dir, tmp_path: Path):
+        """Should skip existing Pi prompt when --no-overwrite is used."""
+        pi_dir = tmp_path / "pi"
+        pi_dir.mkdir(parents=True)
+        mock_pi_dir.return_value = pi_dir
+
+        existing = pi_dir / "simpletask-implement.md"
+        existing.write_text("old content")
+
+        result = runner.invoke(app, ["ai", "install", "--pi", "--no-overwrite"])
+
+        assert result.exit_code == 0
+        assert "Skipped (already exists): simpletask-implement.md" in result.stdout
+        assert existing.read_text() == "old content"
+
+    @patch("simpletask.commands.ai.install.get_global_pi_commands_dir")
+    def test_pi_overwrite_default(self, mock_pi_dir, tmp_path: Path):
+        """Should overwrite existing Pi prompt by default."""
+        pi_dir = tmp_path / "pi"
+        pi_dir.mkdir(parents=True)
+        mock_pi_dir.return_value = pi_dir
+
+        existing = pi_dir / "simpletask-implement.md"
+        existing.write_text("old content")
+
+        result = runner.invoke(app, ["ai", "install", "--pi"])
+
+        assert result.exit_code == 0
+        assert "Overwriting: simpletask-implement.md" in result.stdout
+        assert existing.read_text() != "old content"
+
+    @patch("simpletask.commands.ai.list.get_bundled_pi_templates")
+    @patch("simpletask.commands.ai.list.get_pi_installed_status")
+    @patch("simpletask.commands.ai.list.get_global_pi_commands_dir")
+    @patch("simpletask.commands.ai.list.get_local_pi_commands_dir")
+    def test_ai_list_shows_pi_section(
+        self,
+        mock_local_pi_dir,
+        mock_global_pi_dir,
+        mock_pi_status,
+        mock_pi_templates,
+        tmp_path: Path,
+    ):
+        """ai list should render Pi prompt status and locations."""
+        pi_template = tmp_path / "simpletask-implement.md"
+        pi_template.write_text("content")
+
+        mock_pi_templates.return_value = [pi_template]
+        mock_pi_status.return_value = {"simpletask-implement.md": {"global": True, "local": False}}
+        mock_global_pi_dir.return_value = tmp_path / "global_pi"
+        mock_local_pi_dir.return_value = tmp_path / "local_pi"
+
+        result = runner.invoke(app, ["ai", "list"])
+
+        assert result.exit_code == 0
+        assert "Pi Prompts" in result.stdout
+        assert "simpletask-implement" in result.stdout
+        assert str(tmp_path / "global_pi") in result.stdout
+        assert str(tmp_path / "local_pi") in result.stdout
+
+
+class TestPiInstallBehavior:
+    """Tests verifying Pi install behavior and path resolution."""
+
+    @patch("simpletask.commands.ai.install.get_global_pi_commands_dir")
+    def test_pi_flag_installs_pi_only(self, mock_pi_dir, tmp_path: Path):
+        """--pi flag installs only Pi templates, not other editors."""
+        pi_dir = tmp_path / "pi"
+        mock_pi_dir.return_value = pi_dir
+
+        result = runner.invoke(app, ["ai", "install", "--pi"])
+
+        assert result.exit_code == 0
+        assert "Installing Pi prompts" in result.stdout
+        assert pi_dir.exists()
+        assert (pi_dir / "simpletask-implement.md").exists()
+        # No OpenCode/Qwen/Gemini dirs created
+        assert not (tmp_path / "opencode").exists()
+        assert not (tmp_path / "qwen").exists()

--- a/tests/unit/test_ai_commands.py
+++ b/tests/unit/test_ai_commands.py
@@ -7,6 +7,7 @@ from simpletask.core.ai_templates import (
     get_agents_installed_status,
     get_bundled_agents,
     get_bundled_gemini_templates,
+    get_bundled_pi_templates,
     get_bundled_qwen_templates,
     get_bundled_templates,
     get_bundled_vibe_templates,
@@ -15,18 +16,22 @@ from simpletask.core.ai_templates import (
     get_global_agents_dir,
     get_global_commands_dir,
     get_global_gemini_commands_dir,
+    get_global_pi_commands_dir,
     get_global_qwen_commands_dir,
     get_global_vibe_commands_dir,
     get_installed_status,
     get_local_agents_dir,
     get_local_commands_dir,
     get_local_gemini_commands_dir,
+    get_local_pi_commands_dir,
     get_local_qwen_commands_dir,
     get_local_vibe_commands_dir,
+    get_pi_installed_status,
     get_qwen_installed_status,
     get_vibe_installed_status,
     install_agents,
     install_gemini_templates,
+    install_pi_templates,
     install_qwen_templates,
     install_templates,
     install_vibe_templates,
@@ -566,6 +571,35 @@ class TestGetBundledGeminiTemplates:
         assert template_names == expected
 
 
+class TestGetBundledPiTemplates:
+    """Tests for get_bundled_pi_templates function."""
+
+    def test_returns_list_of_paths(self):
+        """Should return a list of Path objects."""
+        templates = get_bundled_pi_templates()
+        assert isinstance(templates, list)
+        for template in templates:
+            assert isinstance(template, Path)
+
+    def test_returns_only_md_files(self):
+        """Should return only .md files."""
+        templates = get_bundled_pi_templates()
+        for template in templates:
+            assert template.suffix == ".md"
+
+    def test_returns_expected_templates(self):
+        """Should return all 4 bundled Pi prompt templates."""
+        templates = get_bundled_pi_templates()
+        template_names = {t.name for t in templates}
+
+        assert template_names == {
+            "simpletask-implement.md",
+            "simpletask-plan.md",
+            "simpletask-split.md",
+            "simpletask-review.md",
+        }
+
+
 class TestGetGlobalGeminiCommandsDir:
     """Tests for get_global_gemini_commands_dir function."""
 
@@ -593,6 +627,36 @@ class TestGetLocalGeminiCommandsDir:
         """Should return .gemini/commands/ in current directory."""
         result = get_local_gemini_commands_dir()
         expected = Path.cwd() / ".gemini" / "commands"
+        assert result == expected
+
+
+class TestGetGlobalPiCommandsDir:
+    """Tests for get_global_pi_commands_dir function."""
+
+    def test_returns_path_object(self):
+        """Should return a Path object."""
+        result = get_global_pi_commands_dir()
+        assert isinstance(result, Path)
+
+    def test_returns_expected_location(self):
+        """Should return ~/.pi/agent/prompts/."""
+        result = get_global_pi_commands_dir()
+        expected = Path.home() / ".pi" / "agent" / "prompts"
+        assert result == expected
+
+
+class TestGetLocalPiCommandsDir:
+    """Tests for get_local_pi_commands_dir function."""
+
+    def test_returns_path_object(self):
+        """Should return a Path object."""
+        result = get_local_pi_commands_dir()
+        assert isinstance(result, Path)
+
+    def test_returns_expected_location(self):
+        """Should return .pi/prompts/ in current directory."""
+        result = get_local_pi_commands_dir()
+        expected = Path.cwd() / ".pi" / "prompts"
         assert result == expected
 
 
@@ -780,6 +844,188 @@ class TestGetGeminiInstalledStatus:
         for _template_name, locations in status.items():
             assert locations["global"] is True
             assert locations["local"] is True
+
+
+class TestInstallPiTemplates:
+    """Tests for install_pi_templates function."""
+
+    def test_install_to_empty_directory(self, tmp_path: Path):
+        """Should successfully install all 4 Pi prompts to empty directory."""
+        target_dir = tmp_path / "prompts"
+
+        installed, skipped, overwritten = install_pi_templates(target_dir, no_overwrite=False)
+
+        assert target_dir.exists()
+        assert set(installed) == {
+            "simpletask-implement.md",
+            "simpletask-plan.md",
+            "simpletask-split.md",
+            "simpletask-review.md",
+        }
+        assert skipped == []
+        assert overwritten == []
+        assert (target_dir / "simpletask-implement.md").exists()
+        assert (target_dir / "simpletask-plan.md").exists()
+        assert (target_dir / "simpletask-split.md").exists()
+        assert (target_dir / "simpletask-review.md").exists()
+
+    def test_overwrite_existing_files(self, tmp_path: Path):
+        """Should overwrite existing Pi prompt when no_overwrite=False."""
+        target_dir = tmp_path / "prompts"
+        target_dir.mkdir(parents=True)
+
+        existing_file = target_dir / "simpletask-implement.md"
+        existing_file.write_text("old content")
+
+        installed, _skipped, overwritten = install_pi_templates(target_dir, no_overwrite=False)
+
+        assert "simpletask-implement.md" in overwritten
+        assert "simpletask-implement.md" not in installed
+        assert existing_file.read_text() != "old content"
+        # Other 3 templates are freshly installed
+        assert set(installed) == {
+            "simpletask-plan.md",
+            "simpletask-split.md",
+            "simpletask-review.md",
+        }
+
+    def test_no_overwrite_skips_existing(self, tmp_path: Path):
+        """Should skip existing Pi prompt when no_overwrite=True."""
+        target_dir = tmp_path / "prompts"
+        target_dir.mkdir(parents=True)
+
+        existing_file = target_dir / "simpletask-implement.md"
+        existing_file.write_text("old content")
+
+        installed, skipped, overwritten = install_pi_templates(target_dir, no_overwrite=True)
+
+        assert "simpletask-implement.md" in skipped
+        assert overwritten == []
+        assert existing_file.read_text() == "old content"
+        # Other 3 templates are freshly installed
+        assert set(installed) == {
+            "simpletask-plan.md",
+            "simpletask-split.md",
+            "simpletask-review.md",
+        }
+
+    def test_creates_target_directory(self, tmp_path: Path):
+        """Should create target directory if it doesn't exist."""
+        target_dir = tmp_path / "nested" / "path" / "prompts"
+
+        assert not target_dir.exists()
+
+        install_pi_templates(target_dir, no_overwrite=False)
+
+        assert target_dir.exists()
+        assert target_dir.is_dir()
+
+
+class TestGetPiInstalledStatus:
+    """Tests for get_pi_installed_status function."""
+
+    def test_no_installations(self, tmp_path: Path, monkeypatch):
+        """Should report nothing installed when directories don't exist."""
+        fake_global = tmp_path / "global"
+        fake_local = tmp_path / "local"
+
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_global_commands_dir",
+            lambda editor: fake_global,
+        )
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_local_commands_dir",
+            lambda editor: fake_local,
+        )
+
+        status = get_pi_installed_status()
+
+        assert status == {
+            "simpletask-implement.md": {"global": False, "local": False},
+            "simpletask-plan.md": {"global": False, "local": False},
+            "simpletask-split.md": {"global": False, "local": False},
+            "simpletask-review.md": {"global": False, "local": False},
+        }
+
+    def test_global_only(self, tmp_path: Path, monkeypatch):
+        """Should detect Pi prompt in global directory only."""
+        fake_global = tmp_path / "global"
+        fake_global.mkdir(parents=True)
+        fake_local = tmp_path / "local"
+
+        install_pi_templates(fake_global, no_overwrite=False)
+
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_global_commands_dir",
+            lambda editor: fake_global,
+        )
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_local_commands_dir",
+            lambda editor: fake_local,
+        )
+
+        status = get_pi_installed_status()
+
+        assert status == {
+            "simpletask-implement.md": {"global": True, "local": False},
+            "simpletask-plan.md": {"global": True, "local": False},
+            "simpletask-split.md": {"global": True, "local": False},
+            "simpletask-review.md": {"global": True, "local": False},
+        }
+
+    def test_local_only(self, tmp_path: Path, monkeypatch):
+        """Should detect Pi prompt in local directory only."""
+        fake_global = tmp_path / "global"
+        fake_local = tmp_path / "local"
+        fake_local.mkdir(parents=True)
+
+        install_pi_templates(fake_local, no_overwrite=False)
+
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_global_commands_dir",
+            lambda editor: fake_global,
+        )
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_local_commands_dir",
+            lambda editor: fake_local,
+        )
+
+        status = get_pi_installed_status()
+
+        assert status == {
+            "simpletask-implement.md": {"global": False, "local": True},
+            "simpletask-plan.md": {"global": False, "local": True},
+            "simpletask-split.md": {"global": False, "local": True},
+            "simpletask-review.md": {"global": False, "local": True},
+        }
+
+    def test_both_locations(self, tmp_path: Path, monkeypatch):
+        """Should detect Pi prompt in both directories."""
+        fake_global = tmp_path / "global"
+        fake_global.mkdir(parents=True)
+        fake_local = tmp_path / "local"
+        fake_local.mkdir(parents=True)
+
+        install_pi_templates(fake_global, no_overwrite=False)
+        install_pi_templates(fake_local, no_overwrite=False)
+
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_global_commands_dir",
+            lambda editor: fake_global,
+        )
+        monkeypatch.setattr(
+            "simpletask.core.ai_templates._get_local_commands_dir",
+            lambda editor: fake_local,
+        )
+
+        status = get_pi_installed_status()
+
+        assert status == {
+            "simpletask-implement.md": {"global": True, "local": True},
+            "simpletask-plan.md": {"global": True, "local": True},
+            "simpletask-split.md": {"global": True, "local": True},
+            "simpletask-review.md": {"global": True, "local": True},
+        }
 
 
 class TestGeminiAndQwenTemplateDifferences:
@@ -1177,6 +1423,141 @@ class TestCrossEditorConsistency:
         assert "branch=None" not in opencode_content, "OpenCode has branch=None"
         assert "branch=None" not in qwen_content, "Qwen has branch=None"
         assert "branch=None" not in gemini_content, "Gemini has branch=None"
+
+
+class TestPiTemplateContent:
+    """Validate Pi template content structure and CLI-first instructions."""
+
+    def test_pi_implement_template_has_frontmatter(self):
+        """Pi implement template should have markdown frontmatter."""
+        templates = get_bundled_pi_templates()
+        impl_template = next((t for t in templates if t.name == "simpletask-implement.md"), None)
+        assert impl_template is not None
+
+        content = impl_template.read_text()
+
+        assert content.startswith("---\n")
+        assert "description:" in content
+        assert "argument-hint:" in content
+        assert "\n---\n" in content
+
+    def test_pi_implement_template_references_cli_commands(self):
+        """Pi implement template should drive simpletask through CLI commands."""
+        templates = get_bundled_pi_templates()
+        impl_template = next((t for t in templates if t.name == "simpletask-implement.md"), None)
+        assert impl_template is not None
+
+        content = impl_template.read_text()
+
+        required_commands = [
+            "simpletask show",
+            "simpletask task list --flat",
+            "simpletask criteria list",
+            "simpletask quality show",
+            "simpletask task update T001 --status in_progress",
+            "simpletask quality check --format json",
+            "simpletask criteria complete AC1",
+            "simpletask schema validate",
+        ]
+
+        for command in required_commands:
+            assert command in content, f"Missing CLI command reference: {command}"
+
+    def test_pi_implement_template_does_not_reference_mcp_tools(self):
+        """Pi implement template should not rely on MCP tool references."""
+        templates = get_bundled_pi_templates()
+        impl_template = next((t for t in templates if t.name == "simpletask-implement.md"), None)
+        assert impl_template is not None
+
+        content = impl_template.read_text()
+
+        mcp_tools = [
+            "simpletask_get",
+            "simpletask_task",
+            "simpletask_criteria",
+            "simpletask_note",
+            "simpletask_quality",
+        ]
+
+        for tool in mcp_tools:
+            assert tool not in content, f"Unexpected MCP tool reference: {tool}"
+
+    def test_pi_implement_template_uses_show_for_task_detail(self):
+        """Pi implement template should use simpletask show --format json for full task detail."""
+        templates = get_bundled_pi_templates()
+        impl_template = next((t for t in templates if t.name == "simpletask-implement.md"), None)
+        assert impl_template is not None
+
+        content = impl_template.read_text()
+
+        assert "simpletask show --format json" in content
+        assert "full task detail" in content
+
+    def test_pi_implement_template_treats_invocation_as_work_request(self):
+        """Pi implement template should treat the prompt invocation as the implementation request."""
+        templates = get_bundled_pi_templates()
+        impl_template = next((t for t in templates if t.name == "simpletask-implement.md"), None)
+        assert impl_template is not None
+
+        content = impl_template.read_text()
+
+        assert "Invoking `/simpletask-implement` is itself the user's request" in content
+        assert "treat the current branch task file as the work to" in content
+        assert 'Do not wait for the user to provide a "first task"' in content
+
+    def test_pi_implement_template_forbids_acknowledgement_only_replies(self):
+        """Pi implement template should forbid acknowledgement-only replies."""
+        templates = get_bundled_pi_templates()
+        impl_template = next((t for t in templates if t.name == "simpletask-implement.md"), None)
+        assert impl_template is not None
+
+        content = impl_template.read_text()
+
+        assert "Do not reply with an acknowledgement-only message" in content
+        assert '"Understood"' in content
+        assert '"please provide the first task"' in content
+
+    def test_pi_implement_template_handles_read_only_plan_mode(self):
+        """Pi implement template should tell Pi what to do when a plan-mode extension is active."""
+        templates = get_bundled_pi_templates()
+        impl_template = next((t for t in templates if t.name == "simpletask-implement.md"), None)
+        assert impl_template is not None
+
+        content = impl_template.read_text()
+
+        assert "If a system reminder says plan mode or read-only mode is active" in content
+        assert "respond with `Plan:` followed by a" in content
+        assert "Choose Execute the plan to continue." in content
+        assert "do not insist on `simpletask` CLI if it is blocked" in content
+
+
+class TestEditorConfigPiEntry:
+    """Tests for Pi entry in EDITOR_CONFIGS."""
+
+    def test_pi_config_exists(self):
+        """Pi should have an entry in EDITOR_CONFIGS."""
+        from simpletask.core.ai_templates import EDITOR_CONFIGS
+
+        assert "pi" in EDITOR_CONFIGS
+
+    def test_pi_is_not_directory_based(self):
+        """Pi config should be treated as flat-file prompts."""
+        from simpletask.core.ai_templates import EDITOR_CONFIGS
+
+        assert EDITOR_CONFIGS["pi"].is_directory_based is False
+
+    def test_pi_display_name(self):
+        """Pi should have correct display name."""
+        from simpletask.core.ai_templates import EDITOR_CONFIGS
+
+        assert EDITOR_CONFIGS["pi"].display_name == "Pi"
+
+    def test_pi_has_no_agent_support(self):
+        """Pi should not have agent directories configured."""
+        from simpletask.core.ai_templates import EDITOR_CONFIGS
+
+        assert EDITOR_CONFIGS["pi"].global_agents_dir is None
+        assert EDITOR_CONFIGS["pi"].local_agents_dir is None
 
     def test_all_split_templates_reference_same_mcp_tools(self):
         """All split templates should reference the same core MCP tools."""


### PR DESCRIPTION
## Summary

- Add `--pi` flag to `simpletask ai install` and `simpletask ai list` with Pi's global (`~/.pi/agent/prompts/`) and local (`.pi/prompts/`) prompt directories
- Bundle four Pi prompt templates (plan, split, implement, review) that drive `simpletask` through CLI commands and direct task-file reads — no MCP tools required
- Wire Pi through the same editor detection logic (`_should_install`) as OpenCode, Qwen, Gemini, and Vibe: skips if `~/.pi/` is absent, prompts the user when `--pi` is passed explicitly, bypasses detection with `--local`
- Add `global_base_dir=(".pi",)` to Pi's `EditorConfig` so `is_editor_installed("pi")` checks `~/.pi/` rather than falling back to home directory (which is always true)
- Document Pi support in README alongside the other supported editors
- Add comprehensive Pi coverage: 8 unit test classes in `test_ai_commands.py` and extended `TestInstallEditorDetection` integration tests

## Changes

| File | What changed |
|------|-------------|
| `cli/simpletask/commands/ai/install.py` | `--pi` flag, `pi_explicit` tracking, `_should_install("pi", ...)` gate |
| `cli/simpletask/commands/ai/list.py` | Pi section in `simpletask ai list` output |
| `cli/simpletask/core/ai_templates.py` | Pi `EditorConfig` with `global_base_dir`, Pi-specific helper functions |
| `cli/simpletask/templates/pi/` | Four new prompt templates (plan, split, implement, review) |
| `README.md` | Pi installation and workflow documentation |
| `tests/unit/test_ai_commands.py` | Unit tests for Pi config, template functions, content, and installed-status |
| `tests/integration/test_ai_install_cli.py` | Pi integration tests + Pi assertions in `TestInstallEditorDetection` |