### PR TITLE
feat(cli): add --format json to all read and write CLI commands

### DIFF
--- a/cli/simpletask/__init__.py
+++ b/cli/simpletask/__init__.py
@@ -1,6 +1,6 @@
 """simpletask: A Python CLI for managing AI-friendly task definition YAML files."""
 
-__version__ = "0.35.11"
+__version__ = "0.35.13"
 
 import typer
 

--- a/cli/simpletask/commands/constraint/add.py
+++ b/cli/simpletask/commands/constraint/add.py
@@ -1,29 +1,60 @@
 """Add constraint command."""
 
+from typing import Annotated
+
 import typer
 
-from simpletask.core.yaml_parser import InvalidTaskFileError
-from simpletask.mcp.server import constraint
+from simpletask.core.constraint_ops import add_constraint
+from simpletask.core.project import get_task_file_path
+from simpletask.core.yaml_parser import InvalidTaskFileError, parse_task_file, write_task_file
 from simpletask.utils.console import handle_exception, success
+from simpletask.utils.output import OutputFormat, json_error, json_success, resolve_format
 
 
 def add_command(
     value: str = typer.Argument(..., help="Constraint description"),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
 ) -> None:
     """Add an implementation constraint.
 
     Examples:
         simpletask constraint add "Use Pydantic models with extra='forbid'"
         simpletask constraint add "No shell=True in subprocess calls"
+
+    Raises:
+        ValueError: If not in a git repository or branch cannot be determined
+        FileNotFoundError: If task file doesn't exist for the specified branch
+        InvalidTaskFileError: If task file is malformed and cannot be parsed
     """
     try:
-        # Call MCP tool directly
-        constraint(
-            action="add",
-            value=value,
-        )
+        # Resolve format
+        format = resolve_format(format)
 
-        success("Added constraint")
+        file_path = get_task_file_path(None)
+        spec = parse_task_file(file_path)
+        spec = add_constraint(spec=spec, value=value)
+        write_task_file(file_path, spec)
+
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            total_count = len(spec.constraints) if spec.constraints else 0
+            json_success(
+                {
+                    "success": True,
+                    "action": "constraint_added",
+                    "message": "Added constraint",
+                    "summary": {"constraints_total": total_count},
+                }
+            )
+        else:
+            success("Added constraint")
 
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "adding constraint")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "adding constraint")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/constraint/remove.py
+++ b/cli/simpletask/commands/constraint/remove.py
@@ -1,34 +1,64 @@
 """Remove constraint command."""
 
+from typing import Annotated
+
 import typer
 
-from simpletask.core.yaml_parser import InvalidTaskFileError
-from simpletask.mcp.server import constraint
+from simpletask.core.constraint_ops import remove_constraint
+from simpletask.core.project import get_task_file_path
+from simpletask.core.yaml_parser import InvalidTaskFileError, parse_task_file, write_task_file
 from simpletask.utils.console import handle_exception, success
+from simpletask.utils.output import OutputFormat, json_error, json_success, resolve_format
 
 
 def remove_command(
     index: int | None = typer.Argument(None, help="Constraint index to remove (0-based)"),
     all: bool = typer.Option(False, "--all", "-a", help="Remove all constraints"),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
 ) -> None:
     """Remove a constraint.
 
     Examples:
         simpletask constraint remove 0
         simpletask constraint remove --all
+
+    Raises:
+        ValueError: If not in a git repository or branch cannot be determined
+        FileNotFoundError: If task file doesn't exist for the specified branch
+        InvalidTaskFileError: If task file is malformed and cannot be parsed
     """
     try:
-        # Call MCP tool directly
-        constraint(
-            action="remove",
-            index=index,
-            all=all,
-        )
+        # Resolve format
+        format = resolve_format(format)
 
-        if all:
-            success("Removed all constraints")
+        file_path = get_task_file_path(None)
+        spec = parse_task_file(file_path)
+        spec = remove_constraint(spec=spec, index=index, all=all)
+        write_task_file(file_path, spec)
+
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            total_count = len(spec.constraints) if spec.constraints else 0
+            json_success(
+                {
+                    "success": True,
+                    "action": "constraint_removed",
+                    "message": "Removed constraint",
+                    "summary": {"constraints_total": total_count},
+                }
+            )
         else:
-            success(f"Removed constraint {index}")
+            if all:
+                success("Removed all constraints")
+            else:
+                success(f"Removed constraint {index}")
 
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "removing constraint")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "removing constraint")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/context/remove.py
+++ b/cli/simpletask/commands/context/remove.py
@@ -1,34 +1,67 @@
 """Remove context command."""
 
+from typing import Annotated
+
 import typer
 
-from simpletask.core.yaml_parser import InvalidTaskFileError
-from simpletask.mcp.server import context
+from simpletask.core.context_ops import remove_context
+from simpletask.core.project import get_task_file_path
+from simpletask.core.yaml_parser import InvalidTaskFileError, parse_task_file, write_task_file
 from simpletask.utils.console import handle_exception, success
+from simpletask.utils.output import OutputFormat, json_error, json_success, resolve_format
 
 
 def remove_command(
     key: str | None = typer.Argument(None, help="Context key to remove"),
     all: bool = typer.Option(False, "--all", "-a", help="Remove all context entries"),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
+    branch: str | None = typer.Option(
+        None, "--branch", "-b", help="Branch name (defaults to current git branch)"
+    ),
 ) -> None:
     """Remove a context key or all entries.
 
     Examples:
         simpletask context remove framework
         simpletask context remove --all
+
+    Raises:
+        ValueError: If not in a git repository or branch cannot be determined
+        FileNotFoundError: If task file doesn't exist for the specified branch
+        InvalidTaskFileError: If task file is malformed and cannot be parsed
     """
     try:
-        # Call MCP tool directly
-        context(
-            action="remove",
-            key=key,
-            all=all,
-        )
+        # Resolve format
+        format = resolve_format(format)
 
-        if all:
-            success("Removed all context entries")
+        file_path = get_task_file_path(branch)
+        spec = parse_task_file(file_path)
+        spec = remove_context(spec=spec, key=key, all=all)
+        write_task_file(file_path, spec)
+
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            total_count = len(spec.context) if spec.context else 0
+            json_success(
+                {
+                    "success": True,
+                    "action": "context_removed",
+                    "message": "Removed context",
+                    "summary": {"context_total": total_count},
+                }
+            )
         else:
-            success(f"Removed context key '{key}'")
+            if all:
+                success("Removed all context entries")
+            else:
+                success(f"Removed context key '{key}'")
 
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "removing context")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "removing context")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/context/set.py
+++ b/cli/simpletask/commands/context/set.py
@@ -1,31 +1,66 @@
 """Set context command."""
 
+from typing import Annotated
+
 import typer
 
-from simpletask.core.yaml_parser import InvalidTaskFileError
-from simpletask.mcp.server import context
+from simpletask.core.context_ops import set_context
+from simpletask.core.project import get_task_file_path
+from simpletask.core.yaml_parser import InvalidTaskFileError, parse_task_file, write_task_file
 from simpletask.utils.console import handle_exception, success
+from simpletask.utils.output import OutputFormat, json_error, json_success, resolve_format
 
 
 def set_command(
     key: str = typer.Argument(..., help="Context key"),
     value: str = typer.Argument(..., help="Context value"),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
+    branch: str | None = typer.Option(
+        None, "--branch", "-b", help="Branch name (defaults to current git branch)"
+    ),
 ) -> None:
     """Set a context key-value pair.
 
     Examples:
         simpletask context set framework django
         simpletask context set database postgresql
+
+    Raises:
+        ValueError: If not in a git repository or branch cannot be determined
+        FileNotFoundError: If task file doesn't exist for the specified branch
+        InvalidTaskFileError: If task file is malformed and cannot be parsed
     """
     try:
-        # Call MCP tool directly
-        context(
-            action="set",
-            key=key,
-            value=value,
-        )
+        # Resolve format
+        format = resolve_format(format)
 
-        success(f"Set context key '{key}'")
+        file_path = get_task_file_path(branch)
+        spec = parse_task_file(file_path)
+        spec = set_context(spec=spec, key=key, value=value)
+        write_task_file(file_path, spec)
+
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            total_count = len(spec.context) if spec.context else 0
+            json_success(
+                {
+                    "success": True,
+                    "action": "context_set",
+                    "key": key,
+                    "value": value,
+                    "message": f"Set context key '{key}'",
+                    "summary": {"context_total": total_count},
+                }
+            )
+        else:
+            success(f"Set context key '{key}'")
 
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "setting context")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "setting context")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/criteria/add.py
+++ b/cli/simpletask/commands/criteria/add.py
@@ -1,15 +1,47 @@
 """Add acceptance criterion command."""
 
+from typing import Annotated
+
 import typer
 
 from simpletask.core.criteria_ops import add_acceptance_criterion
 from simpletask.core.project import get_task_file_path
 from simpletask.core.yaml_parser import InvalidTaskFileError
 from simpletask.utils.console import handle_exception, success
+from simpletask.utils.output import (
+    OutputFormat,
+    build_write_response,
+    json_error,
+    json_success,
+    resolve_format,
+)
+
+
+def _print_json_criterion_add(criterion_id: str, file_path: str, spec) -> None:
+    """Print criterion add result as JSON.
+
+    Args:
+        criterion_id: The new criterion ID
+        file_path: Path to the task file
+        spec: The updated task spec
+    """
+    json_success(
+        build_write_response(
+            "criterion_added",
+            f"Added criterion {criterion_id}",
+            spec,
+            file_path,
+            criterion_id=criterion_id,
+        )
+    )
 
 
 def add_command(
     description: str = typer.Argument(..., help="Criterion description"),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
     branch: str | None = typer.Option(
         None, "--branch", "-b", help="Branch name (defaults to current git branch)"
     ),
@@ -26,11 +58,22 @@ def add_command(
         InvalidTaskFileError: If task file is malformed and cannot be parsed
     """
     try:
+        # Resolve format
+        format = resolve_format(format)
+
         # Resolve task file path
         file_path = get_task_file_path(branch)
-        new_id, _ = add_acceptance_criterion(file_path, description)
+        new_id, spec = add_acceptance_criterion(file_path, description)
 
-        success(f"Added criterion {new_id}: {description}")
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            _print_json_criterion_add(new_id, str(file_path), spec)
+        else:
+            success(f"Added criterion {new_id}: {description}")
 
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "adding acceptance criterion")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "adding acceptance criterion")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/criteria/complete.py
+++ b/cli/simpletask/commands/criteria/complete.py
@@ -1,11 +1,40 @@
 """Mark acceptance criteria as complete command."""
 
+from typing import Annotated
+
 import typer
 
 from simpletask.core.criteria_ops import mark_criterion_complete
 from simpletask.core.project import get_task_file_path
 from simpletask.core.yaml_parser import InvalidTaskFileError
 from simpletask.utils.console import handle_exception, success
+from simpletask.utils.output import (
+    OutputFormat,
+    build_write_response,
+    json_error,
+    json_success,
+    resolve_format,
+)
+
+
+def _print_json_criterion_complete(
+    criterion_id: str, file_path: str, spec, completed: bool = True
+) -> None:
+    """Print criterion complete result as JSON.
+
+    Args:
+        criterion_id: The criterion ID
+        file_path: Path to the task file
+        spec: The updated task spec
+        completed: Whether the criterion was marked as completed (True) or uncompleted (False)
+    """
+    if completed:
+        action = "criterion_completed"
+        message = f"Marked {criterion_id} as completed"
+    else:
+        action = "criterion_uncompleted"
+        message = f"Marked {criterion_id} as not completed"
+    json_success(build_write_response(action, message, spec, file_path, criterion_id=criterion_id))
 
 
 def complete_command(
@@ -13,6 +42,10 @@ def complete_command(
     uncomplete: bool = typer.Option(
         False, "--uncomplete", "-u", help="Mark as not completed instead"
     ),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
     branch: str | None = typer.Option(
         None, "--branch", "-b", help="Branch name (defaults to current git branch)"
     ),
@@ -30,14 +63,26 @@ def complete_command(
         InvalidTaskFileError: If task file is malformed and cannot be parsed
     """
     try:
+        # Resolve format
+        format = resolve_format(format)
+
         # Resolve task file path and mark complete
         file_path = get_task_file_path(branch)
-        mark_criterion_complete(file_path, criterion_id, completed=not uncomplete)
+        spec = mark_criterion_complete(file_path, criterion_id, completed=not uncomplete)
 
-        if uncomplete:
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            _print_json_criterion_complete(
+                criterion_id, str(file_path), spec, completed=not uncomplete
+            )
+        elif uncomplete:
             success(f"Marked {criterion_id} as not completed")
         else:
             success(f"Marked {criterion_id} as completed")
 
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "marking criterion as complete")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "marking criterion as complete")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/criteria/list.py
+++ b/cli/simpletask/commands/criteria/list.py
@@ -1,10 +1,40 @@
 """List acceptance criteria command."""
 
+from typing import Annotated
+
 import typer
 
 from simpletask.core.project import get_task_file_path
 from simpletask.core.yaml_parser import parse_task_file
 from simpletask.utils.console import console, error
+from simpletask.utils.output import OutputFormat, json_error, json_success, resolve_format
+
+
+def _print_json_criteria_list(
+    criteria, completed_count: int, total_count: int, file_path: str
+) -> None:
+    """Print criteria as JSON.
+
+    Args:
+        criteria: List of criteria to print
+        completed_count: Number of completed criteria
+        total_count: Total number of criteria
+        file_path: Path to the task file
+    """
+    output = {
+        "file_path": file_path,
+        "criteria": [
+            {
+                "id": c.id,
+                "description": c.description,
+                "completed": c.completed,
+            }
+            for c in criteria
+        ],
+        "completed": completed_count,
+        "total": total_count,
+    }
+    json_success(output)
 
 
 def list_command(
@@ -14,6 +44,10 @@ def list_command(
     incomplete_only: bool = typer.Option(
         False, "--incomplete", "-i", help="Show only incomplete criteria"
     ),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
     branch: str | None = typer.Option(
         None, "--branch", "-b", help="Branch name (defaults to current git branch)"
     ),
@@ -32,6 +66,9 @@ def list_command(
         # Parse task file
         spec = parse_task_file(file_path)
 
+        # Resolve format
+        format = resolve_format(format)
+
         # Get criteria
         criteria = list(spec.acceptance_criteria)
 
@@ -43,6 +80,15 @@ def list_command(
             criteria = [c for c in criteria if c.completed]
         elif incomplete_only:
             criteria = [c for c in criteria if not c.completed]
+
+        # Get counts before filtering for display
+        completed_count = sum(1 for c in spec.acceptance_criteria if c.completed)
+        total_count = len(spec.acceptance_criteria)
+
+        # JSON output path
+        if format == OutputFormat.JSON:
+            _print_json_criteria_list(criteria, completed_count, total_count, str(file_path))
+            return
 
         # Display criteria
         if not criteria:
@@ -56,11 +102,15 @@ def list_command(
             console.print(f"{icon} {criterion.id} {criterion.description}")
 
         # Summary
-        completed_count = sum(1 for c in spec.acceptance_criteria if c.completed)
-        total_count = len(spec.acceptance_criteria)
         console.print(f"\n[dim]Completed: {completed_count}/{total_count}[/dim]\n")
 
-    except FileNotFoundError as e:
-        error(str(e))
+    except FileNotFoundError:
+        if format == OutputFormat.JSON:
+            json_error("Task file not found")
+        else:
+            error("Task file not found")
     except Exception as e:
-        error(f"Unexpected error: {e}")
+        if format == OutputFormat.JSON:
+            json_error(f"Unexpected error: {e}")
+        else:
+            error(f"Unexpected error: {e}")

--- a/cli/simpletask/commands/criteria/remove.py
+++ b/cli/simpletask/commands/criteria/remove.py
@@ -1,16 +1,48 @@
 """Remove acceptance criterion command."""
 
+from typing import Annotated
+
 import typer
 
 from simpletask.core.criteria_ops import remove_acceptance_criterion
 from simpletask.core.project import get_task_file_path
 from simpletask.core.yaml_parser import InvalidTaskFileError
 from simpletask.utils.console import confirm, handle_exception, success
+from simpletask.utils.output import (
+    OutputFormat,
+    build_write_response,
+    json_error,
+    json_success,
+    resolve_format,
+)
+
+
+def _print_json_criterion_remove(criterion_id: str, file_path: str, spec) -> None:
+    """Print criterion remove result as JSON.
+
+    Args:
+        criterion_id: The removed criterion ID
+        file_path: Path to the task file
+        spec: The updated task spec
+    """
+    json_success(
+        build_write_response(
+            "criterion_removed",
+            f"Removed criterion {criterion_id}",
+            spec,
+            file_path,
+            criterion_id=criterion_id,
+        )
+    )
 
 
 def remove_command(
     criterion_id: str = typer.Argument(..., help="Criterion ID (e.g., AC1)"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation prompt"),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
     branch: str | None = typer.Option(
         None, "--branch", "-b", help="Branch name (defaults to current git branch)"
     ),
@@ -29,6 +61,9 @@ def remove_command(
         typer.Abort: If user cancels the confirmation prompt
     """
     try:
+        # Resolve format
+        format = resolve_format(format)
+
         # Confirm removal unless --force
         if not force:
             if not confirm(f"Remove criterion {criterion_id}?"):
@@ -36,11 +71,19 @@ def remove_command(
 
         # Resolve task file path and remove
         file_path = get_task_file_path(branch)
-        remove_acceptance_criterion(file_path, criterion_id)
+        spec = remove_acceptance_criterion(file_path, criterion_id)
 
-        success(f"Removed criterion {criterion_id}")
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            _print_json_criterion_remove(criterion_id, str(file_path), spec)
+        else:
+            success(f"Removed criterion {criterion_id}")
 
     except typer.Abort:
         raise
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "removing acceptance criterion")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "removing acceptance criterion")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/criteria/update.py
+++ b/cli/simpletask/commands/criteria/update.py
@@ -1,16 +1,48 @@
 """Update acceptance criterion description command."""
 
+from typing import Annotated
+
 import typer
 
 from simpletask.core.criteria_ops import update_acceptance_criterion
 from simpletask.core.project import get_task_file_path
 from simpletask.core.yaml_parser import InvalidTaskFileError
 from simpletask.utils.console import handle_exception, success
+from simpletask.utils.output import (
+    OutputFormat,
+    build_write_response,
+    json_error,
+    json_success,
+    resolve_format,
+)
+
+
+def _print_json_criterion_update(criterion_id: str, file_path: str, spec) -> None:
+    """Print criterion update result as JSON.
+
+    Args:
+        criterion_id: The updated criterion ID
+        file_path: Path to the task file
+        spec: The updated task spec
+    """
+    json_success(
+        build_write_response(
+            "criterion_updated",
+            f"Updated {criterion_id} description",
+            spec,
+            file_path,
+            criterion_id=criterion_id,
+        )
+    )
 
 
 def update_command(
     criterion_id: str = typer.Argument(..., help="Criterion ID (e.g., AC1)"),
     description: str = typer.Argument(..., help="New criterion description"),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
     branch: str | None = typer.Option(
         None, "--branch", "-b", help="Branch name (defaults to current git branch)"
     ),
@@ -27,9 +59,21 @@ def update_command(
         InvalidTaskFileError: If task file is malformed and cannot be parsed
     """
     try:
+        # Resolve format
+        format = resolve_format(format)
+
         file_path = get_task_file_path(branch)
-        update_acceptance_criterion(file_path, criterion_id, description)
-        success(f"Updated {criterion_id} description")
+        spec = update_acceptance_criterion(file_path, criterion_id, description)
+
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            _print_json_criterion_update(criterion_id, str(file_path), spec)
+        else:
+            success(f"Updated {criterion_id} description")
 
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "updating criterion")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "updating criterion")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/note/add.py
+++ b/cli/simpletask/commands/note/add.py
@@ -1,32 +1,66 @@
 """Add note command."""
 
+from typing import Annotated
+
 import typer
 
-from simpletask.core.yaml_parser import InvalidTaskFileError
-from simpletask.mcp.server import note
+from simpletask.core.note_ops import add_note
+from simpletask.core.project import get_task_file_path
+from simpletask.core.yaml_parser import InvalidTaskFileError, parse_task_file, write_task_file
 from simpletask.utils.console import handle_exception, success
+from simpletask.utils.output import OutputFormat, json_error, json_success, resolve_format
 
 
 def add_command(
     content: str = typer.Argument(..., help="Note content"),
     task: str | None = typer.Option(None, "--task", "-t", help="Task ID to add note to"),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
 ) -> None:
     """Add a note to root-level or task-level.
 
     Examples:
         simpletask note add "Remember to update docs"
         simpletask note add "This task needs refactoring" --task T003
+
+    Raises:
+        ValueError: If not in a git repository or branch cannot be determined
+        FileNotFoundError: If task file doesn't exist for the specified branch
+        InvalidTaskFileError: If task file is malformed and cannot be parsed
     """
     try:
-        # Call MCP tool directly
-        note(
-            action="add",
-            content=content,
-            task_id=task,
+        # Resolve format
+        format = resolve_format(format)
+
+        file_path = get_task_file_path(None)
+        spec = parse_task_file(file_path)
+        spec = add_note(spec=spec, content=content, task_id=task)
+        write_task_file(file_path, spec)
+
+        # Compute notes_total (root + all task notes)
+        notes_total = len(spec.notes or []) + sum(
+            len(t.notes) for t in (spec.tasks or []) if t.notes
         )
 
-        location = f"task {task}" if task else "root"
-        success(f"Added note to {location}")
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            json_success(
+                {
+                    "success": True,
+                    "action": "note_added",
+                    "message": "Added note",
+                    "summary": {"notes_total": notes_total},
+                }
+            )
+        else:
+            location = f"task {task}" if task else "root"
+            success(f"Added note to {location}")
 
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "adding note")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "adding note")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/note/remove.py
+++ b/cli/simpletask/commands/note/remove.py
@@ -1,16 +1,24 @@
 """Remove note command."""
 
+from typing import Annotated
+
 import typer
 
-from simpletask.core.yaml_parser import InvalidTaskFileError
-from simpletask.mcp.server import note
+from simpletask.core.note_ops import remove_note
+from simpletask.core.project import get_task_file_path
+from simpletask.core.yaml_parser import InvalidTaskFileError, parse_task_file, write_task_file
 from simpletask.utils.console import handle_exception, success
+from simpletask.utils.output import OutputFormat, json_error, json_success, resolve_format
 
 
 def remove_command(
     index: int | None = typer.Argument(None, help="Note index to remove (0-based)"),
     task: str | None = typer.Option(None, "--task", "-t", help="Task ID to remove note from"),
     all: bool = typer.Option(False, "--all", "-a", help="Remove all notes"),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
 ) -> None:
     """Remove a note from root-level or task-level.
 
@@ -18,21 +26,46 @@ def remove_command(
         simpletask note remove 0
         simpletask note remove 1 --task T003
         simpletask note remove --all --task T003
+
+    Raises:
+        ValueError: If not in a git repository or branch cannot be determined
+        FileNotFoundError: If task file doesn't exist for the specified branch
+        InvalidTaskFileError: If task file is malformed and cannot be parsed
     """
     try:
-        # Call MCP tool directly
-        note(
-            action="remove",
-            index=index,
-            task_id=task,
-            all=all,
+        # Resolve format
+        format = resolve_format(format)
+
+        file_path = get_task_file_path(None)
+        spec = parse_task_file(file_path)
+        spec = remove_note(spec=spec, index=index, task_id=task, all=all)
+        write_task_file(file_path, spec)
+
+        # Compute notes_total (root + all task notes)
+        notes_total = len(spec.notes or []) + sum(
+            len(t.notes) for t in (spec.tasks or []) if t.notes
         )
 
-        location = f"task {task}" if task else "root"
-        if all:
-            success(f"Removed all notes from {location}")
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            json_success(
+                {
+                    "success": True,
+                    "action": "note_removed",
+                    "message": "Removed note",
+                    "summary": {"notes_total": notes_total},
+                }
+            )
         else:
-            success(f"Removed note {index} from {location}")
+            location = f"task {task}" if task else "root"
+            if all:
+                success(f"Removed all notes from {location}")
+            else:
+                success(f"Removed note {index} from {location}")
 
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "removing note")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "removing note")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/quality/check.py
+++ b/cli/simpletask/commands/quality/check.py
@@ -1,7 +1,5 @@
 """Quality check command."""
 
-import json
-from enum import Enum
 from typing import Annotated
 
 import typer
@@ -12,14 +10,7 @@ from simpletask.core.project import get_task_file_path
 from simpletask.core.quality_ops import run_quality_checks
 from simpletask.core.yaml_parser import parse_task_file
 from simpletask.utils.console import console, error
-
-
-class OutputFormat(str, Enum):
-    """Output format options."""
-
-    RICH = "rich"
-    PLAIN = "plain"
-    JSON = "json"
+from simpletask.utils.output import OutputFormat, json_error, json_success, resolve_format
 
 
 def print_plain_results(results: list[QualityCheckResult], all_passed: bool) -> None:
@@ -63,7 +54,7 @@ def print_json_results(results: list[QualityCheckResult], all_passed: bool) -> N
             for r in results
         ],
     }
-    print(json.dumps(output, indent=2))
+    json_success(output)
 
 
 def check_command(
@@ -97,18 +88,20 @@ def check_command(
         # Get file path
         file_path = get_task_file_path(branch)
 
+        # Auto-detect non-terminal environment and use plain format if rich was selected
+        format = resolve_format(format)
+
         # Parse task file
         spec = parse_task_file(file_path)
 
         # Get quality requirements
         quality_reqs = spec.quality_requirements
         if quality_reqs is None:
-            error("No quality_requirements configuration found in task file")
+            if format == OutputFormat.JSON:
+                json_error("No quality_requirements configuration found in task file")
+            else:
+                error("No quality_requirements configuration found in task file")
             raise typer.Exit(1)
-
-        # Auto-detect non-terminal environment and use plain format if rich was selected
-        if format == OutputFormat.RICH and not console.is_terminal:
-            format = OutputFormat.PLAIN
 
         # Only print Rich formatted header if using rich format
         if format == OutputFormat.RICH:
@@ -129,7 +122,7 @@ def check_command(
             elif format == OutputFormat.PLAIN:
                 print("No quality checks enabled or selected")
             else:  # JSON
-                print(json.dumps({"all_passed": True, "results": []}))
+                json_success({"all_passed": True, "results": []})
             return
 
         # Display results based on format
@@ -186,9 +179,18 @@ def check_command(
             raise typer.Exit(1)
 
     except FileNotFoundError as e:
-        error(str(e))
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            error(str(e))
     except ValueError as e:
-        error(str(e))
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            error(str(e))
         raise typer.Exit(1) from None
     except Exception as e:
-        error(f"Unexpected error: {e}")
+        if format == OutputFormat.JSON:
+            json_error(f"Unexpected error: {e}")
+        else:
+            error(f"Unexpected error: {e}")

--- a/cli/simpletask/commands/quality/show.py
+++ b/cli/simpletask/commands/quality/show.py
@@ -9,6 +9,13 @@ from simpletask.core.models import ToolName
 from simpletask.core.project import get_task_file_path
 from simpletask.core.yaml_parser import parse_task_file
 from simpletask.utils.console import console, error
+from simpletask.utils.output import (
+    OutputFormat,
+    json_error,
+    json_success,
+    resolve_format,
+    serialize_quality_reqs,
+)
 
 
 def _format_tool_command(tool: ToolName | None, args: list[str]) -> str:
@@ -22,7 +29,22 @@ def _format_tool_command(tool: ToolName | None, args: list[str]) -> str:
     return f"{tool.value} {' '.join(args)}"
 
 
+def _print_json_quality_show(quality_reqs, file_path: str) -> None:
+    """Print quality requirements as JSON.
+
+    Args:
+        quality_reqs: Quality requirements configuration
+        file_path: Path to the task file
+    """
+    output = {"file_path": file_path, **serialize_quality_reqs(quality_reqs)}
+    json_success(output)
+
+
 def show_command(
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
     branch: Annotated[
         str | None,
         typer.Option("--branch", "-b", help="Branch name (defaults to current git branch)"),
@@ -44,12 +66,23 @@ def show_command(
         # Parse task file
         spec = parse_task_file(file_path)
 
+        # Resolve format
+        format = resolve_format(format)
+
         # Get quality requirements
         quality_reqs = spec.quality_requirements
 
         if quality_reqs is None:
-            error("No quality requirements configured in task file")
+            if format == OutputFormat.JSON:
+                json_error("No quality requirements configured in task file")
+            else:
+                error("No quality requirements configured in task file")
             raise typer.Exit(1)
+
+        # JSON output path
+        if format == OutputFormat.JSON:
+            _print_json_quality_show(quality_reqs, str(file_path))
+            return
 
         console.print(f"\n[bold]Quality Requirements[/bold] ({file_path.name})\n")
 
@@ -117,7 +150,13 @@ def show_command(
         console.print(table)
         console.print("")
 
-    except FileNotFoundError as e:
-        error(str(e))
+    except FileNotFoundError:
+        if format == OutputFormat.JSON:
+            json_error("Task file not found")
+        else:
+            error("Task file not found")
     except Exception as e:
-        error(f"Unexpected error: {e}")
+        if format == OutputFormat.JSON:
+            json_error(f"Unexpected error: {e}")
+        else:
+            error(f"Unexpected error: {e}")

--- a/cli/simpletask/commands/schema/validate.py
+++ b/cli/simpletask/commands/schema/validate.py
@@ -1,12 +1,43 @@
 """Schema validate command."""
 
 from pathlib import Path
+from typing import Annotated
 
 import typer
 
 from ...core.project import get_task_file_path
 from ...core.validation import validate_task_file
 from ...utils.console import error, success
+from ...utils.output import OutputFormat, json_error, json_success, resolve_format
+
+
+def _print_json_validate_single(file_path: Path, errors: list[str] | None) -> None:
+    """Print validation result for single file as JSON.
+
+    Args:
+        file_path: Path to the validated file
+        errors: List of error messages, or None if valid
+    """
+    output = {
+        "file": str(file_path),
+        "valid": errors is None or len(errors) == 0,
+        "errors": errors or [],
+    }
+    json_success(output)
+
+
+def _print_json_validate_all(results: list[dict]) -> None:
+    """Print validation results for all files as JSON.
+
+    Args:
+        results: List of validation result dicts
+    """
+    all_valid = all(r["valid"] for r in results)
+    output = {
+        "results": results,
+        "all_valid": all_valid,
+    }
+    json_success(output)
 
 
 def validate(
@@ -14,6 +45,10 @@ def validate(
         None, help="Task file to validate (defaults to current branch)"
     ),
     all_files: bool = typer.Option(False, "--all", help="Validate all task files"),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
 ) -> None:
     """Validate task file(s) against JSON schema.
 
@@ -23,6 +58,9 @@ def validate(
         simpletask schema validate --all              # Validate all tasks
     """
     try:
+        # Resolve format
+        format = resolve_format(format)
+
         if all_files:
             # Validate all task files
             from ...core.project import ensure_project
@@ -31,28 +69,47 @@ def validate(
             tasks = project.list_tasks()
 
             if not tasks:
-                error("No tasks found in ./tasks directory")
+                msg = "No tasks found in .tasks directory"
+                if format == OutputFormat.JSON:
+                    json_error(msg)
+                else:
+                    error(msg)
+                raise typer.Exit(1)
 
             errors_found = False
+            results = []
             for branch in tasks:
                 task_file = project.get_task_file(branch)
                 errors = validate_task_file(task_file)
-                if errors:
-                    error_console = __import__(
-                        "...utils.console", fromlist=["error_console"]
-                    ).error_console
-                    error_console.print(
-                        f"\n[red]Errors in {task_file.relative_to(project.root)}:[/red]"
-                    )
-                    for err in errors:
-                        error_console.print(f"  {err}")
+                file_path_rel = task_file.relative_to(project.root)
+                is_valid = not errors
+                results.append(
+                    {
+                        "file": str(file_path_rel),
+                        "valid": is_valid,
+                        "errors": errors or [],
+                    }
+                )
+                if not is_valid:
                     errors_found = True
-                else:
-                    success(f"{task_file.relative_to(project.root)}: Valid")
+                    if format != OutputFormat.JSON:
+                        from ...utils.console import error_console
 
-            if errors_found:
-                raise typer.Exit(1)
+                        error_console.print(f"\n[red]Errors in {file_path_rel}:[/red]")
+                        for err in errors:
+                            error_console.print(f"  {err}")
+                else:
+                    if format != OutputFormat.JSON:
+                        success(f"{file_path_rel}: Valid")
+
+            if format == OutputFormat.JSON:
+                _print_json_validate_all(results)
+                if errors_found:
+                    raise typer.Exit(1)
+                return
             else:
+                if errors_found:
+                    raise typer.Exit(1)
                 success("All task files are valid")
 
         else:
@@ -66,7 +123,9 @@ def validate(
 
             errors = validate_task_file(task_file)
 
-            if errors:
+            if format == OutputFormat.JSON:
+                _print_json_validate_single(task_file, errors)
+            elif errors:
                 from ...utils.console import error_console
 
                 error_console.print("\n[red]Validation errors:[/red]")
@@ -76,7 +135,20 @@ def validate(
             else:
                 success(f"{task_file.name}: Valid")
 
+            if errors:
+                raise typer.Exit(1)
+
+    except typer.Exit:
+        raise
     except ValueError as e:
-        error(str(e))
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+            raise typer.Exit(1) from None
+        else:
+            error(str(e))
     except Exception as e:
-        error(f"Unexpected error: {e}")
+        if format == OutputFormat.JSON:
+            json_error(f"Unexpected error: {e}")
+            raise typer.Exit(1) from None
+        else:
+            error(f"Unexpected error: {e}")

--- a/cli/simpletask/commands/show.py
+++ b/cli/simpletask/commands/show.py
@@ -1,5 +1,6 @@
-"""
-Show command - Display task details."""
+"""Show command - Display task details."""
+
+from typing import Annotated
 
 import typer
 
@@ -7,6 +8,13 @@ from ..core.models import Design, QualityRequirements, Task
 from ..core.project import ensure_project, get_task_file_path
 from ..core.yaml_parser import InvalidTaskFileError, parse_task_file
 from ..utils.console import console, error
+from ..utils.output import (
+    OutputFormat,
+    json_error,
+    json_success,
+    resolve_format,
+    serialize_quality_reqs,
+)
 
 
 def _format_quality_summary(quality_reqs: QualityRequirements) -> str:
@@ -161,8 +169,107 @@ def _task_status_parts(task: Task) -> tuple[str, str]:
         return "○", "white"
 
 
+def _print_json_show(spec, file_path: str) -> None:
+    """Print task specification as JSON.
+
+    Args:
+        spec: Parsed SimpleTaskSpec object
+        file_path: Path to the task file
+    """
+    output = {
+        "file_path": file_path,
+        "branch": spec.branch,
+        "title": spec.title,
+        "created": spec.created.isoformat(),
+        "original_prompt": spec.original_prompt,
+        "acceptance_criteria": [
+            {
+                "id": c.id,
+                "description": c.description,
+                "completed": c.completed,
+            }
+            for c in spec.acceptance_criteria
+        ],
+        "constraints": spec.constraints or [],
+        "tasks": [
+            {
+                "id": t.id,
+                "name": t.name,
+                "status": t.status.value,
+                "goal": t.goal,
+                "steps": t.steps,
+                "done_when": t.done_when or [],
+                "prerequisites": t.prerequisites or [],
+                "files": (
+                    [{"path": f.path, "action": f.action} for f in t.files] if t.files else []
+                ),
+                "code_examples": (
+                    [
+                        {"language": ce.language, "description": ce.description, "code": ce.code}
+                        for ce in t.code_examples
+                    ]
+                    if t.code_examples
+                    else []
+                ),
+                "notes": t.notes or [],
+                "iteration": t.iteration,
+            }
+            for t in (spec.tasks or [])
+        ],
+        "quality_requirements": (
+            serialize_quality_reqs(spec.quality_requirements) if spec.quality_requirements else None
+        ),
+        "design": (
+            {
+                "patterns": [p.value for p in spec.design.patterns] if spec.design.patterns else [],
+                "references": (
+                    [
+                        {"path": r.path, "reason": r.reason}
+                        for r in spec.design.reference_implementations
+                    ]
+                    if spec.design.reference_implementations
+                    else []
+                ),
+                "constraints": (
+                    spec.design.architectural_constraints
+                    if spec.design.architectural_constraints
+                    else []
+                ),
+                "security": (
+                    [
+                        {"category": s.category.value, "description": s.description}
+                        for s in spec.design.security
+                    ]
+                    if spec.design.security
+                    else []
+                ),
+                "error_handling": (
+                    spec.design.error_handling.value if spec.design.error_handling else None
+                ),
+            }
+            if spec.design
+            else None
+        ),
+        "notes": spec.notes or [],
+        "iterations": (
+            [
+                {"id": it.id, "label": it.label, "created": it.created.isoformat()}
+                for it in spec.iterations
+            ]
+            if spec.iterations
+            else []
+        ),
+        "context": spec.context or {},
+    }
+    json_success(output)
+
+
 def show(
     branch: str | None = typer.Argument(None, help="Branch name (defaults to current git branch)"),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
 ) -> None:
     """Show detailed information about a task.
 
@@ -183,11 +290,20 @@ def show(
     """
     task_file = None
     try:
+        # Resolve format first so exception handlers can use it
+        format = resolve_format(format)
+
         task_file = get_task_file_path(branch)
         project = ensure_project()
 
         # Parse task file
         spec = parse_task_file(task_file)
+
+        # JSON output path
+        if format == OutputFormat.JSON:
+            relative_path = task_file.relative_to(project.root)
+            _print_json_show(spec, str(relative_path))
+            return
 
         # Display file location (relative to project root)
         relative_path = task_file.relative_to(project.root)
@@ -312,10 +428,26 @@ def show(
         console.print()
 
     except FileNotFoundError:
-        error(f"Task file not found: {task_file}")
+        if format == OutputFormat.JSON:
+            json_error(f"Task file not found: {task_file}")
+            raise typer.Exit(1) from None
+        else:
+            error(f"Task file not found: {task_file}")
     except InvalidTaskFileError as e:
-        error(f"Invalid task file: {e}")
+        if format == OutputFormat.JSON:
+            json_error(f"Invalid task file: {e}")
+            raise typer.Exit(1) from None
+        else:
+            error(f"Invalid task file: {e}")
     except ValueError as e:
-        error(str(e))
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+            raise typer.Exit(1) from None
+        else:
+            error(str(e))
     except Exception as e:
-        error(f"Unexpected error: {e}")
+        if format == OutputFormat.JSON:
+            json_error(f"Unexpected error: {e}")
+            raise typer.Exit(1) from None
+        else:
+            error(f"Unexpected error: {e}")

--- a/cli/simpletask/commands/task/add.py
+++ b/cli/simpletask/commands/task/add.py
@@ -1,5 +1,7 @@
 """Add implementation task command."""
 
+from typing import Annotated
+
 import typer
 
 from simpletask.commands.task.helpers import _parse_file_actions
@@ -7,6 +9,28 @@ from simpletask.core.project import get_task_file_path
 from simpletask.core.task_ops import add_implementation_task
 from simpletask.core.yaml_parser import InvalidTaskFileError
 from simpletask.utils.console import handle_exception, success
+from simpletask.utils.output import (
+    OutputFormat,
+    build_write_response,
+    json_error,
+    json_success,
+    resolve_format,
+)
+
+
+def _print_json_task_add(task_id: str, file_path: str, spec) -> None:
+    """Print task add result as JSON.
+
+    Args:
+        task_id: The new task ID
+        file_path: Path to the task file
+        spec: The updated task spec
+    """
+    json_success(
+        build_write_response(
+            "task_added", f"Added task {task_id}", spec, file_path, task_id=task_id
+        )
+    )
 
 
 def add_command(
@@ -28,6 +52,10 @@ def add_command(
     iteration: int | None = typer.Option(
         None, "--iteration", "-i", help="Assign task to iteration by ID"
     ),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
     branch: str | None = typer.Option(
         None, "--branch", "-b", help="Branch name (defaults to current git branch)"
     ),
@@ -50,6 +78,9 @@ def add_command(
         InvalidTaskFileError: If task file is malformed and cannot be parsed
     """
     try:
+        # Resolve format
+        format = resolve_format(format)
+
         # Resolve task file path
         file_path = get_task_file_path(branch)
         steps_value = step or None
@@ -57,7 +88,7 @@ def add_command(
         prerequisites_value = prerequisite or None
         file_actions = _parse_file_actions(file) if file else None
 
-        new_id, _ = add_implementation_task(
+        new_id, spec = add_implementation_task(
             file_path,
             name,
             goal,
@@ -68,8 +99,16 @@ def add_command(
             iteration=iteration,
         )
 
-        iter_suffix = f" (iteration {iteration})" if iteration is not None else ""
-        success(f"Added task {new_id}: {name}{iter_suffix}")
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            _print_json_task_add(new_id, str(file_path), spec)
+        else:
+            iter_suffix = f" (iteration {iteration})" if iteration is not None else ""
+            success(f"Added task {new_id}: {name}{iter_suffix}")
 
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "adding implementation task")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "adding implementation task")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/task/list.py
+++ b/cli/simpletask/commands/task/list.py
@@ -1,11 +1,14 @@
 """List implementation tasks command."""
 
+from typing import Annotated
+
 import typer
 
 from simpletask.core.models import Task, TaskStatus
-from simpletask.core.project import get_task_file_path
+from simpletask.core.project import ensure_project, get_task_file_path
 from simpletask.core.yaml_parser import InvalidTaskFileError, parse_task_file
 from simpletask.utils.console import console, error
+from simpletask.utils.output import OutputFormat, json_error, json_success, resolve_format
 
 
 def _get_status_icon(status: TaskStatus) -> str:
@@ -41,6 +44,32 @@ def _print_task_line(task: Task, iter_label: str | None = None, indent: bool = T
     console.print(line)
 
 
+def _print_json_task_list(tasks: list[Task], file_path: str, total_count: int) -> None:
+    """Print tasks as JSON.
+
+    Args:
+        tasks: List of tasks to print
+        file_path: Path to the task file
+        total_count: Total count of tasks in file
+    """
+    output = {
+        "file_path": file_path,
+        "tasks": [
+            {
+                "id": t.id,
+                "name": t.name,
+                "status": t.status.value,
+                "goal": t.goal,
+                "iteration": t.iteration,
+            }
+            for t in tasks
+        ],
+        "returned": len(tasks),
+        "total": total_count,
+    }
+    json_success(output)
+
+
 def list_command(
     status: str | None = typer.Option(
         None,
@@ -59,6 +88,10 @@ def list_command(
         "--flat",
         help="Display flat list without iteration grouping",
     ),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
     branch: str | None = typer.Option(
         None, "--branch", "-b", help="Branch name (defaults to current git branch)"
     ),
@@ -77,13 +110,19 @@ def list_command(
     """
     try:
         # Get file path
+        project = ensure_project()
         file_path = get_task_file_path(branch)
+        relative_path = file_path.relative_to(project.root)
 
         # Parse task file
         spec = parse_task_file(file_path)
 
+        # Resolve format
+        format = resolve_format(format)
+
         # Get tasks
         tasks = spec.tasks or []
+        total_count = len(tasks)
 
         # Apply status filter if provided
         if status:
@@ -91,18 +130,29 @@ def list_command(
                 status_enum = TaskStatus(status)
                 tasks = [t for t in tasks if t.status == status_enum]
             except ValueError:
-                error(
-                    f"Invalid status: {status}. Valid values: not_started, in_progress, completed, blocked, paused"
-                )
-                return
+                msg = f"Invalid status: {status}. Valid values: not_started, in_progress, completed, blocked, paused"
+                if format == OutputFormat.JSON:
+                    json_error(msg)
+                else:
+                    error(msg)
+                raise typer.Exit(1) from None
 
         # Apply iteration filter if provided
         if iteration is not None:
             valid_iter_ids = {it.id for it in (spec.iterations or [])}
             if iteration not in valid_iter_ids:
-                error(f"Iteration {iteration} not found. Valid IDs: {sorted(valid_iter_ids)}")
+                msg = f"Iteration {iteration} not found. Valid IDs: {sorted(valid_iter_ids)}"
+                if format == OutputFormat.JSON:
+                    json_error(msg)
+                    error(msg)
+                raise typer.Exit(1) from None
                 return
             tasks = [t for t in tasks if t.iteration == iteration]
+
+        # JSON output path
+        if format == OutputFormat.JSON:
+            _print_json_task_list(tasks, str(relative_path), total_count)
+            return
 
         # Display tasks
         if not tasks:
@@ -148,7 +198,15 @@ def list_command(
 
         console.print(f"[dim]Total: {len(tasks)} task(s)[/dim]\n")
 
-    except FileNotFoundError as e:
-        error(str(e))
+    except FileNotFoundError:
+        if format == OutputFormat.JSON:
+            json_error("Task file not found")
+        else:
+            error("Task file not found")
+        raise typer.Exit(1) from None
     except (ValueError, InvalidTaskFileError) as e:
-        error(str(e))
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            error(str(e))
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/task/remove.py
+++ b/cli/simpletask/commands/task/remove.py
@@ -1,16 +1,44 @@
 """Remove implementation task command."""
 
+from typing import Annotated
+
 import typer
 
 from simpletask.core.project import get_task_file_path
 from simpletask.core.task_ops import remove_implementation_task
 from simpletask.core.yaml_parser import InvalidTaskFileError
 from simpletask.utils.console import confirm, handle_exception, success
+from simpletask.utils.output import (
+    OutputFormat,
+    build_write_response,
+    json_error,
+    json_success,
+    resolve_format,
+)
+
+
+def _print_json_task_remove(task_id: str, file_path: str, spec) -> None:
+    """Print task remove result as JSON.
+
+    Args:
+        task_id: The removed task ID
+        file_path: Path to the task file
+        spec: The updated task spec
+    """
+    json_success(
+        build_write_response(
+            "task_removed", f"Removed task {task_id}", spec, file_path, task_id=task_id
+        )
+    )
 
 
 def remove_command(
     task_id: str = typer.Argument(..., help="Task ID (e.g., T001)"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation prompt"),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
     branch: str | None = typer.Option(
         None, "--branch", "-b", help="Branch name (defaults to current git branch)"
     ),
@@ -29,6 +57,9 @@ def remove_command(
         typer.Abort: If user cancels the confirmation prompt
     """
     try:
+        # Resolve format
+        format = resolve_format(format)
+
         # Confirm removal unless --force
         if not force:
             if not confirm(f"Remove task {task_id}?"):
@@ -36,11 +67,19 @@ def remove_command(
 
         # Resolve task file path and remove
         file_path = get_task_file_path(branch)
-        remove_implementation_task(file_path, task_id)
+        spec = remove_implementation_task(file_path, task_id)
 
-        success(f"Removed task {task_id}")
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            _print_json_task_remove(task_id, str(file_path), spec)
+        else:
+            success(f"Removed task {task_id}")
 
     except typer.Abort:
         raise
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "removing task")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "removing task")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/task/update.py
+++ b/cli/simpletask/commands/task/update.py
@@ -1,5 +1,7 @@
 """Update implementation task command."""
 
+from typing import Annotated
+
 import typer
 
 from simpletask.commands.task.helpers import _parse_file_actions
@@ -8,6 +10,27 @@ from simpletask.core.project import get_task_file_path
 from simpletask.core.task_ops import _UNSET, _UnsetType, update_implementation_task
 from simpletask.core.yaml_parser import InvalidTaskFileError
 from simpletask.utils.console import handle_exception, success
+from simpletask.utils.output import (
+    OutputFormat,
+    build_write_response,
+    json_error,
+    json_success,
+    resolve_format,
+)
+
+
+def _print_json_task_update(task_id: str, action: str, file_path: str, spec) -> None:
+    """Print task update result as JSON.
+
+    Args:
+        task_id: The updated task ID
+        action: The action performed (e.g., 'task_updated')
+        file_path: Path to the task file
+        spec: The updated task spec
+    """
+    json_success(
+        build_write_response(action, f"Updated task {task_id}", spec, file_path, task_id=task_id)
+    )
 
 
 def update_command(
@@ -46,6 +69,10 @@ def update_command(
         "--unassign-iteration",
         help="Remove task from its current iteration",
     ),
+    format: Annotated[
+        OutputFormat,
+        typer.Option("--format", "-f", help="Output format (rich, plain, json)"),
+    ] = OutputFormat.RICH,
     branch: str | None = typer.Option(
         None, "--branch", "-b", help="Branch name (defaults to current git branch)"
     ),
@@ -69,6 +96,9 @@ def update_command(
         InvalidTaskFileError: If task file is malformed and cannot be parsed
     """
     try:
+        # Resolve format
+        format = resolve_format(format)
+
         # Convert status string to enum if provided
         task_status = None
         if status is not None:
@@ -101,7 +131,7 @@ def update_command(
         file_actions = _parse_file_actions(file) if file else None
 
         file_path = get_task_file_path(branch)
-        update_implementation_task(
+        spec = update_implementation_task(
             file_path,
             task_id,
             name=name,
@@ -114,7 +144,15 @@ def update_command(
             iteration=iteration_value,
         )
 
-        success(f"Updated task {task_id}")
+        # Output results based on format
+        if format == OutputFormat.JSON:
+            _print_json_task_update(task_id, "task_updated", str(file_path), spec)
+        else:
+            success(f"Updated task {task_id}")
 
     except (ValueError, FileNotFoundError, InvalidTaskFileError) as e:
-        handle_exception(e, "updating task")
+        if format == OutputFormat.JSON:
+            json_error(str(e))
+        else:
+            handle_exception(e, "updating task")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/utils/output.py
+++ b/cli/simpletask/utils/output.py
@@ -1,0 +1,157 @@
+"""Output format utilities for CLI commands."""
+
+import json
+import sys
+from enum import Enum
+
+from simpletask.utils.console import console
+
+
+class OutputFormat(str, Enum):
+    """Output format options for CLI commands."""
+
+    RICH = "rich"
+    PLAIN = "plain"
+    JSON = "json"
+
+
+def resolve_format(fmt: OutputFormat) -> OutputFormat:
+    """Resolve output format, auto-downgrading RICH to PLAIN when not in a terminal.
+
+    Args:
+        fmt: The requested output format.
+
+    Returns:
+        PLAIN if fmt is RICH and not in a terminal, otherwise fmt unchanged.
+    """
+    if fmt == OutputFormat.RICH and not console.is_terminal:
+        return OutputFormat.PLAIN
+    return fmt
+
+
+def json_error(message: str) -> None:
+    """Print an error as valid JSON to stderr.
+
+    Args:
+        message: Error message to include in the JSON object.
+    """
+    output = {"success": False, "message": message}
+    print(json.dumps(output, indent=2), file=sys.stderr)
+
+
+def json_success(data: dict) -> None:
+    """Print a success response as valid JSON to stdout.
+
+    Args:
+        data: Dictionary to serialize as JSON.
+    """
+    print(json.dumps(data, indent=2))
+
+
+def build_task_summary(spec) -> dict:
+    """Build a complete status summary dict from a SimpleTaskSpec.
+
+    Args:
+        spec: SimpleTaskSpec instance.
+
+    Returns:
+        Dict with all task status counts and criteria counts.
+    """
+    tasks = spec.tasks or []
+    criteria = spec.acceptance_criteria or []
+    return {
+        "tasks_total": len(tasks),
+        "tasks_completed": sum(1 for t in tasks if t.status.value == "completed"),
+        "tasks_not_started": sum(1 for t in tasks if t.status.value == "not_started"),
+        "tasks_in_progress": sum(1 for t in tasks if t.status.value == "in_progress"),
+        "tasks_blocked": sum(1 for t in tasks if t.status.value == "blocked"),
+        "tasks_paused": sum(1 for t in tasks if t.status.value == "paused"),
+        "criteria_total": len(criteria),
+        "criteria_completed": sum(1 for c in criteria if c.completed),
+    }
+
+
+def build_write_response(action: str, message: str, spec, file_path: str, **extra) -> dict:
+    """Build a standard write command JSON response dict.
+
+    Args:
+        action: Action string (e.g., 'task_added', 'criterion_removed').
+        message: Human-readable success message.
+        spec: SimpleTaskSpec instance used to compute the summary.
+        file_path: Path to the task file.
+        **extra: Additional key-value pairs inserted after 'action' (e.g., task_id).
+
+    Returns:
+        Dict ready for json_success().
+    """
+    response: dict = {"success": True, "action": action}
+    response.update(extra)
+    response["message"] = message
+    response["file_path"] = file_path
+    response["summary"] = build_task_summary(spec)
+    return response
+
+
+def serialize_quality_reqs(quality_reqs) -> dict:
+    """Serialize a QualityRequirements object to a JSON-serializable dict.
+
+    Args:
+        quality_reqs: QualityRequirements instance to serialize.
+
+    Returns:
+        Dictionary representation suitable for JSON output.
+    """
+    return {
+        "linting": {
+            "enabled": quality_reqs.linting.enabled,
+            "tool": quality_reqs.linting.tool.value if quality_reqs.linting.tool else None,
+            "args": quality_reqs.linting.args,
+        },
+        "type_checking": (
+            {
+                "enabled": quality_reqs.type_checking.enabled,
+                "tool": (
+                    quality_reqs.type_checking.tool.value
+                    if quality_reqs.type_checking.tool
+                    else None
+                ),
+                "args": quality_reqs.type_checking.args,
+            }
+            if quality_reqs.type_checking
+            else None
+        ),
+        "testing": (
+            {
+                "enabled": quality_reqs.testing.enabled,
+                "tool": quality_reqs.testing.tool.value if quality_reqs.testing.tool else None,
+                "args": quality_reqs.testing.args,
+                "min_coverage": quality_reqs.testing.min_coverage,
+            }
+            if quality_reqs.testing
+            else None
+        ),
+        "security_check": (
+            {
+                "enabled": quality_reqs.security_check.enabled,
+                "tool": (
+                    quality_reqs.security_check.tool.value
+                    if quality_reqs.security_check.tool
+                    else None
+                ),
+                "args": quality_reqs.security_check.args,
+            }
+            if quality_reqs.security_check
+            else None
+        ),
+    }
+
+
+__all__ = [
+    "OutputFormat",
+    "build_task_summary",
+    "build_write_response",
+    "json_error",
+    "json_success",
+    "resolve_format",
+    "serialize_quality_reqs",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simpletask"
-version = "0.35.11"
+version = "0.35.13"
 description = "CLI tool for managing AI-friendly task definitions in branch-based development workflows"
 requires-python = ">=3.11"
 license = {text = "MIT"}
@@ -103,6 +103,7 @@ warn_required_dynamic_aliases = true
 testpaths = ["tests"]
 python_files = "test_*.py"
 python_classes = "Test*"
+pythonpath = ["cli"]
 # Only collect test classes from test files, not from imported modules
 # This prevents pytest from trying to collect Pydantic models like TestingConfig
 filterwarnings = [

--- a/tests/integration/test_cli_json_output.py
+++ b/tests/integration/test_cli_json_output.py
@@ -1,0 +1,817 @@
+"""Integration tests for --format json output across all CLI commands.
+
+Tests verify:
+- Read commands (show, task list, criteria list, quality show, schema validate)
+  produce valid parseable JSON with correct fields when invoked with --format json
+- Write commands (task add/update/remove, criteria add/complete, note add)
+  produce JSON with success=true, action, message, and summary fields
+- Default (no --format) output is unchanged plain/rich text, not JSON
+- Error paths (bad task ID, missing file) produce JSON with success=false and
+  a message field — no ANSI escape codes or Rich markup in the output
+"""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import git
+import pytest
+from simpletask import app
+from simpletask.core.models import (
+    AcceptanceCriterion,
+    LintingConfig,
+    QualityRequirements,
+    SimpleTaskSpec,
+    Task,
+    TaskStatus,
+    TestingConfig,
+    ToolName,
+    TypeCheckConfig,
+)
+from simpletask.core.yaml_parser import write_task_file
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def json_project(tmp_path: Path, monkeypatch):
+    """Set up a temporary git repo with a pre-existing task file.
+
+    Returns:
+        project_root Path; monkeypatches cwd so simpletask auto-detects branch.
+    """
+    branch_name = "feature/json-output-test"
+    normalized = "feature-json-output-test.yml"
+
+    repo = git.Repo.init(tmp_path)
+    repo.config_writer().set_value("user", "name", "Test").release()
+    repo.config_writer().set_value("user", "email", "t@t.com").release()
+    (tmp_path / "README.md").write_text("# Test\n")
+    repo.index.add(["README.md"])
+    repo.index.commit("initial")
+    new_branch = repo.create_head(branch_name)
+    new_branch.checkout()
+
+    tasks_dir = tmp_path / ".tasks"
+    tasks_dir.mkdir()
+    task_file = tasks_dir / normalized
+
+    spec = SimpleTaskSpec(
+        schema_version="1.0",
+        branch=branch_name,
+        title="JSON Output Test",
+        original_prompt="Test JSON output for CLI commands",
+        created=datetime.now(UTC),
+        acceptance_criteria=[
+            AcceptanceCriterion(id="AC1", description="JSON output works", completed=False),
+            AcceptanceCriterion(id="AC2", description="Default output unchanged", completed=False),
+        ],
+        quality_requirements=QualityRequirements(
+            linting=LintingConfig(enabled=True, tool=ToolName.RUFF, args=["check", "."]),
+            type_checking=TypeCheckConfig(enabled=True, tool=ToolName.MYPY, args=["."]),
+            testing=TestingConfig(
+                enabled=True,
+                tool=ToolName.PYTEST,
+                args=["--cov=cli/simpletask"],
+                min_coverage=80,
+            ),
+        ),
+        tasks=[
+            Task(
+                id="T001",
+                name="First task",
+                status=TaskStatus.NOT_STARTED,
+                goal="Verify JSON output path",
+                steps=["Step 1"],
+            ),
+            Task(
+                id="T002",
+                name="Second task",
+                status=TaskStatus.IN_PROGRESS,
+                goal="Another task",
+                steps=["Step A"],
+            ),
+        ],
+    )
+    write_task_file(task_file, spec)
+
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Read commands: show
+# ---------------------------------------------------------------------------
+
+
+class TestShowJsonOutput:
+    """Tests for 'simpletask show --format json'."""
+
+    def test_valid_json_response(self, json_project):
+        result = runner.invoke(app, ["show", "--format", "json"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_required_fields_present(self, json_project):
+        result = runner.invoke(app, ["show", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert "branch" in parsed
+        assert "title" in parsed
+        assert "acceptance_criteria" in parsed
+        assert "tasks" in parsed
+
+    def test_branch_and_title_correct(self, json_project):
+        result = runner.invoke(app, ["show", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["branch"] == "feature/json-output-test"
+        assert parsed["title"] == "JSON Output Test"
+
+    def test_no_ansi_codes(self, json_project):
+        result = runner.invoke(app, ["show", "--format", "json"])
+        assert "\033[" not in result.output
+        assert "\x1b[" not in result.output
+
+    def test_default_format_not_json(self, json_project):
+        result = runner.invoke(app, ["show"])
+        assert result.exit_code == 0
+        # Default output should be plain/rich text, not JSON
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(result.output)
+
+
+# ---------------------------------------------------------------------------
+# Read commands: task list
+# ---------------------------------------------------------------------------
+
+
+class TestTaskListJsonOutput:
+    """Tests for 'simpletask task list --format json'."""
+
+    def test_valid_json_response(self, json_project):
+        result = runner.invoke(app, ["task", "list", "--format", "json"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_required_fields_present(self, json_project):
+        result = runner.invoke(app, ["task", "list", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert "tasks" in parsed
+        assert "total" in parsed
+        assert "returned" in parsed
+        assert "file_path" in parsed
+
+    def test_tasks_list_is_correct(self, json_project):
+        result = runner.invoke(app, ["task", "list", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["total"] == 2
+        assert len(parsed["tasks"]) == 2
+
+    def test_task_entries_have_required_fields(self, json_project):
+        result = runner.invoke(app, ["task", "list", "--format", "json"])
+        parsed = json.loads(result.output)
+        for task in parsed["tasks"]:
+            assert "id" in task
+            assert "name" in task
+            assert "status" in task
+
+    def test_no_ansi_codes(self, json_project):
+        result = runner.invoke(app, ["task", "list", "--format", "json"])
+        assert "\033[" not in result.output
+
+    def test_default_format_not_json(self, json_project):
+        result = runner.invoke(app, ["task", "list"])
+        assert result.exit_code == 0
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(result.output)
+
+
+# ---------------------------------------------------------------------------
+# Read commands: criteria list
+# ---------------------------------------------------------------------------
+
+
+class TestCriteriaListJsonOutput:
+    """Tests for 'simpletask criteria list --format json'."""
+
+    def test_valid_json_response(self, json_project):
+        result = runner.invoke(app, ["criteria", "list", "--format", "json"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_required_fields_present(self, json_project):
+        result = runner.invoke(app, ["criteria", "list", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert "criteria" in parsed
+        assert "total" in parsed
+        assert "completed" in parsed
+        assert "file_path" in parsed
+
+    def test_criteria_entries_have_required_fields(self, json_project):
+        result = runner.invoke(app, ["criteria", "list", "--format", "json"])
+        parsed = json.loads(result.output)
+        for criterion in parsed["criteria"]:
+            assert "id" in criterion
+            assert "description" in criterion
+            assert "completed" in criterion
+
+    def test_counts_are_correct(self, json_project):
+        result = runner.invoke(app, ["criteria", "list", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["total"] == 2
+        assert parsed["completed"] == 0
+
+    def test_default_format_not_json(self, json_project):
+        result = runner.invoke(app, ["criteria", "list"])
+        assert result.exit_code == 0
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(result.output)
+
+
+# ---------------------------------------------------------------------------
+# Read commands: quality show
+# ---------------------------------------------------------------------------
+
+
+class TestQualityShowJsonOutput:
+    """Tests for 'simpletask quality show --format json'."""
+
+    def test_valid_json_response(self, json_project):
+        result = runner.invoke(app, ["quality", "show", "--format", "json"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_required_fields_present(self, json_project):
+        result = runner.invoke(app, ["quality", "show", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert "file_path" in parsed
+        assert "linting" in parsed
+
+    def test_linting_fields_present(self, json_project):
+        result = runner.invoke(app, ["quality", "show", "--format", "json"])
+        parsed = json.loads(result.output)
+        linting = parsed["linting"]
+        assert "enabled" in linting
+        assert "tool" in linting
+        assert "args" in linting
+
+    def test_linting_values_correct(self, json_project):
+        result = runner.invoke(app, ["quality", "show", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["linting"]["tool"] == "ruff"
+        assert parsed["linting"]["enabled"] is True
+
+    def test_no_ansi_codes(self, json_project):
+        result = runner.invoke(app, ["quality", "show", "--format", "json"])
+        assert "\033[" not in result.output
+
+    def test_default_format_not_json(self, json_project):
+        result = runner.invoke(app, ["quality", "show"])
+        assert result.exit_code == 0
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(result.output)
+
+
+# ---------------------------------------------------------------------------
+# Read commands: schema validate
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaValidateJsonOutput:
+    """Tests for 'simpletask schema validate --format json'."""
+
+    def test_valid_json_response(self, json_project):
+        result = runner.invoke(app, ["schema", "validate", "--format", "json"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_required_fields_present(self, json_project):
+        result = runner.invoke(app, ["schema", "validate", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert "file" in parsed
+        assert "valid" in parsed
+        assert "errors" in parsed
+
+    def test_valid_task_file_shows_valid_true(self, json_project):
+        result = runner.invoke(app, ["schema", "validate", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["valid"] is True
+        assert parsed["errors"] == []
+
+    def test_no_ansi_codes(self, json_project):
+        result = runner.invoke(app, ["schema", "validate", "--format", "json"])
+        assert "\033[" not in result.output
+
+    def test_default_format_not_json(self, json_project):
+        result = runner.invoke(app, ["schema", "validate"])
+        assert result.exit_code == 0
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(result.output)
+
+
+# ---------------------------------------------------------------------------
+# Read commands: schema validate --all
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaValidateAllJsonOutput:
+    """Tests for 'simpletask schema validate --all --format json'."""
+
+    # ------------------------------------------------------------------
+    # Happy path: single valid task file
+    # ------------------------------------------------------------------
+
+    def test_happy_path_exit_code_zero(self, json_project: Path) -> None:
+        result = runner.invoke(app, ["schema", "validate", "--all", "--format", "json"])
+        assert result.exit_code == 0, result.output
+
+    def test_happy_path_output_is_valid_json(self, json_project: Path) -> None:
+        result = runner.invoke(app, ["schema", "validate", "--all", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_happy_path_required_top_level_fields(self, json_project: Path) -> None:
+        result = runner.invoke(app, ["schema", "validate", "--all", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert "results" in parsed
+        assert "all_valid" in parsed
+
+    def test_happy_path_all_valid_true(self, json_project: Path) -> None:
+        result = runner.invoke(app, ["schema", "validate", "--all", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["all_valid"] is True
+
+    def test_happy_path_results_per_file_structure(self, json_project: Path) -> None:
+        """Each entry in 'results' must have 'file', 'valid', and 'errors' keys."""
+        result = runner.invoke(app, ["schema", "validate", "--all", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert isinstance(parsed["results"], list)
+        assert len(parsed["results"]) >= 1
+        for entry in parsed["results"]:
+            assert "file" in entry
+            assert "valid" in entry
+            assert "errors" in entry
+        # The fixture file is valid — no errors expected
+        assert all(e["valid"] for e in parsed["results"])
+
+    # ------------------------------------------------------------------
+    # Invalid file: schema-invalid task (has 'branch' key, fails schema)
+    # ------------------------------------------------------------------
+
+    def test_invalid_file_all_valid_false(self, json_project: Path) -> None:
+        """Injecting a schema-invalid YAML makes all_valid False."""
+        tasks_dir = json_project / ".tasks"
+        # Valid YAML with 'branch' so list_tasks() picks it up, but missing
+        # required schema fields so validate_task_file() returns errors.
+        (tasks_dir / "broken-branch.yml").write_text("branch: broken-test\ntitle: Bad\n")
+
+        result = runner.invoke(app, ["schema", "validate", "--all", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["all_valid"] is False
+
+    def test_invalid_file_broken_entry_has_errors(self, json_project: Path) -> None:
+        """The broken file entry in 'results' must show valid=False with errors."""
+        tasks_dir = json_project / ".tasks"
+        (tasks_dir / "broken-branch.yml").write_text("branch: broken-test\ntitle: Bad\n")
+
+        result = runner.invoke(app, ["schema", "validate", "--all", "--format", "json"])
+        parsed = json.loads(result.output)
+        broken = next((r for r in parsed["results"] if "broken" in r["file"]), None)
+        assert broken is not None, f"Expected broken entry in results: {parsed['results']}"
+        assert broken["valid"] is False
+        assert len(broken["errors"]) > 0
+
+    def test_invalid_file_exit_code_one(self, json_project: Path) -> None:
+        tasks_dir = json_project / ".tasks"
+        (tasks_dir / "broken-branch.yml").write_text("branch: broken-test\ntitle: Bad\n")
+
+        result = runner.invoke(app, ["schema", "validate", "--all", "--format", "json"])
+        assert result.exit_code == 1
+
+    def test_invalid_file_output_is_still_valid_json(self, json_project: Path) -> None:
+        """Even on validation failure the output must be parseable JSON."""
+        tasks_dir = json_project / ".tasks"
+        (tasks_dir / "broken-branch.yml").write_text("branch: broken-test\ntitle: Bad\n")
+
+        result = runner.invoke(app, ["schema", "validate", "--all", "--format", "json"])
+        parsed = json.loads(result.output)  # must not raise
+        assert isinstance(parsed, dict)
+
+    # ------------------------------------------------------------------
+    # Empty .tasks directory
+    # ------------------------------------------------------------------
+
+    def test_empty_tasks_exit_code_one(self, json_project: Path) -> None:
+        """Empty .tasks dir → exit 1."""
+        for f in (json_project / ".tasks").iterdir():
+            f.unlink()
+        result = runner.invoke(app, ["schema", "validate", "--all", "--format", "json"])
+        assert result.exit_code == 1
+
+    def test_empty_tasks_json_error_response(self, json_project: Path) -> None:
+        """Empty .tasks dir → JSON object with success=False and a message."""
+        for f in (json_project / ".tasks").iterdir():
+            f.unlink()
+        result = runner.invoke(app, ["schema", "validate", "--all", "--format", "json"])
+        parsed = json.loads(result.stderr)
+        assert parsed["success"] is False
+        assert "message" in parsed
+        assert parsed["message"]  # non-empty
+
+    def test_empty_tasks_no_ansi_codes(self, json_project: Path) -> None:
+        """Error response must contain no ANSI escape codes."""
+        for f in (json_project / ".tasks").iterdir():
+            f.unlink()
+        result = runner.invoke(app, ["schema", "validate", "--all", "--format", "json"])
+        assert "\033[" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Write commands: task add
+# ---------------------------------------------------------------------------
+
+
+class TestTaskAddJsonOutput:
+    """Tests for 'simpletask task add --format json'."""
+
+    def test_valid_json_response(self, json_project):
+        result = runner.invoke(app, ["task", "add", "New task", "--format", "json"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_required_fields_present(self, json_project):
+        result = runner.invoke(app, ["task", "add", "New task", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["success"] is True
+        assert "action" in parsed
+        assert "message" in parsed
+        assert "summary" in parsed
+
+    def test_action_is_task_added(self, json_project):
+        result = runner.invoke(app, ["task", "add", "New task", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["action"] == "task_added"
+
+    def test_summary_contains_task_counts(self, json_project):
+        result = runner.invoke(app, ["task", "add", "New task", "--format", "json"])
+        parsed = json.loads(result.output)
+        summary = parsed["summary"]
+        # Fixture has T001 (not_started) + T002 (in_progress); new task is not_started
+        assert summary["tasks_total"] == 3
+        assert summary["tasks_completed"] == 0
+        assert summary["tasks_not_started"] == 2
+        assert summary["tasks_in_progress"] == 1
+        assert summary["tasks_blocked"] == 0
+        assert summary["tasks_paused"] == 0
+
+    def test_default_format_not_json(self, json_project):
+        result = runner.invoke(app, ["task", "add", "Another task"])
+        assert result.exit_code == 0
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(result.output)
+
+
+# ---------------------------------------------------------------------------
+# Write commands: task update
+# ---------------------------------------------------------------------------
+
+
+class TestTaskUpdateJsonOutput:
+    """Tests for 'simpletask task update --format json'."""
+
+    def test_valid_json_response(self, json_project):
+        result = runner.invoke(
+            app, ["task", "update", "T001", "--status", "in_progress", "--format", "json"]
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_required_fields_present(self, json_project):
+        result = runner.invoke(
+            app, ["task", "update", "T001", "--status", "in_progress", "--format", "json"]
+        )
+        parsed = json.loads(result.output)
+        assert parsed["success"] is True
+        assert "action" in parsed
+        assert "message" in parsed
+        assert "summary" in parsed
+
+    def test_action_is_task_updated(self, json_project):
+        result = runner.invoke(
+            app, ["task", "update", "T001", "--status", "in_progress", "--format", "json"]
+        )
+        parsed = json.loads(result.output)
+        assert parsed["action"] == "task_updated"
+
+    def test_default_format_not_json(self, json_project):
+        result = runner.invoke(app, ["task", "update", "T002", "--status", "completed"])
+        assert result.exit_code == 0
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(result.output)
+
+
+# ---------------------------------------------------------------------------
+# Write commands: task remove
+# ---------------------------------------------------------------------------
+
+
+class TestTaskRemoveJsonOutput:
+    """Tests for 'simpletask task remove --force --format json'."""
+
+    def test_valid_json_response(self, json_project):
+        result = runner.invoke(app, ["task", "remove", "T001", "--force", "--format", "json"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_required_fields_present(self, json_project):
+        result = runner.invoke(app, ["task", "remove", "T001", "--force", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["success"] is True
+        assert "action" in parsed
+        assert "message" in parsed
+        assert "summary" in parsed
+
+    def test_action_is_task_removed(self, json_project):
+        result = runner.invoke(app, ["task", "remove", "T001", "--force", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["action"] == "task_removed"
+
+    def test_task_count_decremented(self, json_project):
+        result = runner.invoke(app, ["task", "remove", "T001", "--force", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["summary"]["tasks_total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Write commands: criteria add
+# ---------------------------------------------------------------------------
+
+
+class TestCriteriaAddJsonOutput:
+    """Tests for 'simpletask criteria add --format json'."""
+
+    def test_valid_json_response(self, json_project):
+        result = runner.invoke(app, ["criteria", "add", "New criterion text", "--format", "json"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_required_fields_present(self, json_project):
+        result = runner.invoke(app, ["criteria", "add", "New criterion text", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["success"] is True
+        assert "action" in parsed
+        assert "message" in parsed
+        assert "summary" in parsed
+
+    def test_action_is_criterion_added(self, json_project):
+        result = runner.invoke(app, ["criteria", "add", "New criterion text", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["action"] == "criterion_added"
+
+    def test_summary_has_criteria_counts(self, json_project):
+        result = runner.invoke(app, ["criteria", "add", "New criterion text", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert "criteria_total" in parsed["summary"]
+        assert "criteria_completed" in parsed["summary"]
+
+
+# ---------------------------------------------------------------------------
+# Write commands: criteria complete
+# ---------------------------------------------------------------------------
+
+
+class TestCriteriaCompleteJsonOutput:
+    """Tests for 'simpletask criteria complete --format json'."""
+
+    def test_valid_json_response(self, json_project):
+        result = runner.invoke(app, ["criteria", "complete", "AC1", "--format", "json"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_required_fields_present(self, json_project):
+        result = runner.invoke(app, ["criteria", "complete", "AC1", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["success"] is True
+        assert "action" in parsed
+        assert "message" in parsed
+        assert "summary" in parsed
+
+    def test_action_is_criterion_completed(self, json_project):
+        result = runner.invoke(app, ["criteria", "complete", "AC1", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["action"] == "criterion_completed"
+
+    def test_completed_count_incremented(self, json_project):
+        result = runner.invoke(app, ["criteria", "complete", "AC1", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["summary"]["criteria_completed"] == 1
+
+    def test_default_format_not_json(self, json_project):
+        result = runner.invoke(app, ["criteria", "complete", "AC2"])
+        assert result.exit_code == 0
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(result.output)
+
+    def test_uncomplete_action_field_correct(self, json_project):
+        # First complete the criterion so uncomplete has something to revert
+        runner.invoke(app, ["criteria", "complete", "AC1", "--format", "json"])
+        result = runner.invoke(
+            app, ["criteria", "complete", "AC1", "--uncomplete", "--format", "json"]
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed["action"] == "criterion_uncompleted"
+        assert (
+            "not completed" in parsed["message"].lower()
+            or "uncomplete" in parsed["message"].lower()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Write commands: note add
+# ---------------------------------------------------------------------------
+
+
+class TestNoteAddJsonOutput:
+    """Tests for 'simpletask note add --format json'."""
+
+    def test_valid_json_response(self, json_project):
+        result = runner.invoke(app, ["note", "add", "Remember this", "--format", "json"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_required_fields_present(self, json_project):
+        result = runner.invoke(app, ["note", "add", "Remember this", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["success"] is True
+        assert "action" in parsed
+        assert "message" in parsed
+        assert "summary" in parsed
+
+    def test_action_is_note_added(self, json_project):
+        result = runner.invoke(app, ["note", "add", "Remember this", "--format", "json"])
+        parsed = json.loads(result.output)
+        assert parsed["action"] == "note_added"
+
+    def test_default_format_not_json(self, json_project):
+        result = runner.invoke(app, ["note", "add", "Some note"])
+        assert result.exit_code == 0
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(result.output)
+
+    def test_task_level_note_on_task_without_prior_notes(self, json_project):
+        # T001 in the fixture has no task-level notes; adding one must not crash
+        result = runner.invoke(
+            app, ["note", "add", "task note", "--task", "T001", "--format", "json"]
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed["success"] is True
+        assert parsed["action"] == "note_added"
+        assert parsed["summary"]["notes_total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Error path tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPathJsonOutput:
+    """Tests that error paths produce JSON with success=false when --format json is set."""
+
+    def test_task_update_bad_id_produces_json_error(self, json_project):
+        result = runner.invoke(
+            app,
+            ["task", "update", "T999", "--status", "completed", "--format", "json"],
+        )
+        parsed = json.loads(result.stderr)
+        assert parsed["success"] is False
+        assert "message" in parsed
+
+    def test_task_update_bad_id_no_ansi(self, json_project):
+        result = runner.invoke(
+            app,
+            ["task", "update", "T999", "--status", "completed", "--format", "json"],
+        )
+        assert "\033[" not in result.stderr
+        assert "\x1b[" not in result.stderr
+
+    def test_task_remove_bad_id_produces_json_error(self, json_project):
+        result = runner.invoke(app, ["task", "remove", "T999", "--force", "--format", "json"])
+        parsed = json.loads(result.stderr)
+        assert parsed["success"] is False
+        assert "message" in parsed
+
+    def test_criteria_complete_bad_id_produces_json_error(self, json_project):
+        result = runner.invoke(app, ["criteria", "complete", "AC99", "--format", "json"])
+        parsed = json.loads(result.stderr)
+        assert parsed["success"] is False
+        assert "message" in parsed
+
+    def test_show_missing_file_produces_json_error(self, tmp_path, monkeypatch):
+        """show with --format json and no task file returns JSON error."""
+        repo = git.Repo.init(tmp_path)
+        repo.config_writer().set_value("user", "name", "Test").release()
+        repo.config_writer().set_value("user", "email", "t@t.com").release()
+        (tmp_path / "README.md").write_text("# Test\n")
+        repo.index.add(["README.md"])
+        repo.index.commit("initial")
+        repo.create_head("feature/no-task").checkout()
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["show", "--format", "json"])
+        parsed = json.loads(result.stderr)
+        assert parsed["success"] is False
+        assert "message" in parsed
+
+    def test_task_list_missing_file_produces_json_error(self, tmp_path, monkeypatch):
+        """task list with --format json and no task file returns JSON error."""
+        repo = git.Repo.init(tmp_path)
+        repo.config_writer().set_value("user", "name", "Test").release()
+        repo.config_writer().set_value("user", "email", "t@t.com").release()
+        (tmp_path / "README.md").write_text("# Test\n")
+        repo.index.add(["README.md"])
+        repo.index.commit("initial")
+        repo.create_head("feature/no-task").checkout()
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["task", "list", "--format", "json"])
+        parsed = json.loads(result.stderr)
+        assert parsed["success"] is False
+        assert "message" in parsed
+
+
+class TestJsonErrorExitCodes:
+    """Tests that JSON error paths exit with code 1."""
+
+    def test_task_update_bad_id_exits_1(self, json_project):
+        result = runner.invoke(
+            app, ["task", "update", "T999", "--status", "completed", "--format", "json"]
+        )
+        assert result.exit_code == 1
+
+    def test_task_remove_bad_id_exits_1(self, json_project):
+        result = runner.invoke(app, ["task", "remove", "T999", "--force", "--format", "json"])
+        assert result.exit_code == 1
+
+    def test_criteria_complete_bad_id_exits_1(self, json_project):
+        result = runner.invoke(app, ["criteria", "complete", "AC99", "--format", "json"])
+        assert result.exit_code == 1
+
+    def test_show_missing_file_exits_1(self, tmp_path, monkeypatch):
+        """show --format json with missing task file exits 1."""
+        import git
+
+        repo = git.Repo.init(tmp_path)
+        repo.config_writer().set_value("user", "name", "Test").release()
+        repo.config_writer().set_value("user", "email", "t@t.com").release()
+        (tmp_path / "README.md").write_text("# Test\n")
+        repo.index.add(["README.md"])
+        repo.index.commit("initial")
+        repo.create_head("feature/no-task").checkout()
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["show", "--format", "json"])
+        assert result.exit_code == 1
+
+    def test_schema_validate_missing_file_exits_1(self, tmp_path, monkeypatch):
+        """schema validate --format json with missing task file exits 1."""
+        import git
+
+        repo = git.Repo.init(tmp_path)
+        repo.config_writer().set_value("user", "name", "Test").release()
+        repo.config_writer().set_value("user", "email", "t@t.com").release()
+        (tmp_path / "README.md").write_text("# Test\n")
+        repo.index.add(["README.md"])
+        repo.index.commit("initial")
+        repo.create_head("feature/no-task").checkout()
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["schema", "validate", "--format", "json"])
+        assert result.exit_code == 1
+
+    def test_error_json_goes_to_stderr_not_stdout(self, json_project):
+        """json_error() output must be in stderr; stdout must be empty for error paths."""
+        result = runner.invoke(
+            app, ["task", "update", "T999", "--status", "completed", "--format", "json"]
+        )
+        # Successful JSON responses go to stdout; error JSON goes to stderr
+        assert result.output.strip() == "" or json.loads(result.stderr)["success"] is False
+        parsed = json.loads(result.stderr)
+        assert parsed["success"] is False

--- a/tests/integration/test_show_json_complete.py
+++ b/tests/integration/test_show_json_complete.py
@@ -1,0 +1,128 @@
+"""Test that show --format json includes all task fields."""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import git
+import pytest
+from simpletask import app
+from simpletask.core.models import (
+    AcceptanceCriterion,
+    LintingConfig,
+    QualityRequirements,
+    SimpleTaskSpec,
+    Task,
+    TaskStatus,
+    TestingConfig,
+    ToolName,
+    TypeCheckConfig,
+)
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def json_project(tmp_path: Path, monkeypatch):
+    """Set up a temporary git repo with a pre-existing task file."""
+    branch_name = "feature/show-complete-test"
+    normalized = "feature-show-complete-test.yml"
+
+    repo = git.Repo.init(tmp_path)
+    repo.config_writer().set_value("user", "name", "Test").release()
+    repo.config_writer().set_value("user", "email", "t@t.com").release()
+    (tmp_path / "README.md").write_text("# Test\n")
+    repo.index.add(["README.md"])
+    repo.index.commit("initial")
+    new_branch = repo.create_head(branch_name)
+    new_branch.checkout()
+
+    tasks_dir = tmp_path / ".tasks"
+    tasks_dir.mkdir()
+    task_file = tasks_dir / normalized
+
+    spec = SimpleTaskSpec(
+        schema_version="1.0",
+        branch=branch_name,
+        title="Show Complete Fields Test",
+        original_prompt="Test show command includes all fields",
+        created=datetime.now(UTC),
+        acceptance_criteria=[
+            AcceptanceCriterion(id="AC1", description="Include all fields", completed=False),
+        ],
+        quality_requirements=QualityRequirements(
+            linting=LintingConfig(enabled=True, tool=ToolName.RUFF, args=["check", "."]),
+            type_checking=TypeCheckConfig(enabled=True, tool=ToolName.MYPY, args=["."]),
+            testing=TestingConfig(
+                enabled=True,
+                tool=ToolName.PYTEST,
+                args=["--cov=cli/simpletask"],
+                min_coverage=80,
+            ),
+        ),
+        tasks=[
+            Task(
+                id="T001",
+                name="Test task",
+                status=TaskStatus.NOT_STARTED,
+                goal="Verify all fields present",
+                steps=["Step 1", "Step 2"],
+                done_when=["All tests pass"],
+                prerequisites=None,
+                files=None,
+                code_examples=None,
+                notes=["Important note"],
+                iteration=None,
+            ),
+        ],
+        context={"version": "1.0", "environment": "test"},
+    )
+
+    spec.model_dump_json()  # Validate the model
+    task_file.write_text(json.dumps(json.loads(spec.model_dump_json()), indent=2))
+
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+class TestShowJsonCompleteFields:
+    """Verify show --format json includes complete task information."""
+
+    def test_show_json_includes_all_task_fields(self, json_project: Path) -> None:
+        """show --format json should include steps, done_when, prerequisites, files, code_examples, notes."""
+        result = runner.invoke(app, ["show", "--format", "json"])
+        assert result.exit_code == 0, f"Exit code: {result.exit_code}, Output: {result.output}"
+
+        parsed = json.loads(result.output)
+        assert "tasks" in parsed
+
+        # Check first task has all expected fields
+        if parsed["tasks"]:
+            task = parsed["tasks"][0]
+            expected_fields = {
+                "id",
+                "name",
+                "status",
+                "goal",
+                "steps",
+                "done_when",
+                "prerequisites",
+                "files",
+                "code_examples",
+                "notes",
+                "iteration",
+            }
+            for field in expected_fields:
+                assert field in task, f"Task missing field: {field}"
+
+    def test_show_json_includes_iterations_and_context(self, json_project: Path) -> None:
+        """show --format json should include top-level iterations and context."""
+        result = runner.invoke(app, ["show", "--format", "json"])
+        assert result.exit_code == 0
+
+        parsed = json.loads(result.output)
+        assert "iterations" in parsed, "Missing iterations in output"
+        assert "context" in parsed, "Missing context in output"
+        assert isinstance(parsed["iterations"], list)
+        assert isinstance(parsed["context"], dict)

--- a/tests/unit/test_output_format.py
+++ b/tests/unit/test_output_format.py
@@ -1,0 +1,146 @@
+"""Unit tests for OutputFormat enum, resolve_format(), and json_error().
+
+Tests cover:
+- OutputFormat enum has correct string values
+- resolve_format() auto-downgrades RICH to PLAIN when stdout is not a terminal
+- resolve_format() leaves PLAIN and JSON unchanged regardless of terminal state
+- resolve_format() keeps RICH when stdout is a real terminal
+- json_error() prints valid JSON to stdout with success=False and a message field
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from simpletask.utils.output import OutputFormat, json_error, resolve_format
+
+
+class TestOutputFormatEnum:
+    """Tests for OutputFormat enum values."""
+
+    def test_rich_value(self):
+        """RICH has string value 'rich'."""
+        assert OutputFormat.RICH == "rich"
+        assert OutputFormat.RICH.value == "rich"
+
+    def test_plain_value(self):
+        """PLAIN has string value 'plain'."""
+        assert OutputFormat.PLAIN == "plain"
+        assert OutputFormat.PLAIN.value == "plain"
+
+    def test_json_value(self):
+        """JSON has string value 'json'."""
+        assert OutputFormat.JSON == "json"
+        assert OutputFormat.JSON.value == "json"
+
+    def test_enum_is_str_subclass(self):
+        """OutputFormat is a str enum (usable as a plain string)."""
+        assert isinstance(OutputFormat.JSON, str)
+
+    def test_all_three_values_distinct(self):
+        """All three enum members are distinct."""
+        values = {OutputFormat.RICH, OutputFormat.PLAIN, OutputFormat.JSON}
+        assert len(values) == 3
+
+
+class TestResolveFormat:
+    """Tests for resolve_format() auto-downgrade logic."""
+
+    def test_rich_downgrades_to_plain_when_not_terminal(self):
+        """RICH is downgraded to PLAIN when console is not a terminal."""
+        with patch("simpletask.utils.output.console") as mock_console:
+            mock_console.is_terminal = False
+            result = resolve_format(OutputFormat.RICH)
+        assert result == OutputFormat.PLAIN
+
+    def test_rich_unchanged_when_terminal(self):
+        """RICH stays RICH when console is a real terminal."""
+        with patch("simpletask.utils.output.console") as mock_console:
+            mock_console.is_terminal = True
+            result = resolve_format(OutputFormat.RICH)
+        assert result == OutputFormat.RICH
+
+    def test_plain_unchanged_when_not_terminal(self):
+        """PLAIN is unaffected by terminal state (not a terminal)."""
+        with patch("simpletask.utils.output.console") as mock_console:
+            mock_console.is_terminal = False
+            result = resolve_format(OutputFormat.PLAIN)
+        assert result == OutputFormat.PLAIN
+
+    def test_plain_unchanged_when_terminal(self):
+        """PLAIN is unaffected by terminal state (is a terminal)."""
+        with patch("simpletask.utils.output.console") as mock_console:
+            mock_console.is_terminal = True
+            result = resolve_format(OutputFormat.PLAIN)
+        assert result == OutputFormat.PLAIN
+
+    def test_json_unchanged_when_not_terminal(self):
+        """JSON is never downgraded regardless of terminal state."""
+        with patch("simpletask.utils.output.console") as mock_console:
+            mock_console.is_terminal = False
+            result = resolve_format(OutputFormat.JSON)
+        assert result == OutputFormat.JSON
+
+    def test_json_unchanged_when_terminal(self):
+        """JSON stays JSON even when stdout is a terminal."""
+        with patch("simpletask.utils.output.console") as mock_console:
+            mock_console.is_terminal = True
+            result = resolve_format(OutputFormat.JSON)
+        assert result == OutputFormat.JSON
+
+
+class TestJsonError:
+    """Tests for json_error() output."""
+
+    def test_outputs_valid_json(self, capsys):
+        """json_error() prints parseable JSON to stderr."""
+        json_error("Something went wrong")
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.err)
+        assert isinstance(parsed, dict)
+
+    def test_success_is_false(self, capsys):
+        """json_error() always sets success=False."""
+        json_error("error message")
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.err)
+        assert parsed["success"] is False
+
+    def test_message_field_present(self, capsys):
+        """json_error() includes the provided message."""
+        json_error("Task not found")
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.err)
+        assert parsed["message"] == "Task not found"
+
+    def test_no_ansi_codes_in_output(self, capsys):
+        """json_error() output contains no ANSI escape sequences."""
+        json_error("error")
+        captured = capsys.readouterr()
+        assert "\033[" not in captured.err
+        assert "\x1b[" not in captured.err
+
+    def test_nothing_written_to_stdout(self, capsys):
+        """json_error() writes only to stderr, not stdout."""
+        json_error("some error")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        parsed = json.loads(captured.err)
+        assert parsed["success"] is False
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "simple error",
+            "Error with 'quotes' and \"double quotes\"",
+            "Unicode: café, résumé",
+            "Newline\\nin message",
+        ],
+    )
+    def test_various_messages_produce_valid_json(self, capsys, msg):
+        """json_error() handles various message strings without breaking JSON."""
+        json_error(msg)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.err)
+        assert parsed["success"] is False
+        assert "message" in parsed


### PR DESCRIPTION
## Summary

- Adds `--format json` to all read-oriented commands (`show`, `task list`, `criteria list`, `quality show`, `schema validate`) — JSON output contains the same fields as Rich tables, no ANSI codes
- Adds `--format json` to all write-oriented commands (`task update/add/remove`, `criteria complete/add/remove/update`, `note add/remove`, `constraint add/remove`, `context set/remove`) — emits `{success, action, message, summary}` on success; `{success: false, message}` on error
- Extracts `OutputFormat` enum + `resolve_format()` / `json_error()` helpers into `cli/simpletask/utils/output.py` — single definition shared by all commands
- Default behaviour (no `--format` flag) is **unchanged**
- Exit code semantics preserved: `schema validate` exits 1 on validation failure regardless of format
- Fixes `schema validate --all --format json` emitting Rich prose instead of JSON when `.tasks/` is empty
- 13 integration test classes + 3 unit test classes covering JSON output, required field presence, error paths, and unchanged default output

## Closes

Closes #29
Closes #30