### PR TITLE
refactor(quality): execution specs and workflow runners

### DIFF
--- a/cli/simpletask/__init__.py
+++ b/cli/simpletask/__init__.py
@@ -1,6 +1,6 @@
 """simpletask: A Python CLI for managing AI-friendly task definition YAML files."""
 
-__version__ = "0.35.13"
+__version__ = "0.36.0"
 
 import typer
 

--- a/cli/simpletask/commands/defaults/commands.py
+++ b/cli/simpletask/commands/defaults/commands.py
@@ -22,6 +22,7 @@ from simpletask.core.models import (
     SecurityCategory,
     SecurityRequirement,
     ToolName,
+    WorkflowRunner,
 )
 from simpletask.core.presets import (
     QUALITY_PRESETS,
@@ -422,6 +423,18 @@ def quality_set_command(
             "--args", "-a", help="Tool arguments as comma-separated list (e.g., 'check,.,--fix')"
         ),
     ] = None,
+    runner: Annotated[
+        WorkflowRunner | None,
+        typer.Option("--runner", "-r", help="Workflow runner (make or earthly)"),
+    ] = None,
+    target: Annotated[
+        str | None,
+        typer.Option(
+            "--target",
+            "-T",
+            help="Workflow target or rule name (used with --runner)",
+        ),
+    ] = None,
     enable: Annotated[bool, typer.Option("--enable", help="Enable this quality check")] = False,
     disable: Annotated[bool, typer.Option("--disable", help="Disable this quality check")] = False,
     min_coverage: Annotated[
@@ -440,20 +453,35 @@ def quality_set_command(
 ) -> None:
     """Set a quality configuration in project defaults.
 
-    Examples:
+    Tool-mode examples (direct tool execution):
         simpletask defaults quality set linting --tool ruff --args "check,."
         simpletask defaults quality set testing --tool pytest --min-coverage 80
         simpletask defaults quality set type-checking --tool mypy --enable
+
+    Workflow-mode examples (make or earthly):
+        simpletask defaults quality set linting --runner make --target lint
+        simpletask defaults quality set testing --runner earthly --target +test
     """
     try:
+        # Validate that tool/args and runner/target are not mixed
+        has_tool_args = tool is not None or args is not None
+        has_workflow = runner is not None or target is not None
+
+        if has_tool_args and has_workflow:
+            error(
+                "Cannot mix tool-mode and workflow-mode: provide either "
+                "(--tool/--args) or (--runner/--target), not both"
+            )
+            return
+
         if enable and disable:
             error("Cannot specify both --enable and --disable")
+            return
 
         project = ensure_project()
         defaults = _load_or_empty(project)
 
-        # update_quality_requirements operates directly on QualityRequirements.
-
+        # Parse arguments
         args_list: list[str] | None = None
         if args:
             args_list = [a.strip() for a in args.split(",")]
@@ -475,6 +503,8 @@ def quality_set_command(
             enabled=enabled_status,
             min_coverage=min_coverage,
             timeout=timeout,
+            workflow_runner=runner,
+            workflow_target=target,
         )
         defaults.quality_requirements = updated_reqs
         save_defaults(project, defaults)
@@ -488,6 +518,10 @@ def quality_set_command(
             changes.append(f"tool: {tool.value}")
         if args_list:
             changes.append(f"args: {', '.join(args_list)}")
+        if runner:
+            changes.append(f"runner: {runner.value}")
+        if target:
+            changes.append(f"target: {target}")
         if enabled_status is not None:
             changes.append(f"enabled: {str(enabled_status).lower()}")
         if min_coverage is not None:

--- a/cli/simpletask/commands/quality/set.py
+++ b/cli/simpletask/commands/quality/set.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 import typer
 
-from simpletask.core.models import ToolName
+from simpletask.core.models import ToolName, WorkflowRunner
 from simpletask.core.project import get_task_file_path
 from simpletask.core.quality_ops import update_quality_config
 from simpletask.core.yaml_parser import parse_task_file, write_task_file
@@ -38,6 +38,18 @@ def set_command(
             "--args", "-a", help="Tool arguments as comma-separated list (e.g., 'check,.,--fix')"
         ),
     ] = None,
+    runner: Annotated[
+        WorkflowRunner | None,
+        typer.Option("--runner", "-r", help="Workflow runner (make or earthly)"),
+    ] = None,
+    target: Annotated[
+        str | None,
+        typer.Option(
+            "--target",
+            "-T",
+            help="Workflow target or rule name (used with --runner)",
+        ),
+    ] = None,
     enable: Annotated[bool, typer.Option("--enable", help="Enable this quality check")] = False,
     disable: Annotated[bool, typer.Option("--disable", help="Disable this quality check")] = False,
     min_coverage: Annotated[
@@ -65,15 +77,29 @@ def set_command(
     """Set quality requirements configuration.
 
     Configure individual quality check settings including tools, arguments, enable/disable status,
-    coverage thresholds, and timeouts.
+    coverage thresholds, timeouts, and workflow runners.
 
-    Examples:
+    Tool-mode examples (direct tool execution):
         simpletask quality set linting --tool ruff --args "check,."
         simpletask quality set testing --enable --min-coverage 80 --timeout 600
         simpletask quality set type-checking --disable
-        simpletask quality set security --enable --tool bandit --args "-r,." --timeout 120
+
+    Workflow-mode examples (make or earthly):
+        simpletask quality set linting --runner make --target lint
+        simpletask quality set testing --runner earthly --target +test
     """
     try:
+        # Validate that tool/args and runner/target are not mixed
+        has_tool_args = tool is not None or args is not None
+        has_workflow = runner is not None or target is not None
+
+        if has_tool_args and has_workflow:
+            error(
+                "Cannot mix tool-mode and workflow-mode: provide either "
+                "(--tool/--args) or (--runner/--target), not both"
+            )
+            raise typer.Exit(1)
+
         # Parse args string into list if provided
         args_list: list[str] | None = None
         if args:
@@ -89,6 +115,7 @@ def set_command(
         # Validate enable/disable conflict
         if enable and disable:
             error("Cannot specify both --enable and --disable")
+            raise typer.Exit(1)
 
         # Parse task file
         file_path = get_task_file_path(branch)
@@ -97,22 +124,22 @@ def set_command(
         # Map ConfigType enum to string for quality_ops
         config_type_str = config_type.value  # "linting", "type-checking", "testing", "security"
 
-        # Convert ToolName enum value
-        tool_enum = tool  # Already a ToolName enum from Typer
-
         # Update using shared logic
         try:
             updated_spec = update_quality_config(
                 spec,
                 config_type_str,  # type: ignore
-                tool=tool_enum,
+                tool=tool,
                 args=args_list,
                 enabled=enabled_status,
                 min_coverage=min_coverage,
                 timeout=timeout,
+                workflow_runner=runner,
+                workflow_target=target,
             )
         except ValueError as e:
             error(str(e))
+            raise typer.Exit(1) from None
 
         # Write back to file
         write_task_file(file_path, updated_spec)
@@ -128,6 +155,10 @@ def set_command(
             changes.append(f"tool: {tool.value}")
         if args_list:
             changes.append(f"args: {', '.join(args_list)}")
+        if runner:
+            changes.append(f"runner: {runner.value}")
+        if target:
+            changes.append(f"target: {target}")
         if enabled_status is not None:
             changes.append(f"enabled: {str(enabled_status).lower()}")
         if min_coverage is not None:
@@ -140,5 +171,7 @@ def set_command(
 
     except FileNotFoundError as e:
         error(str(e))
+        raise typer.Exit(1) from None
     except Exception as e:
         error(f"Unexpected error: {e}")
+        raise typer.Exit(1) from None

--- a/cli/simpletask/commands/quality/show.py
+++ b/cli/simpletask/commands/quality/show.py
@@ -5,7 +5,7 @@ from typing import Annotated
 import typer
 from rich.table import Table
 
-from simpletask.core.models import ToolName
+from simpletask.core.models import ToolExecutionSpec, WorkflowExecutionSpec
 from simpletask.core.project import get_task_file_path
 from simpletask.core.yaml_parser import parse_task_file
 from simpletask.utils.console import console, error
@@ -18,15 +18,27 @@ from simpletask.utils.output import (
 )
 
 
-def _format_tool_command(tool: ToolName | None, args: list[str]) -> str:
-    """Format tool and args into a human-readable command string."""
-    if tool is None:
+def _format_execution_spec(execution) -> str:
+    """Format execution spec into a human-readable command string.
+
+    Args:
+        execution: ToolExecutionSpec or WorkflowExecutionSpec instance, or None.
+
+    Returns:
+        Human-readable command string.
+    """
+    if execution is None:
         return ""
 
-    if not args:
-        return tool.value
+    if isinstance(execution, ToolExecutionSpec):
+        if not execution.args:
+            return execution.tool.value
+        return f"{execution.tool.value} {' '.join(execution.args)}"
 
-    return f"{tool.value} {' '.join(args)}"
+    if isinstance(execution, WorkflowExecutionSpec):
+        return f"{execution.runner.value} {execution.target}"
+
+    return ""
 
 
 def _print_json_quality_show(quality_reqs, file_path: str) -> None:
@@ -98,7 +110,7 @@ def show_command(
         table.add_row(
             "Linting",
             enabled_icon,
-            _format_tool_command(quality_reqs.linting.tool, quality_reqs.linting.args),
+            _format_execution_spec(quality_reqs.linting.execution),
             "",
         )
 
@@ -110,9 +122,7 @@ def show_command(
             table.add_row(
                 "Type Checking",
                 enabled_icon,
-                _format_tool_command(
-                    quality_reqs.type_checking.tool, quality_reqs.type_checking.args
-                ),
+                _format_execution_spec(quality_reqs.type_checking.execution),
                 "",
             )
         else:
@@ -126,7 +136,7 @@ def show_command(
         table.add_row(
             "Testing",
             enabled_icon,
-            _format_tool_command(quality_reqs.testing.tool, quality_reqs.testing.args),
+            _format_execution_spec(quality_reqs.testing.execution),
             options,
         )
 
@@ -135,9 +145,7 @@ def show_command(
             enabled_icon = (
                 "[green]✓[/green]" if quality_reqs.security_check.enabled else "[red]✗[/red]"
             )
-            cmd = _format_tool_command(
-                quality_reqs.security_check.tool, quality_reqs.security_check.args
-            )
+            cmd = _format_execution_spec(quality_reqs.security_check.execution)
             table.add_row(
                 "Security Check",
                 enabled_icon,

--- a/cli/simpletask/commands/show.py
+++ b/cli/simpletask/commands/show.py
@@ -4,7 +4,13 @@ from typing import Annotated
 
 import typer
 
-from ..core.models import Design, QualityRequirements, Task
+from ..core.models import (
+    Design,
+    QualityRequirements,
+    Task,
+    ToolExecutionSpec,
+    WorkflowExecutionSpec,
+)
 from ..core.project import ensure_project, get_task_file_path
 from ..core.yaml_parser import InvalidTaskFileError, parse_task_file
 from ..utils.console import console, error
@@ -28,16 +34,24 @@ def _format_quality_summary(quality_reqs: QualityRequirements) -> str:
     """
     parts = []
 
+    def _exec_label(execution: ToolExecutionSpec | WorkflowExecutionSpec | None) -> str:
+        """Return a short human-readable label for an execution spec."""
+        if execution is None:
+            return ""
+        if isinstance(execution, ToolExecutionSpec):
+            return execution.tool.value
+        return f"{execution.runner.value} {execution.target}"
+
     # Linting
     icon = "✓" if quality_reqs.linting.enabled else "○"
     color = "green" if quality_reqs.linting.enabled else "dim"
-    tool_name = quality_reqs.linting.tool.value if quality_reqs.linting.enabled else ""
+    tool_name = _exec_label(quality_reqs.linting.execution) if quality_reqs.linting.enabled else ""
     parts.append(f"[{color}]{icon}[/{color}] lint" + (f" ({tool_name})" if tool_name else ""))
 
     # Testing
     icon = "✓" if quality_reqs.testing.enabled else "○"
     color = "green" if quality_reqs.testing.enabled else "dim"
-    tool_name = quality_reqs.testing.tool.value if quality_reqs.testing.enabled else ""
+    tool_name = _exec_label(quality_reqs.testing.execution) if quality_reqs.testing.enabled else ""
     cov = f", {quality_reqs.testing.min_coverage}% cov" if quality_reqs.testing.min_coverage else ""
     parts.append(f"[{color}]{icon}[/{color}] test" + (f" ({tool_name}{cov})" if tool_name else ""))
 
@@ -46,7 +60,9 @@ def _format_quality_summary(quality_reqs: QualityRequirements) -> str:
         icon = "✓" if quality_reqs.type_checking.enabled else "○"
         color = "green" if quality_reqs.type_checking.enabled else "dim"
         tool_name = (
-            quality_reqs.type_checking.tool.value if quality_reqs.type_checking.enabled else ""
+            _exec_label(quality_reqs.type_checking.execution)
+            if quality_reqs.type_checking.enabled
+            else ""
         )
         parts.append(f"[{color}]{icon}[/{color}] types" + (f" ({tool_name})" if tool_name else ""))
     else:
@@ -57,8 +73,8 @@ def _format_quality_summary(quality_reqs: QualityRequirements) -> str:
         icon = "✓" if quality_reqs.security_check.enabled else "○"
         color = "green" if quality_reqs.security_check.enabled else "dim"
         tool_name = (
-            quality_reqs.security_check.tool.value
-            if quality_reqs.security_check.enabled and quality_reqs.security_check.tool
+            _exec_label(quality_reqs.security_check.execution)
+            if quality_reqs.security_check.enabled
             else ""
         )
         parts.append(

--- a/cli/simpletask/core/models.py
+++ b/cli/simpletask/core/models.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_serializer, model_validator
 
 
 class TaskStatus(str, Enum):
@@ -57,6 +57,21 @@ class ToolName(str, Enum):
 
     # Other tools
     MAKE = "make"
+    EARTHLY = "earthly"
+
+
+class ExecutionKind(str, Enum):
+    """Type of execution for quality checks."""
+
+    TOOL = "tool"
+    WORKFLOW = "workflow"
+
+
+class WorkflowRunner(str, Enum):
+    """Supported workflow runners for quality checks."""
+
+    MAKE = "make"
+    EARTHLY = "earthly"
 
 
 class AcceptanceCriterion(BaseModel):
@@ -88,6 +103,32 @@ class CodeExample(BaseModel):
     code: str = Field(..., description="The actual code")
 
 
+class ToolExecutionSpec(BaseModel):
+    """Execution specification for tool-based quality checks."""
+
+    model_config = {"extra": "forbid"}
+
+    kind: ExecutionKind = Field(ExecutionKind.TOOL, description="Execution kind")
+    tool: ToolName = Field(..., description="Tool to execute")
+    args: list[str] = Field(default_factory=list, description="Tool arguments")
+
+
+class WorkflowExecutionSpec(BaseModel):
+    """Execution specification for workflow-based quality checks."""
+
+    model_config = {"extra": "forbid"}
+
+    kind: ExecutionKind = Field(ExecutionKind.WORKFLOW, description="Execution kind")
+    runner: WorkflowRunner = Field(..., description="Workflow runner to use")
+    target: str = Field(..., description="Workflow target or rule name")
+    no_cache: bool = Field(
+        default=False, description="Pass --no-cache to Earthly runner (ignored for make)"
+    )
+    extra_args: list[str] = Field(
+        default_factory=list, description="Additional flags passed to the runner before the target"
+    )
+
+
 def validate_no_shell_metacharacters(args: list[str]) -> list[str]:
     """Shared validator for rejecting dangerous shell metacharacters.
 
@@ -117,83 +158,117 @@ def validate_no_shell_metacharacters(args: list[str]) -> list[str]:
     return args
 
 
-class LintingConfig(BaseModel):
+def normalize_legacy_to_execution(
+    tool: ToolName | None,
+    args: list[str] | None,
+    execution: ToolExecutionSpec | WorkflowExecutionSpec | None,
+) -> ToolExecutionSpec | WorkflowExecutionSpec | None:
+    """Normalize legacy tool/args to canonical execution spec if needed.
+
+    If execution is already set, return it as-is.
+    If tool is set, convert tool and args to ToolExecutionSpec.
+    Otherwise return None.
+
+    Args:
+        tool: Legacy tool name if using legacy form
+        args: Legacy arguments if using legacy form
+        execution: Already-set execution spec if using canonical form
+
+    Returns:
+        Execution spec in canonical form, or None if neither form provided
+    """
+    if execution is not None:
+        return execution
+
+    if tool is not None:
+        return ToolExecutionSpec(tool=tool, args=args or [])
+
+    return None
+
+
+class BaseQualityConfig(BaseModel):
+    """Shared base for all quality check configuration types.
+
+    Holds the common execution, legacy-compat, and timeout fields used by
+    LintingConfig, TypeCheckConfig, TestingConfig, and SecurityCheckConfig.
+    Subclasses add only the fields that differ (e.g. min_coverage, enabled default).
+    """
+
+    model_config = {"extra": "forbid"}
+
+    enabled: bool = Field(..., description="Whether this check is enabled")
+    execution: ToolExecutionSpec | WorkflowExecutionSpec | None = Field(
+        None, description="Nested execution specification (canonical form)"
+    )
+    tool: ToolName | None = Field(None, description="(Legacy) Tool to run the check")
+    args: list[str] = Field(
+        default_factory=list, description="(Legacy) Arguments to pass to the tool"
+    )
+    timeout: int | None = Field(
+        default=300, ge=1, description="Timeout in seconds for the check (default: 300)"
+    )
+
+    @field_validator("args")
+    @classmethod
+    def validate_args(cls, v: list[str]) -> list[str]:
+        """Validate that arguments don't contain dangerous shell metacharacters."""
+        return validate_no_shell_metacharacters(v)
+
+    @model_validator(mode="after")
+    def normalize_execution(self) -> "BaseQualityConfig":
+        """Normalize legacy tool/args to canonical execution spec."""
+        config_type = type(self).__name__
+        if self.execution is not None and self.tool is not None:
+            raise ValueError(
+                f"{config_type} has both 'execution' (canonical form) and 'tool' (legacy form) "
+                "set; remove the legacy 'tool'/'args' fields or the canonical 'execution' block"
+            )
+        self.execution = normalize_legacy_to_execution(
+            tool=self.tool, args=self.args, execution=self.execution
+        )
+        self.tool = None
+        return self
+
+    @model_validator(mode="after")
+    def ensure_execution_when_enabled(self) -> "BaseQualityConfig":
+        """Ensure either execution spec or tool is configured when enabled."""
+        config_type = type(self).__name__
+        if self.enabled and self.execution is None and self.tool is None:
+            raise ValueError(
+                f"{config_type} must have either 'execution' (canonical form) or "
+                "'tool' (legacy form) when enabled, but neither is provided"
+            )
+        return self
+
+    @model_serializer(mode="wrap")
+    def _serialize_strip_legacy(self, handler: Any) -> dict[str, Any]:
+        """Exclude legacy args field when canonical execution spec is present."""
+        data: dict[str, Any] = handler(self)
+        if data.get("execution") is not None:
+            data.pop("args", None)
+        return data
+
+
+class LintingConfig(BaseQualityConfig):
     """Configuration for code linting checks."""
 
-    model_config = {"extra": "forbid"}
 
-    enabled: bool = Field(..., description="Whether linting is enabled")
-    tool: ToolName = Field(..., description="Tool to run linting check")
-    args: list[str] = Field(default_factory=list, description="Arguments to pass to the tool")
-    timeout: int | None = Field(
-        default=300, ge=1, description="Timeout in seconds for linting check (default: 300)"
-    )
-
-    @field_validator("args")
-    @classmethod
-    def validate_args(cls, v: list[str]) -> list[str]:
-        """Validate that arguments don't contain dangerous shell metacharacters."""
-        return validate_no_shell_metacharacters(v)
-
-
-class TypeCheckConfig(BaseModel):
+class TypeCheckConfig(BaseQualityConfig):
     """Configuration for type checking."""
 
-    model_config = {"extra": "forbid"}
 
-    enabled: bool = Field(..., description="Whether type checking is enabled")
-    tool: ToolName = Field(..., description="Tool to run type check")
-    args: list[str] = Field(default_factory=list, description="Arguments to pass to the tool")
-    timeout: int | None = Field(
-        default=300, ge=1, description="Timeout in seconds for type checking (default: 300)"
-    )
-
-    @field_validator("args")
-    @classmethod
-    def validate_args(cls, v: list[str]) -> list[str]:
-        """Validate that arguments don't contain dangerous shell metacharacters."""
-        return validate_no_shell_metacharacters(v)
-
-
-class TestingConfig(BaseModel):
+class TestingConfig(BaseQualityConfig):
     """Configuration for test execution."""
 
-    model_config = {"extra": "forbid"}
-
-    enabled: bool = Field(..., description="Whether testing is enabled")
-    tool: ToolName = Field(..., description="Tool to run tests")
-    args: list[str] = Field(default_factory=list, description="Arguments to pass to the tool")
     min_coverage: int | None = Field(
         None, ge=0, le=100, description="Minimum test coverage percentage (0-100)"
     )
-    timeout: int | None = Field(
-        default=300, ge=1, description="Timeout in seconds for test execution (default: 300)"
-    )
-
-    @field_validator("args")
-    @classmethod
-    def validate_args(cls, v: list[str]) -> list[str]:
-        """Validate that arguments don't contain dangerous shell metacharacters."""
-        return validate_no_shell_metacharacters(v)
 
 
-class SecurityCheckConfig(BaseModel):
+class SecurityCheckConfig(BaseQualityConfig):
     """Configuration for security checks."""
 
-    model_config = {"extra": "forbid"}
-
     enabled: bool = Field(default=False, description="Whether security checks are enabled")
-    tool: ToolName | None = Field(None, description="Tool to run security check")
-    args: list[str] = Field(default_factory=list, description="Arguments to pass to the tool")
-    timeout: int | None = Field(
-        default=300, ge=1, description="Timeout in seconds for security check (default: 300)"
-    )
-
-    @field_validator("args")
-    @classmethod
-    def validate_args(cls, v: list[str]) -> list[str]:
-        """Validate that arguments don't contain dangerous shell metacharacters."""
-        return validate_no_shell_metacharacters(v)
 
 
 class DesignReference(BaseModel):
@@ -379,13 +454,15 @@ class SimpleTaskSpec(BaseModel):
     This represents the complete structure of a task definition file
     stored in ./.tasks/<branch>.yml
 
-    Current schema version: 1.0
+    Supported schema versions: 1.0, 1.1
+    Current write version: 1.1
     """
 
     model_config = {"extra": "forbid"}
 
     schema_version: str = Field(
-        default="1.0", description="Schema version for compatibility tracking"
+        default="1.0",
+        description="Schema version for compatibility tracking (supports 1.0 and 1.1)",
     )
     branch: str = Field(
         ..., description="Branch name / unique task identifier (also git branch name)"
@@ -413,6 +490,18 @@ class SimpleTaskSpec(BaseModel):
     iterations: list[Iteration] | None = Field(
         None, description="Development iterations for grouping tasks"
     )
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, v: str) -> str:
+        """Ensure schema version is supported (1.0 or 1.1)."""
+        valid_versions = {"1.0", "1.1"}
+        if v not in valid_versions:
+            raise ValueError(
+                f"Unsupported schema version '{v}'. "
+                f"Supported versions: {', '.join(sorted(valid_versions))}"
+            )
+        return v
 
     @field_validator("tasks")
     @classmethod
@@ -516,6 +605,7 @@ __all__ = [
     "CodeExample",
     "Design",
     "DesignReference",
+    "ExecutionKind",
     "FileAction",
     "Iteration",
     "LintingConfig",
@@ -527,6 +617,9 @@ __all__ = [
     "Task",
     "TaskStatus",
     "TestingConfig",
+    "ToolExecutionSpec",
     "ToolName",
     "TypeCheckConfig",
+    "WorkflowExecutionSpec",
+    "WorkflowRunner",
 ]

--- a/cli/simpletask/core/presets.py
+++ b/cli/simpletask/core/presets.py
@@ -21,62 +21,123 @@ from simpletask.core.models import (
     QualityRequirements,
     SecurityCheckConfig,
     TestingConfig,
+    ToolExecutionSpec,
     ToolName,
     TypeCheckConfig,
 )
 
 # Predefined quality presets for common tech stacks
+# These use canonical nested execution specs
+
 QUALITY_PRESETS: dict[str, QualityRequirements] = {
     "python": QualityRequirements(
-        linting=LintingConfig(enabled=True, tool=ToolName.RUFF, args=["check", "."]),
-        type_checking=TypeCheckConfig(enabled=True, tool=ToolName.MYPY, args=["cli/"]),
-        testing=TestingConfig(enabled=True, tool=ToolName.PYTEST, args=[], min_coverage=80),
-        security_check=SecurityCheckConfig(enabled=False, tool=None, args=[]),
+        linting=LintingConfig(
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.RUFF, args=["check", "."]),
+        ),
+        type_checking=TypeCheckConfig(
+            enabled=True, execution=ToolExecutionSpec(tool=ToolName.MYPY, args=["cli/"])
+        ),
+        testing=TestingConfig(
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.PYTEST, args=[]),
+            min_coverage=80,
+        ),
+        security_check=SecurityCheckConfig(enabled=False),
     ),
     "typescript": QualityRequirements(
-        linting=LintingConfig(enabled=True, tool=ToolName.ESLINT, args=[".", "--ext", ".ts,.tsx"]),
-        type_checking=TypeCheckConfig(enabled=True, tool=ToolName.TSC, args=["--noEmit"]),
-        testing=TestingConfig(enabled=True, tool=ToolName.NPM, args=["test"], min_coverage=80),
-        security_check=SecurityCheckConfig(enabled=False, tool=None, args=[]),
+        linting=LintingConfig(
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.ESLINT, args=[".", "--ext", ".ts,.tsx"]),
+        ),
+        type_checking=TypeCheckConfig(
+            enabled=True, execution=ToolExecutionSpec(tool=ToolName.TSC, args=["--noEmit"])
+        ),
+        testing=TestingConfig(
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.NPM, args=["test"]),
+            min_coverage=80,
+        ),
+        security_check=SecurityCheckConfig(enabled=False),
     ),
     "node": QualityRequirements(
-        linting=LintingConfig(enabled=True, tool=ToolName.ESLINT, args=["."]),
+        linting=LintingConfig(
+            enabled=True, execution=ToolExecutionSpec(tool=ToolName.ESLINT, args=["."])
+        ),
         type_checking=None,
-        testing=TestingConfig(enabled=True, tool=ToolName.NPM, args=["test"], min_coverage=75),
-        security_check=SecurityCheckConfig(enabled=True, tool=ToolName.NPM, args=["audit"]),
+        testing=TestingConfig(
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.NPM, args=["test"]),
+            min_coverage=75,
+        ),
+        security_check=SecurityCheckConfig(
+            enabled=True, execution=ToolExecutionSpec(tool=ToolName.NPM, args=["audit"])
+        ),
     ),
     "go": QualityRequirements(
-        linting=LintingConfig(enabled=True, tool=ToolName.GOLANGCI_LINT, args=["run"]),
+        linting=LintingConfig(
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.GOLANGCI_LINT, args=["run"]),
+        ),
         type_checking=None,  # Go has built-in type checking at compile time
         testing=TestingConfig(
-            enabled=True, tool=ToolName.GO, args=["test", "./..."], min_coverage=80
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.GO, args=["test", "./..."]),
+            min_coverage=80,
         ),
-        security_check=SecurityCheckConfig(enabled=True, tool=ToolName.GOSEC, args=["./..."]),
+        security_check=SecurityCheckConfig(
+            enabled=True, execution=ToolExecutionSpec(tool=ToolName.GOSEC, args=["./..."])
+        ),
     ),
     "rust": QualityRequirements(
         linting=LintingConfig(
-            enabled=True, tool=ToolName.CARGO, args=["clippy", "--", "-D", "warnings"]
+            enabled=True,
+            execution=ToolExecutionSpec(
+                tool=ToolName.CARGO, args=["clippy", "--", "-D", "warnings"]
+            ),
         ),
         type_checking=None,  # Rust has built-in type checking at compile time
-        testing=TestingConfig(enabled=True, tool=ToolName.CARGO, args=["test"], min_coverage=75),
-        security_check=SecurityCheckConfig(enabled=True, tool=ToolName.CARGO, args=["audit"]),
+        testing=TestingConfig(
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.CARGO, args=["test"]),
+            min_coverage=75,
+        ),
+        security_check=SecurityCheckConfig(
+            enabled=True, execution=ToolExecutionSpec(tool=ToolName.CARGO, args=["audit"])
+        ),
     ),
     "java-maven": QualityRequirements(
-        linting=LintingConfig(enabled=True, tool=ToolName.MVN, args=["checkstyle:check"]),
+        linting=LintingConfig(
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.MVN, args=["checkstyle:check"]),
+        ),
         type_checking=None,  # Java has built-in type checking at compile time
-        testing=TestingConfig(enabled=True, tool=ToolName.MVN, args=["test"], min_coverage=80),
+        testing=TestingConfig(
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.MVN, args=["test"]),
+            min_coverage=80,
+        ),
         security_check=SecurityCheckConfig(
-            enabled=True, tool=ToolName.MVN, args=["dependency-check:check"]
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.MVN, args=["dependency-check:check"]),
         ),
     ),
     "java-gradle": QualityRequirements(
         linting=LintingConfig(
-            enabled=True, tool=ToolName.GRADLE, args=["checkstyleMain", "checkstyleTest"]
+            enabled=True,
+            execution=ToolExecutionSpec(
+                tool=ToolName.GRADLE, args=["checkstyleMain", "checkstyleTest"]
+            ),
         ),
         type_checking=None,  # Java has built-in type checking at compile time
-        testing=TestingConfig(enabled=True, tool=ToolName.GRADLE, args=["test"], min_coverage=80),
+        testing=TestingConfig(
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.GRADLE, args=["test"]),
+            min_coverage=80,
+        ),
         security_check=SecurityCheckConfig(
-            enabled=True, tool=ToolName.GRADLE, args=["dependencyCheckAnalyze"]
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.GRADLE, args=["dependencyCheckAnalyze"]),
         ),
     ),
 }

--- a/cli/simpletask/core/quality_checker.py
+++ b/cli/simpletask/core/quality_checker.py
@@ -6,8 +6,76 @@ from typing import Protocol
 from simpletask.core.models import QualityCheckResult, QualityRequirements, ToolName
 from simpletask.core.presets import build_command
 
+
+def extract_tool_and_args_from_execution(
+    execution,  # ToolExecutionSpec | WorkflowExecutionSpec
+) -> tuple:
+    """Extract tool and args from execution spec.
+
+    For ToolExecutionSpec, returns (tool, args).
+    For WorkflowExecutionSpec, builds workflow runner command.
+
+    Args:
+        execution: ExecutionSpec instance (tool or workflow mode)
+
+    Returns:
+        Tuple of (tool: ToolName, args: list[str])
+
+    Raises:
+        ValueError: If execution type is unsupported or runner is invalid
+    """
+    from simpletask.core.models import (
+        ToolExecutionSpec,
+        ToolName,
+        WorkflowExecutionSpec,
+        WorkflowRunner,
+    )
+
+    if isinstance(execution, ToolExecutionSpec):
+        return (execution.tool, execution.args)
+
+    if isinstance(execution, WorkflowExecutionSpec):
+        # Build workflow runner command
+        if execution.runner == WorkflowRunner.MAKE:
+            # Make target: make <extra_args> <target>
+            return (ToolName.MAKE, [*execution.extra_args, execution.target])
+        elif execution.runner == WorkflowRunner.EARTHLY:
+            # Earthly target: earthly [--no-cache] <extra_args> <target>
+            no_cache_flag = ["--no-cache"] if execution.no_cache else []
+            return (ToolName.EARTHLY, [*no_cache_flag, *execution.extra_args, execution.target])
+        else:
+            raise ValueError(
+                f"Unsupported workflow runner: {execution.runner}. Supported runners: make, earthly"
+            )
+
+    raise ValueError(f"Unknown execution type: {type(execution)}")
+
+
 # Maximum output size (1MB) to prevent memory exhaustion
 MAX_OUTPUT_SIZE = 1024 * 1024  # 1MB in bytes
+
+
+def get_tool_and_args_from_config(config):
+    """Extract tool and args from quality config (supporting both forms).
+
+    If execution spec is present (canonical form), extracts from there.
+    Otherwise falls back to legacy tool/args fields.
+
+    Args:
+        config: LintingConfig, TypeCheckConfig, TestingConfig, or SecurityCheckConfig
+
+    Returns:
+        Tuple of (tool: ToolName, args: list[str])
+
+    Raises:
+        ValueError: If execution spec is workflow type (not yet supported)
+    """
+    # Prefer execution spec if present
+    if config.execution is not None:
+        return extract_tool_and_args_from_execution(config.execution)
+
+    # Fall back to legacy fields
+    return (config.tool, config.args)
 
 
 class QualityCheckRunner(Protocol):
@@ -230,10 +298,11 @@ class QualityChecker:
 
         # Run linting
         if lint and self.requirements.linting.enabled:
+            tool_name, args = get_tool_and_args_from_config(self.requirements.linting)
             result = self.runner.run_check(
                 "Linting",
-                self.requirements.linting.tool,
-                self.requirements.linting.args,
+                tool_name,
+                args,
                 self.requirements.linting.timeout,
             )
             results.append(result)
@@ -241,31 +310,34 @@ class QualityChecker:
         # Run type checking
         if type_check and self.requirements.type_checking:
             if self.requirements.type_checking.enabled:
+                tool_name, args = get_tool_and_args_from_config(self.requirements.type_checking)
                 result = self.runner.run_check(
                     "Type Checking",
-                    self.requirements.type_checking.tool,
-                    self.requirements.type_checking.args,
+                    tool_name,
+                    args,
                     self.requirements.type_checking.timeout,
                 )
                 results.append(result)
 
         # Run testing
         if test and self.requirements.testing.enabled:
+            tool_name, args = get_tool_and_args_from_config(self.requirements.testing)
             result = self.runner.run_check(
                 "Testing",
-                self.requirements.testing.tool,
-                self.requirements.testing.args,
+                tool_name,
+                args,
                 self.requirements.testing.timeout,
             )
             results.append(result)
 
         # Run security checks
         if security and self.requirements.security_check:
-            if self.requirements.security_check.enabled and self.requirements.security_check.tool:
+            if self.requirements.security_check.enabled:
+                tool_name, args = get_tool_and_args_from_config(self.requirements.security_check)
                 result = self.runner.run_check(
                     "Security Check",
-                    self.requirements.security_check.tool,
-                    self.requirements.security_check.args,
+                    tool_name,
+                    args,
                     self.requirements.security_check.timeout,
                 )
                 results.append(result)

--- a/cli/simpletask/core/quality_ops.py
+++ b/cli/simpletask/core/quality_ops.py
@@ -9,8 +9,11 @@ from simpletask.core.models import (
     SecurityCheckConfig,
     SimpleTaskSpec,
     TestingConfig,
+    ToolExecutionSpec,
     ToolName,
     TypeCheckConfig,
+    WorkflowExecutionSpec,
+    WorkflowRunner,
 )
 from simpletask.core.presets import apply_preset as apply_preset_impl
 from simpletask.core.quality_checker import QualityChecker
@@ -57,6 +60,68 @@ def run_quality_checks(
         return checker.run_all()
 
 
+def _build_updated_execution_spec(
+    existing: ToolExecutionSpec | WorkflowExecutionSpec | None,
+    tool: ToolName | None,
+    args: list[str] | None,
+    workflow_runner: WorkflowRunner | None,
+    workflow_target: str | None,
+) -> ToolExecutionSpec | WorkflowExecutionSpec | None:
+    """Build an updated execution spec from inputs.
+
+    Returns None when no execution-related inputs are provided (caller should
+    leave existing execution spec unchanged).
+
+    Args:
+        existing: Current execution spec, if any.
+        tool: Tool name for tool-mode execution.
+        args: Arguments for tool-mode execution.
+        workflow_runner: Runner for workflow-mode execution.
+        workflow_target: Target/rule for workflow-mode execution.
+
+    Returns:
+        Updated execution spec, or None if no execution-related inputs provided.
+
+    Raises:
+        ValueError: If workflow and tool inputs are mixed, or required fields are missing.
+    """
+    has_workflow = workflow_runner is not None or workflow_target is not None
+    has_tool = tool is not None or args is not None
+
+    if has_workflow and has_tool:
+        raise ValueError(
+            "Cannot mix tool and workflow fields: provide either (tool/args) or "
+            "(workflow_runner/workflow_target), not both."
+        )
+
+    if has_workflow:
+        if isinstance(existing, WorkflowExecutionSpec):
+            runner = workflow_runner if workflow_runner is not None else existing.runner
+            target = workflow_target if workflow_target is not None else existing.target
+        else:
+            if workflow_runner is None or workflow_target is None:
+                raise ValueError(
+                    "Both workflow_runner and workflow_target are required when creating "
+                    "a new workflow execution spec."
+                )
+            runner = workflow_runner
+            target = workflow_target
+        return WorkflowExecutionSpec(runner=runner, target=target)
+
+    if has_tool:
+        if isinstance(existing, ToolExecutionSpec):
+            new_tool = tool if tool is not None else existing.tool
+            new_args = args if args is not None else existing.args
+        else:
+            if tool is None:
+                raise ValueError("tool is required when creating a new tool execution spec.")
+            new_tool = tool
+            new_args = args if args is not None else []
+        return ToolExecutionSpec(tool=new_tool, args=new_args)
+
+    return None
+
+
 def update_quality_config(
     spec: SimpleTaskSpec,
     config_type: Literal["linting", "type-checking", "testing", "security"],
@@ -65,17 +130,24 @@ def update_quality_config(
     enabled: bool | None = None,
     min_coverage: int | None = None,
     timeout: int | None = None,
+    workflow_runner: WorkflowRunner | None = None,
+    workflow_target: str | None = None,
 ) -> SimpleTaskSpec:
     """Update quality configuration in task spec.
+
+    Supports both tool-mode (tool/args) and workflow-mode (workflow_runner/workflow_target)
+    execution specs. The resulting config always uses the canonical nested execution form.
 
     Args:
         spec: Task specification to update
         config_type: Type of configuration to update
-        tool: Tool to use (optional)
-        args: Tool arguments (optional)
+        tool: Tool to use for tool-mode execution (optional)
+        args: Tool arguments for tool-mode execution (optional)
         enabled: Enable/disable status (optional)
         min_coverage: Minimum coverage for testing (optional)
         timeout: Timeout in seconds (optional)
+        workflow_runner: Workflow runner for workflow-mode execution (optional)
+        workflow_target: Workflow target/rule name (optional)
 
     Returns:
         Updated task specification
@@ -83,19 +155,20 @@ def update_quality_config(
     Raises:
         ValueError: If invalid configuration provided
     """
-    # Validate at least one option provided
     if (
         tool is None
         and args is None
         and enabled is None
         and min_coverage is None
         and timeout is None
+        and workflow_runner is None
+        and workflow_target is None
     ):
         raise ValueError(
-            "At least one option must be provided: tool, args, enabled, min_coverage, or timeout"
+            "At least one option must be provided: tool, args, enabled, min_coverage, "
+            "timeout, workflow_runner, or workflow_target"
         )
 
-    # Validate min_coverage only for testing
     if min_coverage is not None and config_type != "testing":
         raise ValueError("min_coverage can only be used with 'testing' config type")
 
@@ -103,65 +176,167 @@ def update_quality_config(
     if quality_reqs is None:
         raise ValueError("Task spec has no quality_requirements field")
 
-    # Build updates dict
-    updates: dict[str, Any] = {}
-    if tool is not None:
-        updates["tool"] = tool
-    if args is not None:
-        updates["args"] = args
-    if enabled is not None:
-        updates["enabled"] = enabled
-    if min_coverage is not None:
-        updates["min_coverage"] = min_coverage
-    if timeout is not None:
-        updates["timeout"] = timeout
+    quality_reqs = _apply_config_update(
+        quality_reqs,
+        config_type,
+        tool=tool,
+        args=args,
+        enabled=enabled,
+        min_coverage=min_coverage,
+        timeout=timeout,
+        workflow_runner=workflow_runner,
+        workflow_target=workflow_target,
+    )
 
-    # Apply updates based on config type
+    return spec.model_copy(update={"quality_requirements": quality_reqs})
+
+
+def _apply_config_update(
+    quality_reqs: QualityRequirements,
+    config_type: Literal["linting", "type-checking", "testing", "security"],
+    tool: ToolName | None,
+    args: list[str] | None,
+    enabled: bool | None,
+    min_coverage: int | None,
+    timeout: int | None,
+    workflow_runner: WorkflowRunner | None,
+    workflow_target: str | None,
+) -> QualityRequirements:
+    """Apply configuration updates to QualityRequirements.
+
+    Args:
+        quality_reqs: Existing quality requirements
+        config_type: Which config section to update
+        tool: Tool for tool-mode execution
+        args: Arguments for tool-mode execution
+        enabled: Enable/disable toggle
+        min_coverage: Minimum test coverage
+        timeout: Execution timeout
+        workflow_runner: Runner for workflow-mode execution
+        workflow_target: Target for workflow-mode execution
+
+    Returns:
+        Updated QualityRequirements
+
+    Raises:
+        ValueError: If configuration is invalid or incomplete
+    """
+    # Scalar-only updates (enabled, timeout, min_coverage)
+    scalar_updates: dict[str, Any] = {}
+    if enabled is not None:
+        scalar_updates["enabled"] = enabled
+    if timeout is not None:
+        scalar_updates["timeout"] = timeout
+    if min_coverage is not None:
+        scalar_updates["min_coverage"] = min_coverage
+
     if config_type == "linting":
-        quality_reqs = quality_reqs.model_copy(
-            update={"linting": quality_reqs.linting.model_copy(update=updates)}
+        existing_exec = quality_reqs.linting.execution
+        new_exec = _build_updated_execution_spec(
+            existing_exec, tool, args, workflow_runner, workflow_target
         )
-    elif config_type == "type-checking":
-        # Type checking is optional, create if doesn't exist
+        exec_updates: dict[str, Any] = {}
+        if new_exec is not None:
+            exec_updates["execution"] = new_exec
+            exec_updates["tool"] = None
+            exec_updates["args"] = []
+        return quality_reqs.model_copy(
+            update={
+                "linting": quality_reqs.linting.model_copy(
+                    update={**exec_updates, **scalar_updates}
+                )
+            }
+        )
+
+    if config_type == "type-checking":
         if quality_reqs.type_checking is None:
-            if tool is None:
-                raise ValueError("tool is required when creating a new type-checking configuration")
-            quality_reqs = quality_reqs.model_copy(
+            new_exec = _build_updated_execution_spec(
+                None, tool, args, workflow_runner, workflow_target
+            )
+            if new_exec is None:
+                raise ValueError(
+                    "tool or workflow_runner is required when creating a new type-checking configuration"
+                )
+            return quality_reqs.model_copy(
                 update={
                     "type_checking": TypeCheckConfig(
-                        enabled=True, tool=tool, args=args if args else []
+                        enabled=scalar_updates.get("enabled", False),
+                        execution=new_exec,
+                        timeout=scalar_updates.get("timeout", 300),
                     )
                 }
             )
-        else:
-            quality_reqs = quality_reqs.model_copy(
-                update={"type_checking": quality_reqs.type_checking.model_copy(update=updates)}
-            )
-    elif config_type == "testing":
-        quality_reqs = quality_reqs.model_copy(
-            update={"testing": quality_reqs.testing.model_copy(update=updates)}
+        existing_exec = quality_reqs.type_checking.execution
+        new_exec = _build_updated_execution_spec(
+            existing_exec, tool, args, workflow_runner, workflow_target
         )
-    elif config_type == "security":
-        # Security check is optional, create if doesn't exist
+        exec_updates = {}
+        if new_exec is not None:
+            exec_updates["execution"] = new_exec
+            exec_updates["tool"] = None
+            exec_updates["args"] = []
+        return quality_reqs.model_copy(
+            update={
+                "type_checking": quality_reqs.type_checking.model_copy(
+                    update={**exec_updates, **scalar_updates}
+                )
+            }
+        )
+
+    if config_type == "testing":
+        existing_exec = quality_reqs.testing.execution
+        new_exec = _build_updated_execution_spec(
+            existing_exec, tool, args, workflow_runner, workflow_target
+        )
+        exec_updates = {}
+        if new_exec is not None:
+            exec_updates["execution"] = new_exec
+            exec_updates["tool"] = None
+            exec_updates["args"] = []
+        return quality_reqs.model_copy(
+            update={
+                "testing": quality_reqs.testing.model_copy(
+                    update={**exec_updates, **scalar_updates}
+                )
+            }
+        )
+
+    if config_type == "security":
         if quality_reqs.security_check is None:
-            if tool is None:
-                raise ValueError("tool is required when creating a new security configuration")
-            quality_reqs = quality_reqs.model_copy(
+            new_exec = _build_updated_execution_spec(
+                None, tool, args, workflow_runner, workflow_target
+            )
+            if new_exec is None:
+                raise ValueError(
+                    "tool or workflow_runner is required when creating a new security configuration"
+                )
+            return quality_reqs.model_copy(
                 update={
                     "security_check": SecurityCheckConfig(
-                        enabled=True, tool=tool, args=args if args else []
+                        enabled=scalar_updates.get("enabled", False),
+                        execution=new_exec,
+                        timeout=scalar_updates.get("timeout", 300),
                     )
                 }
             )
-        else:
-            quality_reqs = quality_reqs.model_copy(
-                update={"security_check": quality_reqs.security_check.model_copy(update=updates)}
-            )
+        existing_exec = quality_reqs.security_check.execution
+        new_exec = _build_updated_execution_spec(
+            existing_exec, tool, args, workflow_runner, workflow_target
+        )
+        exec_updates = {}
+        if new_exec is not None:
+            exec_updates["execution"] = new_exec
+            exec_updates["tool"] = None
+            exec_updates["args"] = []
+        return quality_reqs.model_copy(
+            update={
+                "security_check": quality_reqs.security_check.model_copy(
+                    update={**exec_updates, **scalar_updates}
+                )
+            }
+        )
 
-    # Update spec with modified quality requirements
-    spec = spec.model_copy(update={"quality_requirements": quality_reqs})
-
-    return spec
+    raise ValueError(f"Unknown config_type: {config_type!r}")  # pragma: no cover
 
 
 def update_quality_requirements(
@@ -172,11 +347,15 @@ def update_quality_requirements(
     enabled: bool | None = None,
     min_coverage: int | None = None,
     timeout: int | None = None,
+    workflow_runner: WorkflowRunner | None = None,
+    workflow_target: str | None = None,
 ) -> QualityRequirements:
     """Update quality requirements without wrapping in a SimpleTaskSpec.
 
     Equivalent to update_quality_config but operates directly on QualityRequirements.
     Used by operations that manage quality outside a task file context (e.g. defaults.yml).
+    Supports both tool-mode (tool/args) and workflow-mode (workflow_runner/workflow_target)
+    execution specs.
 
     Args:
         existing: Existing quality requirements. When None, only 'linting' and 'testing'
@@ -184,11 +363,13 @@ def update_quality_requirements(
             QualityRequirements (apply a preset first) to avoid creating phantom placeholder
             linting/testing entries that would block future fill-gaps-only preset merges.
         config_type: Type of configuration to update
-        tool: Tool to use (optional)
-        args: Tool arguments (optional)
+        tool: Tool for tool-mode execution (optional)
+        args: Arguments for tool-mode execution (optional)
         enabled: Enable/disable status (optional)
         min_coverage: Minimum coverage for testing (optional)
         timeout: Timeout in seconds (optional)
+        workflow_runner: Runner for workflow-mode execution (optional)
+        workflow_target: Target/rule for workflow-mode execution (optional)
 
     Returns:
         Updated QualityRequirements
@@ -203,9 +384,12 @@ def update_quality_requirements(
         and enabled is None
         and min_coverage is None
         and timeout is None
+        and workflow_runner is None
+        and workflow_target is None
     ):
         raise ValueError(
-            "At least one option must be provided: tool, args, enabled, min_coverage, or timeout"
+            "At least one option must be provided: tool, args, enabled, min_coverage, "
+            "timeout, workflow_runner, or workflow_target"
         )
 
     if min_coverage is not None and config_type != "testing":
@@ -226,58 +410,17 @@ def update_quality_requirements(
             testing=TestingConfig(enabled=False, tool=ToolName.PYTEST, args=[], min_coverage=0),
         )
 
-    updates: dict[str, Any] = {}
-    if tool is not None:
-        updates["tool"] = tool
-    if args is not None:
-        updates["args"] = args
-    if enabled is not None:
-        updates["enabled"] = enabled
-    if min_coverage is not None:
-        updates["min_coverage"] = min_coverage
-    if timeout is not None:
-        updates["timeout"] = timeout
-
-    if config_type == "linting":
-        quality_reqs = quality_reqs.model_copy(
-            update={"linting": quality_reqs.linting.model_copy(update=updates)}
-        )
-    elif config_type == "type-checking":
-        if quality_reqs.type_checking is None:
-            if tool is None:
-                raise ValueError("tool is required when creating a new type-checking configuration")
-            quality_reqs = quality_reqs.model_copy(
-                update={
-                    "type_checking": TypeCheckConfig(
-                        enabled=True, tool=tool, args=args if args else []
-                    )
-                }
-            )
-        else:
-            quality_reqs = quality_reqs.model_copy(
-                update={"type_checking": quality_reqs.type_checking.model_copy(update=updates)}
-            )
-    elif config_type == "testing":
-        quality_reqs = quality_reqs.model_copy(
-            update={"testing": quality_reqs.testing.model_copy(update=updates)}
-        )
-    elif config_type == "security":
-        if quality_reqs.security_check is None:
-            if tool is None:
-                raise ValueError("tool is required when creating a new security configuration")
-            quality_reqs = quality_reqs.model_copy(
-                update={
-                    "security_check": SecurityCheckConfig(
-                        enabled=True, tool=tool, args=args if args else []
-                    )
-                }
-            )
-        else:
-            quality_reqs = quality_reqs.model_copy(
-                update={"security_check": quality_reqs.security_check.model_copy(update=updates)}
-            )
-
-    return quality_reqs
+    return _apply_config_update(
+        quality_reqs,
+        config_type,
+        tool=tool,
+        args=args,
+        enabled=enabled,
+        min_coverage=min_coverage,
+        timeout=timeout,
+        workflow_runner=workflow_runner,
+        workflow_target=workflow_target,
+    )
 
 
 def apply_quality_preset(

--- a/cli/simpletask/core/yaml_parser.py
+++ b/cli/simpletask/core/yaml_parser.py
@@ -100,6 +100,35 @@ def parse_task_file_lenient(path: Path) -> dict[str, Any]:
     return data
 
 
+_QUALITY_CONFIG_KEYS = ("linting", "type_checking", "testing", "security_check")
+
+
+def _bump_schema_version_if_canonical(data: dict[str, Any]) -> dict[str, Any]:
+    """Upgrade schema_version to '1.1' when any quality section uses canonical execution.
+
+    The model serializer already strips legacy 'args' from canonical sections;
+    this function only handles the version bump that belongs to the writer layer.
+
+    Args:
+        data: Serialized task spec dict (from model_dump)
+
+    Returns:
+        Mutated dict with schema_version bumped to '1.1' when canonical execution is present
+    """
+    quality_reqs = data.get("quality_requirements")
+    if not isinstance(quality_reqs, dict):
+        return data
+
+    has_canonical = any(
+        isinstance(quality_reqs.get(key), dict) and "execution" in quality_reqs[key]
+        for key in _QUALITY_CONFIG_KEYS
+    )
+    if has_canonical:
+        data["schema_version"] = "1.1"
+
+    return data
+
+
 def write_task_file(path: Path, spec: SimpleTaskSpec) -> None:
     """Write task YAML file.
 
@@ -132,6 +161,9 @@ def write_task_file(path: Path, spec: SimpleTaskSpec) -> None:
 
     # Convert spec to dict (mode='json' for datetime serialization)
     data = spec.model_dump(mode="json", exclude_none=True)
+
+    # Bump schema_version for files using canonical execution specs
+    data = _bump_schema_version_if_canonical(data)
 
     # Generate YAML with nice formatting
     yaml_content = yaml.dump(

--- a/cli/simpletask/mcp/server.py
+++ b/cli/simpletask/mcp/server.py
@@ -69,6 +69,7 @@ from ..core.models import (
     SecurityRequirement,
     TaskStatus,
     ToolName,
+    WorkflowRunner,
 )
 from ..core.note_ops import add_note, list_notes, remove_note
 from ..core.project import ensure_project, get_current_task_file_path
@@ -788,6 +789,8 @@ def quality(
     min_coverage: int | None = None,
     timeout: int | None = None,
     preset_name: str | None = None,
+    workflow_runner: str | None = None,
+    workflow_target: str | None = None,
     lint_only: bool = False,
     test_only: bool = False,
     type_only: bool = False,
@@ -805,6 +808,8 @@ def quality(
         min_coverage: Minimum coverage for 'set' action with testing type
         timeout: Timeout in seconds for 'set' action (default: 300)
         preset_name: Preset name for 'preset' action
+        workflow_runner: Workflow runner for 'set' action (make or earthly)
+        workflow_target: Workflow target for 'set' action (used with workflow_runner)
         lint_only: Only run linting check (for 'check' action). Raises ValueError
             if combined with a non-check action or combined with another filter flag.
         test_only: Only run testing check (for 'check' action). Raises ValueError
@@ -860,6 +865,17 @@ def quality(
             valid_tools = ", ".join([t.value for t in ToolName])
             raise ValueError(f"Invalid tool '{tool}'. Valid tools: {valid_tools}") from None
 
+    # Convert workflow_runner string to WorkflowRunner enum if provided
+    runner_enum: WorkflowRunner | None = None
+    if workflow_runner:
+        try:
+            runner_enum = WorkflowRunner(workflow_runner)
+        except ValueError:
+            valid_runners = ", ".join([r.value for r in WorkflowRunner])
+            raise ValueError(
+                f"Invalid workflow_runner '{workflow_runner}'. Valid runners: {valid_runners}"
+            ) from None
+
     # ------------------------------------------------------------------ #
     # Defaults target path
     # ------------------------------------------------------------------ #
@@ -902,6 +918,8 @@ def quality(
                     enabled=enabled,
                     min_coverage=min_coverage,
                     timeout=timeout,
+                    workflow_runner=runner_enum,
+                    workflow_target=workflow_target,
                 )
                 set_defaults_path: str = _commit_defaults(defaults)
                 return SimpleTaskWriteResponse(
@@ -1004,6 +1022,8 @@ def quality(
                 enabled=enabled,
                 min_coverage=min_coverage,
                 timeout=timeout,
+                workflow_runner=runner_enum,
+                workflow_target=workflow_target,
             )
 
             write_task_file(file_path, spec)

--- a/cli/simpletask/schema/simpletask.schema.json
+++ b/cli/simpletask/schema/simpletask.schema.json
@@ -1,33 +1,57 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "simpletask-v1.schema.json",
-  "title": "SimpleTask Schema",
-  "description": "Schema for AI-friendly task definitions with acceptance criteria, implementation tasks, and context. Designed for branch-based development workflows.",
+  "$id": "simpletask-v1.1.schema.json",
+  "title": "SimpleTask Schema v1.1",
+  "description": "Schema for AI-friendly task definitions with execution specs, quality requirements, and design guidance. Supports schema versions 1.0 (legacy) and 1.1 (canonical).",
   "type": "object",
-  "required": ["schema_version", "branch", "title", "original_prompt", "created", "acceptance_criteria"],
+  "required": [
+    "schema_version",
+    "branch",
+    "title",
+    "original_prompt",
+    "created",
+    "acceptance_criteria"
+  ],
   "properties": {
     "schema_version": {
       "type": "string",
-      "description": "Schema version for compatibility tracking",
-      "examples": ["1.0"]
+      "enum": [
+        "1.0",
+        "1.1"
+      ],
+      "description": "Schema version for compatibility tracking. 1.1 is canonical for all writes.",
+      "examples": [
+        "1.0",
+        "1.1"
+      ]
     },
     "branch": {
       "type": "string",
       "description": "Branch name / unique task identifier. Used for both the Git branch and filename.",
-      "examples": ["020-list-show-commands", "feature/dark-mode"]
+      "examples": [
+        "020-list-show-commands",
+        "feature/dark-mode"
+      ]
     },
     "title": {
       "type": "string",
       "description": "Human-readable task title",
-      "examples": ["Add list and show commands for task management"]
+      "examples": [
+        "Add list and show commands for task management"
+      ]
     },
     "original_prompt": {
       "type": "string",
       "description": "The verbatim user request that initiated this task. Preserved for context recovery and human verification.",
-      "examples": ["Add list and show commands so users can see available tasks and their details"]
+      "examples": [
+        "Add list and show commands so users can see available tasks and their details"
+      ]
     },
     "notes": {
-      "type": ["array", "null"],
+      "type": [
+        "array",
+        "null"
+      ],
       "description": "Freeform notes about this task specification",
       "items": {
         "type": "string"
@@ -37,7 +61,9 @@
       "type": "string",
       "format": "date-time",
       "description": "Timestamp when the task was created (ISO 8601 format)",
-      "examples": ["2024-01-15T14:30:00Z"]
+      "examples": [
+        "2024-01-15T14:30:00Z"
+      ]
     },
     "acceptance_criteria": {
       "type": "array",
@@ -54,13 +80,33 @@
         "type": "string"
       },
       "examples": [
-        ["Do not modify files in src/core/legacy/", "Follow existing error handling patterns", "No new dependencies without approval"]
+        [
+          "Do not modify files in src/core/legacy/",
+          "Follow existing error handling patterns",
+          "No new dependencies without approval"
+        ]
       ]
     },
     "context": {
       "type": "object",
       "description": "Flexible context block for requirements, dependencies, related files, gotchas, and any other relevant information",
       "additionalProperties": true
+    },
+    "design": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "Design guidance including patterns, references, constraints, and security considerations",
+      "$ref": "#/$defs/Design"
+    },
+    "quality_requirements": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "Quality check configuration (linting, type-checking, testing, security) with execution specs",
+      "$ref": "#/$defs/QualityRequirements"
     },
     "tasks": {
       "type": "array",
@@ -70,7 +116,10 @@
       }
     },
     "iterations": {
-      "type": ["array", "null"],
+      "type": [
+        "array",
+        "null"
+      ],
       "description": "List of development iterations for semantic separation of work rounds",
       "items": {
         "$ref": "#/$defs/Iteration"
@@ -81,12 +130,19 @@
     "AcceptanceCriterion": {
       "type": "object",
       "description": "A single acceptance criterion that must be met",
-      "required": ["id", "description", "completed"],
+      "required": [
+        "id",
+        "description",
+        "completed"
+      ],
       "properties": {
         "id": {
           "type": "string",
           "description": "Unique identifier for the criterion",
-          "examples": ["AC1", "AC2"]
+          "examples": [
+            "AC1",
+            "AC2"
+          ]
         },
         "description": {
           "type": "string",
@@ -98,15 +154,391 @@
         }
       }
     },
+    "Design": {
+      "type": "object",
+      "description": "Design guidance for implementation",
+      "properties": {
+        "patterns": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Architectural patterns to follow",
+          "items": {
+            "type": "string"
+          }
+        },
+        "reference_implementations": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Reference implementations to study or follow",
+          "items": {
+            "$ref": "#/$defs/DesignReference"
+          }
+        },
+        "architectural_constraints": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Architectural constraints and requirements",
+          "items": {
+            "type": "string"
+          }
+        },
+        "security": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Security considerations",
+          "items": {
+            "$ref": "#/$defs/SecurityRequirement"
+          }
+        },
+        "error_handling": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Error handling strategy",
+          "enum": [
+            "exceptions",
+            "result_type",
+            "error_codes",
+            "callbacks",
+            "panic_recover"
+          ]
+        }
+      }
+    },
+    "DesignReference": {
+      "type": "object",
+      "description": "A reference implementation or pattern to follow",
+      "required": [
+        "path",
+        "reason"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to the reference file or location"
+        },
+        "reason": {
+          "type": "string",
+          "description": "Why this reference is important to follow"
+        }
+      }
+    },
+    "SecurityRequirement": {
+      "type": "object",
+      "description": "A security requirement or consideration",
+      "required": [
+        "category",
+        "description"
+      ],
+      "properties": {
+        "category": {
+          "type": "string",
+          "description": "Security category",
+          "enum": [
+            "authentication",
+            "authorization",
+            "cryptography",
+            "input_validation",
+            "output_encoding",
+            "session_management",
+            "secure_communication",
+            "data_protection",
+            "audit_logging"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Security requirement description"
+        }
+      }
+    },
+    "QualityRequirements": {
+      "type": "object",
+      "description": "Quality check configuration with nested execution specs (canonical form)",
+      "required": [
+        "linting",
+        "testing"
+      ],
+      "properties": {
+        "linting": {
+          "$ref": "#/$defs/LintingConfig"
+        },
+        "type_checking": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "$ref": "#/$defs/TypeCheckConfig"
+        },
+        "testing": {
+          "$ref": "#/$defs/TestingConfig"
+        },
+        "security_check": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "$ref": "#/$defs/SecurityCheckConfig"
+        }
+      }
+    },
+    "LintingConfig": {
+      "type": "object",
+      "description": "Linting configuration with execution spec",
+      "required": [
+        "enabled"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether linting is enabled"
+        },
+        "execution": {
+          "description": "Execution spec (tool or workflow mode)",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ToolExecutionSpec"
+            },
+            {
+              "$ref": "#/$defs/WorkflowExecutionSpec"
+            }
+          ]
+        },
+        "timeout": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1,
+          "description": "Timeout in seconds (default: 300)"
+        }
+      }
+    },
+    "TypeCheckConfig": {
+      "type": "object",
+      "description": "Type checking configuration with execution spec",
+      "required": [
+        "enabled"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether type checking is enabled"
+        },
+        "execution": {
+          "description": "Execution spec (tool or workflow mode)",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ToolExecutionSpec"
+            },
+            {
+              "$ref": "#/$defs/WorkflowExecutionSpec"
+            }
+          ]
+        },
+        "timeout": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1,
+          "description": "Timeout in seconds (default: 300)"
+        }
+      }
+    },
+    "TestingConfig": {
+      "type": "object",
+      "description": "Testing configuration with execution spec and coverage threshold",
+      "required": [
+        "enabled"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether testing is enabled"
+        },
+        "execution": {
+          "description": "Execution spec (tool or workflow mode)",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ToolExecutionSpec"
+            },
+            {
+              "$ref": "#/$defs/WorkflowExecutionSpec"
+            }
+          ]
+        },
+        "min_coverage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Minimum test coverage percentage"
+        },
+        "timeout": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1,
+          "description": "Timeout in seconds (default: 300)"
+        }
+      }
+    },
+    "SecurityCheckConfig": {
+      "type": "object",
+      "description": "Security check configuration with execution spec",
+      "required": [
+        "enabled"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether security check is enabled"
+        },
+        "execution": {
+          "description": "Execution spec (tool or workflow mode)",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ToolExecutionSpec"
+            },
+            {
+              "$ref": "#/$defs/WorkflowExecutionSpec"
+            }
+          ]
+        },
+        "timeout": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1,
+          "description": "Timeout in seconds (default: 300)"
+        }
+      }
+    },
+    "ToolExecutionSpec": {
+      "type": "object",
+      "description": "Execution spec for direct tool execution",
+      "required": [
+        "kind",
+        "tool"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "tool"
+          ],
+          "description": "Execution kind"
+        },
+        "tool": {
+          "type": "string",
+          "description": "Tool name to execute",
+          "enum": [
+            "ruff",
+            "mypy",
+            "pytest",
+            "black",
+            "pylint",
+            "bandit",
+            "eslint",
+            "tsc",
+            "npm",
+            "yarn",
+            "jest",
+            "go",
+            "golangci-lint",
+            "gosec",
+            "cargo",
+            "clippy",
+            "mvn",
+            "gradle",
+            "make",
+            "earthly"
+          ]
+        },
+        "args": {
+          "type": "array",
+          "description": "Tool arguments",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "WorkflowExecutionSpec": {
+      "type": "object",
+      "description": "Execution spec for workflow runners (make, earthly)",
+      "required": [
+        "kind",
+        "runner",
+        "target"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "workflow"
+          ],
+          "description": "Execution kind"
+        },
+        "runner": {
+          "type": "string",
+          "enum": [
+            "make",
+            "earthly"
+          ],
+          "description": "Workflow runner to use"
+        },
+        "target": {
+          "type": "string",
+          "description": "Workflow target or rule name"
+        },
+        "no_cache": {
+          "type": "boolean",
+          "default": false,
+          "description": "Pass --no-cache to Earthly runner (ignored for make)"
+        },
+        "extra_args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Additional flags passed to the runner before the target"
+        }
+      }
+    },
     "Task": {
       "type": "object",
       "description": "A single implementation task",
-      "required": ["id", "name", "status", "goal", "steps"],
+      "required": [
+        "id",
+        "name",
+        "status",
+        "goal",
+        "steps"
+      ],
       "properties": {
         "id": {
           "type": "string",
           "description": "Unique task identifier",
-          "examples": ["T001", "T002"]
+          "examples": [
+            "T001",
+            "T002"
+          ]
         },
         "name": {
           "type": "string",
@@ -114,7 +546,13 @@
         },
         "status": {
           "type": "string",
-          "enum": ["not_started", "in_progress", "completed", "blocked", "paused"],
+          "enum": [
+            "not_started",
+            "in_progress",
+            "completed",
+            "blocked",
+            "paused"
+          ],
           "description": "Current status of this task"
         },
         "goal": {
@@ -136,7 +574,11 @@
             "type": "string"
           },
           "examples": [
-            ["File exists at src/commands/list.py", "All imports are present", "pytest tests/test_list.py passes"]
+            [
+              "File exists at src/commands/list.py",
+              "All imports are present",
+              "pytest tests/test_list.py passes"
+            ]
           ]
         },
         "code_examples": {
@@ -147,7 +589,10 @@
           }
         },
         "notes": {
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "description": "Freeform notes about this task",
           "items": {
             "type": "string"
@@ -168,7 +613,10 @@
           }
         },
         "iteration": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "minimum": 1,
           "description": "ID of the iteration this task belongs to"
         }
@@ -177,12 +625,20 @@
     "CodeExample": {
       "type": "object",
       "description": "A code example to guide implementation",
-      "required": ["language", "code"],
+      "required": [
+        "language",
+        "code"
+      ],
       "properties": {
         "language": {
           "type": "string",
           "description": "Programming language for syntax highlighting",
-          "examples": ["python", "javascript", "bash", "yaml"]
+          "examples": [
+            "python",
+            "javascript",
+            "bash",
+            "yaml"
+          ]
         },
         "description": {
           "type": "string",
@@ -197,7 +653,10 @@
     "FileAction": {
       "type": "object",
       "description": "A file to be created or modified",
-      "required": ["path", "action"],
+      "required": [
+        "path",
+        "action"
+      ],
       "properties": {
         "path": {
           "type": "string",
@@ -205,7 +664,11 @@
         },
         "action": {
           "type": "string",
-          "enum": ["create", "modify", "delete"],
+          "enum": [
+            "create",
+            "modify",
+            "delete"
+          ],
           "description": "Action to perform on the file"
         }
       }
@@ -213,7 +676,11 @@
     "Iteration": {
       "type": "object",
       "description": "A development iteration representing a round of work",
-      "required": ["id", "label", "created"],
+      "required": [
+        "id",
+        "label",
+        "created"
+      ],
       "properties": {
         "id": {
           "type": "integer",
@@ -223,7 +690,11 @@
         "label": {
           "type": "string",
           "description": "Human-readable label for this iteration",
-          "examples": ["Initial implementation", "Review feedback", "Performance improvements"]
+          "examples": [
+            "Initial implementation",
+            "Review feedback",
+            "Performance improvements"
+          ]
         },
         "created": {
           "type": "string",

--- a/cli/simpletask/utils/output.py
+++ b/cli/simpletask/utils/output.py
@@ -92,8 +92,41 @@ def build_write_response(action: str, message: str, spec, file_path: str, **extr
     return response
 
 
+def _serialize_execution_spec(execution) -> dict | None:
+    """Serialize a ToolExecutionSpec or WorkflowExecutionSpec to a dict.
+
+    Args:
+        execution: ToolExecutionSpec or WorkflowExecutionSpec instance, or None.
+
+    Returns:
+        Dict representation or None if execution is None.
+    """
+    from simpletask.core.models import ToolExecutionSpec, WorkflowExecutionSpec
+
+    if execution is None:
+        return None
+
+    if isinstance(execution, ToolExecutionSpec):
+        return {
+            "kind": execution.kind.value,
+            "tool": execution.tool.value,
+            "args": execution.args,
+        }
+
+    if isinstance(execution, WorkflowExecutionSpec):
+        return {
+            "kind": execution.kind.value,
+            "runner": execution.runner.value,
+            "target": execution.target,
+        }
+
+    return None
+
+
 def serialize_quality_reqs(quality_reqs) -> dict:
     """Serialize a QualityRequirements object to a JSON-serializable dict.
+
+    Uses the canonical nested execution specs.
 
     Args:
         quality_reqs: QualityRequirements instance to serialize.
@@ -104,18 +137,14 @@ def serialize_quality_reqs(quality_reqs) -> dict:
     return {
         "linting": {
             "enabled": quality_reqs.linting.enabled,
-            "tool": quality_reqs.linting.tool.value if quality_reqs.linting.tool else None,
-            "args": quality_reqs.linting.args,
+            "execution": _serialize_execution_spec(quality_reqs.linting.execution),
+            "timeout": quality_reqs.linting.timeout,
         },
         "type_checking": (
             {
                 "enabled": quality_reqs.type_checking.enabled,
-                "tool": (
-                    quality_reqs.type_checking.tool.value
-                    if quality_reqs.type_checking.tool
-                    else None
-                ),
-                "args": quality_reqs.type_checking.args,
+                "execution": _serialize_execution_spec(quality_reqs.type_checking.execution),
+                "timeout": quality_reqs.type_checking.timeout,
             }
             if quality_reqs.type_checking
             else None
@@ -123,9 +152,9 @@ def serialize_quality_reqs(quality_reqs) -> dict:
         "testing": (
             {
                 "enabled": quality_reqs.testing.enabled,
-                "tool": quality_reqs.testing.tool.value if quality_reqs.testing.tool else None,
-                "args": quality_reqs.testing.args,
+                "execution": _serialize_execution_spec(quality_reqs.testing.execution),
                 "min_coverage": quality_reqs.testing.min_coverage,
+                "timeout": quality_reqs.testing.timeout,
             }
             if quality_reqs.testing
             else None
@@ -133,12 +162,8 @@ def serialize_quality_reqs(quality_reqs) -> dict:
         "security_check": (
             {
                 "enabled": quality_reqs.security_check.enabled,
-                "tool": (
-                    quality_reqs.security_check.tool.value
-                    if quality_reqs.security_check.tool
-                    else None
-                ),
-                "args": quality_reqs.security_check.args,
+                "execution": _serialize_execution_spec(quality_reqs.security_check.execution),
+                "timeout": quality_reqs.security_check.timeout,
             }
             if quality_reqs.security_check
             else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simpletask"
-version = "0.35.13"
+version = "0.36.0"
 description = "CLI tool for managing AI-friendly task definitions in branch-based development workflows"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/tests/integration/test_cli_json_output.py
+++ b/tests/integration/test_cli_json_output.py
@@ -261,13 +261,15 @@ class TestQualityShowJsonOutput:
         parsed = json.loads(result.output)
         linting = parsed["linting"]
         assert "enabled" in linting
-        assert "tool" in linting
-        assert "args" in linting
+        assert "execution" in linting
+        assert "timeout" in linting
+        assert "tool" in linting["execution"]
+        assert "args" in linting["execution"]
 
     def test_linting_values_correct(self, json_project):
         result = runner.invoke(app, ["quality", "show", "--format", "json"])
         parsed = json.loads(result.output)
-        assert parsed["linting"]["tool"] == "ruff"
+        assert parsed["linting"]["execution"]["tool"] == "ruff"
         assert parsed["linting"]["enabled"] is True
 
     def test_no_ansi_codes(self, json_project):

--- a/tests/unit/test_defaults_commands.py
+++ b/tests/unit/test_defaults_commands.py
@@ -405,8 +405,9 @@ class TestQualitySetCommand:
         assert result.quality_requirements is not None
         assert result.quality_requirements.linting is not None
         linting = result.quality_requirements.linting
-        assert linting.tool == ToolName.RUFF
         assert linting.enabled is True
+        assert linting.execution is not None
+        assert linting.execution.tool == ToolName.RUFF
 
     @patch("simpletask.commands.defaults.commands.ensure_project")
     def test_set_testing_with_coverage(self, mock_ensure, tmp_path):
@@ -429,9 +430,10 @@ class TestQualitySetCommand:
         assert result.quality_requirements is not None
         assert result.quality_requirements.testing is not None
         testing = result.quality_requirements.testing
-        assert testing.tool == ToolName.PYTEST
         assert testing.min_coverage == 80
         assert testing.timeout == 600
+        assert testing.execution is not None
+        assert testing.execution.tool == ToolName.PYTEST
 
 
 # ---------------------------------------------------------------------------
@@ -496,10 +498,11 @@ class TestQualityPresetCommand:
         result = load_defaults(mock_project)
         assert result is not None
         assert result.quality_requirements is not None
-        # Existing linting should be kept (args preserved)
+        # Existing linting should be kept (args preserved in execution spec)
         linting = result.quality_requirements.linting
         assert linting is not None
-        assert linting.args == ["check", "src/"]
+        assert linting.execution is not None
+        assert linting.execution.args == ["check", "src/"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_defaults_target.py
+++ b/tests/unit/test_mcp_defaults_target.py
@@ -261,7 +261,8 @@ class TestQualityDefaultsTarget:
 
         assert response.quality_requirements is not None
         assert response.quality_requirements.linting is not None
-        assert response.quality_requirements.linting.tool.value == "ruff"
+        assert response.quality_requirements.linting.execution is not None
+        assert response.quality_requirements.linting.execution.tool.value == "ruff"
 
     def test_check_action_raises_for_defaults_target(self, defaults_project):
         _tasks_dir, mock_project = defaults_project
@@ -300,7 +301,8 @@ class TestQualityDefaultsTarget:
         assert response.quality_requirements is not None
         assert response.quality_requirements.linting is not None
         # Existing linting config (pylint) should be preserved
-        assert response.quality_requirements.linting.tool.value == "pylint"
+        assert response.quality_requirements.linting.execution is not None
+        assert response.quality_requirements.linting.execution.tool.value == "pylint"
 
     def test_summary_shows_defaults_branch(self, defaults_project):
         _tasks_dir, mock_project = defaults_project
@@ -372,7 +374,8 @@ class TestQualityDefaultsTarget:
         assert get_response is not None
         assert get_response.quality_requirements is not None
         assert get_response.quality_requirements.type_checking is not None
-        assert get_response.quality_requirements.type_checking.tool.value == "mypy"
+        assert get_response.quality_requirements.type_checking.execution is not None
+        assert get_response.quality_requirements.type_checking.execution.tool.value == "mypy"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_quality_design_tools.py
+++ b/tests/unit/test_mcp_quality_design_tools.py
@@ -99,7 +99,8 @@ class TestQualityToolGet:
 
         assert result.action == "quality_get"
         assert result.quality_requirements is not None
-        assert result.quality_requirements.linting.tool == ToolName.RUFF
+        assert result.quality_requirements.linting.execution is not None
+        assert result.quality_requirements.linting.execution.tool == ToolName.RUFF
         assert result.quality_requirements.testing.min_coverage == 80
         assert result.check_results is None
         assert result.all_passed is None
@@ -204,8 +205,9 @@ class TestQualityToolSet:
 
         # Verify write was called
         written_spec = mock_write.call_args[0][1]
-        assert written_spec.quality_requirements.linting.tool == ToolName.ESLINT
-        assert written_spec.quality_requirements.linting.args == [".", "--fix"]
+        assert written_spec.quality_requirements.linting.execution is not None
+        assert written_spec.quality_requirements.linting.execution.tool == ToolName.ESLINT
+        assert written_spec.quality_requirements.linting.execution.args == [".", "--fix"]
 
     @patch("simpletask.mcp.server.write_task_file")
     @patch("simpletask.mcp.server.parse_task_file")
@@ -306,7 +308,8 @@ class TestQualityToolPreset:
         # Verify type checking was added
         written_spec = mock_write.call_args[0][1]
         assert written_spec.quality_requirements.type_checking is not None
-        assert written_spec.quality_requirements.type_checking.tool == ToolName.MYPY
+        assert written_spec.quality_requirements.type_checking.execution is not None
+        assert written_spec.quality_requirements.type_checking.execution.tool == ToolName.MYPY
 
     @patch("simpletask.mcp.server.parse_task_file")
     @patch("simpletask.mcp.server.get_current_task_file_path")

--- a/tests/unit/test_presets.py
+++ b/tests/unit/test_presets.py
@@ -10,6 +10,7 @@ Tests cover:
 """
 
 import pytest
+import yaml
 from simpletask.core.models import (
     LintingConfig,
     QualityRequirements,
@@ -39,70 +40,102 @@ class TestQualityPresets:
             assert preset_name in QUALITY_PRESETS
 
     def test_python_preset(self):
-        """Python preset has correct configuration."""
+        """Python preset has correct configuration with nested execution specs."""
         preset = QUALITY_PRESETS["python"]
         assert preset.linting.enabled is True
-        assert preset.linting.tool == ToolName.RUFF
-        assert preset.linting.args == ["check", "."]
+        assert preset.linting.execution is not None
+        assert preset.linting.execution.kind.value == "tool"
+        assert preset.linting.execution.tool == ToolName.RUFF
+        assert preset.linting.execution.args == ["check", "."]
         assert preset.type_checking is not None
-        assert preset.type_checking.tool == ToolName.MYPY
+        assert preset.type_checking.execution is not None
+        assert preset.type_checking.execution.tool == ToolName.MYPY
         assert preset.testing.enabled is True
-        assert preset.testing.tool == ToolName.PYTEST
+        assert preset.testing.execution is not None
+        assert preset.testing.execution.tool == ToolName.PYTEST
         assert preset.testing.min_coverage == 80
         assert preset.security_check.enabled is False
 
     def test_typescript_preset(self):
         """TypeScript preset has correct configuration."""
         preset = QUALITY_PRESETS["typescript"]
-        assert preset.linting.tool == ToolName.ESLINT
+        assert preset.linting.enabled is True
+        assert preset.linting.execution is not None
+        assert preset.linting.execution.tool == ToolName.ESLINT
         assert preset.type_checking is not None
-        assert preset.type_checking.tool == ToolName.TSC
-        assert preset.testing.tool == ToolName.NPM
-        assert preset.testing.args == ["test"]
+        assert preset.type_checking.execution is not None
+        assert preset.type_checking.execution.tool == ToolName.TSC
+        assert preset.testing.enabled is True
+        assert preset.testing.execution is not None
+        assert preset.testing.execution.tool == ToolName.NPM
+        assert preset.testing.execution.args == ["test"]
 
     def test_node_preset(self):
         """Node preset has correct configuration."""
         preset = QUALITY_PRESETS["node"]
-        assert preset.linting.tool == ToolName.ESLINT
+        assert preset.linting.enabled is True
+        assert preset.linting.execution is not None
+        assert preset.linting.execution.tool == ToolName.ESLINT
         assert preset.type_checking is None  # No type checking for plain Node
-        assert preset.testing.tool == ToolName.NPM
+        assert preset.testing.enabled is True
+        assert preset.testing.execution is not None
+        assert preset.testing.execution.tool == ToolName.NPM
         assert preset.security_check.enabled is True
-        assert preset.security_check.tool == ToolName.NPM
-        assert preset.security_check.args == ["audit"]
+        assert preset.security_check.execution is not None
+        assert preset.security_check.execution.tool == ToolName.NPM
+        assert preset.security_check.execution.args == ["audit"]
 
     def test_go_preset(self):
         """Go preset has correct configuration."""
         preset = QUALITY_PRESETS["go"]
-        assert preset.linting.tool == ToolName.GOLANGCI_LINT
+        assert preset.linting.enabled is True
+        assert preset.linting.execution is not None
+        assert preset.linting.execution.tool == ToolName.GOLANGCI_LINT
         assert preset.type_checking is None  # Built-in at compile time
-        assert preset.testing.tool == ToolName.GO
+        assert preset.testing.enabled is True
+        assert preset.testing.execution is not None
+        assert preset.testing.execution.tool == ToolName.GO
         assert preset.security_check.enabled is True
-        assert preset.security_check.tool == ToolName.GOSEC
+        assert preset.security_check.execution is not None
+        assert preset.security_check.execution.tool == ToolName.GOSEC
 
     def test_rust_preset(self):
         """Rust preset has correct configuration."""
         preset = QUALITY_PRESETS["rust"]
-        assert preset.linting.tool == ToolName.CARGO
-        assert "clippy" in preset.linting.args
+        assert preset.linting.enabled is True
+        assert preset.linting.execution is not None
+        assert preset.linting.execution.tool == ToolName.CARGO
+        assert "clippy" in preset.linting.execution.args
         assert preset.type_checking is None  # Built-in at compile time
-        assert preset.testing.tool == ToolName.CARGO
+        assert preset.testing.enabled is True
+        assert preset.testing.execution is not None
+        assert preset.testing.execution.tool == ToolName.CARGO
         assert preset.security_check.enabled is True
-        assert preset.security_check.tool == ToolName.CARGO
+        assert preset.security_check.execution is not None
+        assert preset.security_check.execution.tool == ToolName.CARGO
 
     def test_java_maven_preset(self):
         """Java Maven preset has correct configuration."""
         preset = QUALITY_PRESETS["java-maven"]
-        assert preset.linting.tool == ToolName.MVN
-        assert "checkstyle:check" in preset.linting.args
+        assert preset.linting.enabled is True
+        assert preset.linting.execution is not None
+        assert preset.linting.execution.tool == ToolName.MVN
+        assert "checkstyle:check" in preset.linting.execution.args
         assert preset.type_checking is None  # Built-in at compile time
-        assert preset.testing.tool == ToolName.MVN
+        assert preset.testing.enabled is True
+        assert preset.testing.execution is not None
+        assert preset.testing.execution.tool == ToolName.MVN
         assert preset.security_check.enabled is True
 
     def test_java_gradle_preset(self):
         """Java Gradle preset has correct configuration."""
         preset = QUALITY_PRESETS["java-gradle"]
-        assert preset.linting.tool == ToolName.GRADLE
-        assert preset.testing.tool == ToolName.GRADLE
+        assert preset.linting.enabled is True
+        assert preset.linting.execution is not None
+        assert preset.linting.execution.tool == ToolName.GRADLE
+        assert preset.testing.enabled is True
+        assert preset.testing.execution is not None
+        assert preset.testing.execution.tool == ToolName.GRADLE
         assert preset.security_check.enabled is True
 
 
@@ -113,7 +146,8 @@ class TestGetPreset:
         """Getting a valid preset returns QualityRequirements."""
         preset = get_preset("python")
         assert isinstance(preset, QualityRequirements)
-        assert preset.linting.tool == ToolName.RUFF
+        assert preset.linting.execution is not None
+        assert preset.linting.execution.tool == ToolName.RUFF
 
     def test_get_invalid_preset(self):
         """Getting an invalid preset raises ValueError."""
@@ -154,10 +188,13 @@ class TestApplyPreset:
     def test_apply_to_none(self):
         """Applying preset to None uses preset directly."""
         merged, applied = apply_preset(None, "python")
-        assert merged.linting.tool == ToolName.RUFF
+        assert merged.linting.execution is not None
+        assert merged.linting.execution.tool == ToolName.RUFF
         assert merged.type_checking is not None
-        assert merged.type_checking.tool == ToolName.MYPY
-        assert merged.testing.tool == ToolName.PYTEST
+        assert merged.type_checking.execution is not None
+        assert merged.type_checking.execution.tool == ToolName.MYPY
+        assert merged.testing.execution is not None
+        assert merged.testing.execution.tool == ToolName.PYTEST
         assert applied["linting"] is True
         assert applied["type_checking"] is True
         assert applied["testing"] is True
@@ -176,16 +213,19 @@ class TestApplyPreset:
         merged, applied = apply_preset(existing, "python")
 
         # Linting should NOT be replaced (user's PYLINT preserved)
-        assert merged.linting.tool == ToolName.PYLINT
+        assert merged.linting.execution is not None
+        assert merged.linting.execution.tool == ToolName.PYLINT
         assert applied["linting"] is False
 
         # Type checking should be filled from preset (MYPY)
         assert merged.type_checking is not None
-        assert merged.type_checking.tool == ToolName.MYPY
+        assert merged.type_checking.execution is not None
+        assert merged.type_checking.execution.tool == ToolName.MYPY
         assert applied["type_checking"] is True
 
         # Testing should NOT be replaced (user's config preserved)
-        assert merged.testing.tool == ToolName.PYTEST
+        assert merged.testing.execution is not None
+        assert merged.testing.execution.tool == ToolName.PYTEST
         assert applied["testing"] is False
 
         # Security check should NOT be replaced (user's config preserved)
@@ -207,11 +247,14 @@ class TestApplyPreset:
         merged, applied = apply_preset(existing, "python")
 
         # All fields should be preserved
-        assert merged.linting.tool == ToolName.RUFF
-        assert merged.linting.args == ["check", "src/"]
-        assert merged.type_checking.args == ["src/"]
+        assert merged.linting.execution is not None
+        assert merged.linting.execution.tool == ToolName.RUFF
+        assert merged.linting.execution.args == ["check", "src/"]
+        assert merged.type_checking.execution is not None
+        assert merged.type_checking.execution.args == ["src/"]
         assert merged.testing.min_coverage == 90
-        assert merged.security_check.tool == ToolName.BANDIT
+        assert merged.security_check.execution is not None
+        assert merged.security_check.execution.tool == ToolName.BANDIT
         assert applied["linting"] is False
         assert applied["type_checking"] is False
         assert applied["testing"] is False
@@ -229,7 +272,8 @@ class TestApplyPreset:
         merged, applied = apply_preset(existing, "python")
 
         assert merged.type_checking is not None
-        assert merged.type_checking.tool == ToolName.MYPY
+        assert merged.type_checking.execution is not None
+        assert merged.type_checking.execution.tool == ToolName.MYPY
         assert applied["type_checking"] is True
         assert applied["linting"] is False
         assert applied["testing"] is False
@@ -319,8 +363,9 @@ custom-python:
         assert "custom-python" in presets
         preset = presets["custom-python"]
         assert preset.linting.enabled is True
-        assert preset.linting.tool == ToolName.RUFF
-        assert preset.linting.args == ["check", "src/"]
+        assert preset.linting.execution is not None
+        assert preset.linting.execution.tool == ToolName.RUFF
+        assert preset.linting.execution.args == ["check", "src/"]
         assert preset.testing.min_coverage == 90
 
     def test_load_file_not_found(self, tmp_path):
@@ -394,8 +439,10 @@ preset2:
         assert len(presets) == 2
         assert "preset1" in presets
         assert "preset2" in presets
-        assert presets["preset1"].linting.tool == ToolName.RUFF
-        assert presets["preset2"].linting.tool == ToolName.ESLINT
+        assert presets["preset1"].linting.execution is not None
+        assert presets["preset1"].linting.execution.tool == ToolName.RUFF
+        assert presets["preset2"].linting.execution is not None
+        assert presets["preset2"].linting.execution.tool == ToolName.ESLINT
 
 
 class TestLoadAllPresets:
@@ -437,5 +484,71 @@ python:
 
         # Custom 'python' preset should override built-in
         assert "python" in all_presets
-        assert all_presets["python"].linting.args == ["check", "custom/"]
+        assert all_presets["python"].linting.execution is not None
+        assert all_presets["python"].linting.execution.args == ["check", "custom/"]
         assert all_presets["python"].testing.min_coverage == 95
+
+
+class TestPresetWriteYamlIntegration:
+    """Integration tests verifying that preset → write_task_file emits canonical YAML bytes."""
+
+    def test_preset_apply_then_write_emits_canonical_execution(self, tmp_path, sample_spec):
+        """AC3: after apply_preset + write_task_file, YAML must use only nested execution."""
+        from simpletask.core.yaml_parser import write_task_file
+
+        sample_spec.quality_requirements = None
+        merged, _ = apply_preset(None, "python")
+        sample_spec.quality_requirements = merged
+
+        task_file = tmp_path / "test.yml"
+        write_task_file(task_file, sample_spec)
+        data = yaml.safe_load(task_file.read_text())
+
+        linting = data["quality_requirements"]["linting"]
+        assert "execution" in linting, "linting must have nested execution block"
+        assert "tool" not in linting, "legacy 'tool' must not be present"
+        assert "args" not in linting, "legacy 'args' must not be present"
+        assert data["schema_version"] == "1.1"
+
+    def test_preset_write_preserves_execution_kind_and_tool(self, tmp_path, sample_spec):
+        """Nested execution tool and kind survive the write/read round trip."""
+        from simpletask.core.yaml_parser import parse_task_file, write_task_file
+
+        sample_spec.quality_requirements = None
+        merged, _ = apply_preset(None, "python")
+        sample_spec.quality_requirements = merged
+
+        task_file = tmp_path / "test.yml"
+        write_task_file(task_file, sample_spec)
+        parsed = parse_task_file(task_file)
+
+        assert parsed.quality_requirements is not None
+        assert parsed.quality_requirements.linting.execution is not None
+        assert parsed.quality_requirements.linting.execution.tool == ToolName.RUFF
+        assert parsed.quality_requirements.type_checking is not None
+        assert parsed.quality_requirements.type_checking.execution is not None
+        assert parsed.quality_requirements.type_checking.execution.tool == ToolName.MYPY
+
+    def test_preset_fill_gaps_write_canonical_yaml(self, tmp_path, sample_spec):
+        """Filling only type_checking from preset still produces canonical YAML."""
+        from simpletask.core.yaml_parser import write_task_file
+
+        sample_spec.quality_requirements = QualityRequirements(
+            linting=LintingConfig(enabled=True, tool=ToolName.RUFF, args=["check", "."]),
+            type_checking=None,
+            testing=TestingConfig(enabled=True, tool=ToolName.PYTEST, args=[]),
+            security_check=SecurityCheckConfig(enabled=False),
+        )
+        merged, applied = apply_preset(sample_spec.quality_requirements, "python")
+        assert applied["type_checking"] is True
+        sample_spec.quality_requirements = merged
+
+        task_file = tmp_path / "test.yml"
+        write_task_file(task_file, sample_spec)
+        data = yaml.safe_load(task_file.read_text())
+
+        type_checking = data["quality_requirements"]["type_checking"]
+        assert "execution" in type_checking
+        assert "tool" not in type_checking
+        assert "args" not in type_checking
+        assert data["schema_version"] == "1.1"

--- a/tests/unit/test_quality_commands.py
+++ b/tests/unit/test_quality_commands.py
@@ -237,7 +237,8 @@ class TestSetCommand:
         # Verify write_task_file was called
         mock_write.assert_called_once()
         updated_spec = mock_write.call_args[0][1]
-        assert updated_spec.quality_requirements.linting.tool == ToolName.PYLINT
+        assert updated_spec.quality_requirements.linting.execution is not None
+        assert updated_spec.quality_requirements.linting.execution.tool == ToolName.PYLINT
 
     @patch("simpletask.commands.quality.set.write_task_file")
     @patch("simpletask.commands.quality.set.parse_task_file")
@@ -289,7 +290,8 @@ class TestSetCommand:
 
         mock_write.assert_called_once()
         updated_spec = mock_write.call_args[0][1]
-        assert updated_spec.quality_requirements.linting.args == ["check", "src", "--fix"]
+        assert updated_spec.quality_requirements.linting.execution is not None
+        assert updated_spec.quality_requirements.linting.execution.args == ["check", "src", "--fix"]
 
     @patch("simpletask.commands.quality.set.get_task_file_path")
     def test_set_coverage_non_testing_error(self, mock_get_path):
@@ -370,7 +372,8 @@ class TestPresetCommand:
         updated_spec = mock_write.call_args[0][1]
         # Type checking should be filled from preset
         assert updated_spec.quality_requirements.type_checking is not None
-        assert updated_spec.quality_requirements.type_checking.tool == ToolName.MYPY
+        assert updated_spec.quality_requirements.type_checking.execution is not None
+        assert updated_spec.quality_requirements.type_checking.execution.tool == ToolName.MYPY
 
     @patch("simpletask.commands.quality.preset.write_task_file")
     @patch("simpletask.commands.quality.preset.parse_task_file")
@@ -381,14 +384,15 @@ class TestPresetCommand:
         """Applying preset preserves existing configurations."""
         mock_get_path.return_value = Path(".tasks/test-feature.yml")
         mock_parse.return_value = sample_spec_with_quality
-        original_tool = sample_spec_with_quality.quality_requirements.linting.tool
+        original_tool = sample_spec_with_quality.quality_requirements.linting.execution.tool
 
         preset_command(preset_name="python")
 
         mock_write.assert_called_once()
         updated_spec = mock_write.call_args[0][1]
         # Linting should be preserved (not replaced)
-        assert updated_spec.quality_requirements.linting.tool == original_tool
+        assert updated_spec.quality_requirements.linting.execution is not None
+        assert updated_spec.quality_requirements.linting.execution.tool == original_tool
 
     @patch("simpletask.commands.quality.preset.load_all_presets")
     @patch("simpletask.commands.quality.preset.QUALITY_PRESETS")

--- a/tests/unit/test_quality_models.py
+++ b/tests/unit/test_quality_models.py
@@ -26,6 +26,7 @@ from simpletask.core.models import (
     SecurityRequirement,
     SimpleTaskSpec,
     TestingConfig,
+    ToolExecutionSpec,
     ToolName,
     TypeCheckConfig,
 )
@@ -51,10 +52,12 @@ class TestLintingConfig:
     """Test LintingConfig model."""
 
     def test_valid_config(self):
-        """Valid linting config validates correctly."""
+        """Valid linting config validates correctly; tool is normalized into execution spec."""
         config = LintingConfig(enabled=True, tool=ToolName.RUFF, args=["check", "."])
         assert config.enabled is True
-        assert config.tool == ToolName.RUFF
+        assert config.tool is None  # cleared by normalization
+        assert config.execution is not None
+        assert config.execution.tool == ToolName.RUFF
         assert config.args == ["check", "."]
 
     def test_empty_args(self):
@@ -99,10 +102,12 @@ class TestTypeCheckConfig:
     """Test TypeCheckConfig model."""
 
     def test_valid_config(self):
-        """Valid type check config validates correctly."""
+        """Valid type check config validates correctly; tool is normalized into execution spec."""
         config = TypeCheckConfig(enabled=True, tool=ToolName.MYPY, args=["cli/"])
         assert config.enabled is True
-        assert config.tool == ToolName.MYPY
+        assert config.tool is None  # cleared by normalization
+        assert config.execution is not None
+        assert config.execution.tool == ToolName.MYPY
         assert config.args == ["cli/"]
 
     def test_shell_metacharacters_rejected(self):
@@ -116,10 +121,12 @@ class TestTestingConfig:
     """Test TestingConfig model."""
 
     def test_valid_config_with_coverage(self):
-        """Valid test config with coverage validates correctly."""
+        """Valid test config with coverage validates correctly; tool normalized into execution spec."""
         config = TestingConfig(enabled=True, tool=ToolName.PYTEST, args=[], min_coverage=80)
         assert config.enabled is True
-        assert config.tool == ToolName.PYTEST
+        assert config.tool is None  # cleared by normalization
+        assert config.execution is not None
+        assert config.execution.tool == ToolName.PYTEST
         assert config.min_coverage == 80
 
     def test_valid_config_without_coverage(self):
@@ -151,10 +158,12 @@ class TestSecurityCheckConfig:
     """Test SecurityCheckConfig model."""
 
     def test_valid_config_enabled(self):
-        """Valid enabled security config validates correctly."""
+        """Valid enabled security config validates correctly; tool normalized into execution spec."""
         config = SecurityCheckConfig(enabled=True, tool=ToolName.BANDIT, args=["-r", "."])
         assert config.enabled is True
-        assert config.tool == ToolName.BANDIT
+        assert config.tool is None  # cleared by normalization
+        assert config.execution is not None
+        assert config.execution.tool == ToolName.BANDIT
         assert config.args == ["-r", "."]
 
     def test_valid_config_disabled(self):
@@ -437,7 +446,8 @@ class TestSimpleTaskSpecWithQualityAndDesign:
             ),
         )
         assert spec.quality_requirements is not None
-        assert spec.quality_requirements.linting.tool == ToolName.RUFF
+        assert spec.quality_requirements.linting.execution is not None
+        assert spec.quality_requirements.linting.execution.tool == ToolName.RUFF
         assert spec.quality_requirements.testing.min_coverage == 80
 
     def test_spec_with_design(self):
@@ -495,3 +505,69 @@ class TestSimpleTaskSpecWithQualityAndDesign:
             ),
         )
         assert spec.design is None
+
+
+class TestMixedLegacyAndCanonicalRejection:
+    """Verify that setting both 'execution' and 'tool' in the same config is rejected (AC5)."""
+
+    def test_linting_config_rejects_mixed_fields(self):
+        """LintingConfig raises ValidationError when both execution and tool are set."""
+        with pytest.raises(ValidationError, match=r"both 'execution'.*and 'tool'"):
+            LintingConfig(
+                enabled=True,
+                execution=ToolExecutionSpec(tool=ToolName.RUFF, args=["check", "."]),
+                tool=ToolName.MYPY,
+            )
+
+    def test_type_check_config_rejects_mixed_fields(self):
+        """TypeCheckConfig raises ValidationError when both execution and tool are set."""
+        with pytest.raises(ValidationError, match=r"both 'execution'.*and 'tool'"):
+            TypeCheckConfig(
+                enabled=True,
+                execution=ToolExecutionSpec(tool=ToolName.MYPY, args=[]),
+                tool=ToolName.RUFF,
+            )
+
+    def test_testing_config_rejects_mixed_fields(self):
+        """TestingConfig raises ValidationError when both execution and tool are set."""
+        with pytest.raises(ValidationError, match=r"both 'execution'.*and 'tool'"):
+            TestingConfig(
+                enabled=True,
+                execution=ToolExecutionSpec(tool=ToolName.PYTEST, args=[]),
+                tool=ToolName.PYTEST,
+            )
+
+    def test_security_check_config_rejects_mixed_fields(self):
+        """SecurityCheckConfig raises ValidationError when both execution and tool are set."""
+        with pytest.raises(ValidationError, match=r"both 'execution'.*and 'tool'"):
+            SecurityCheckConfig(
+                enabled=True,
+                execution=ToolExecutionSpec(tool=ToolName.RUFF, args=[]),
+                tool=ToolName.RUFF,
+            )
+
+    def test_error_message_identifies_config_type(self):
+        """Error message names the config class so the offending field is identifiable."""
+        with pytest.raises(ValidationError) as exc_info:
+            LintingConfig(
+                enabled=True,
+                execution=ToolExecutionSpec(tool=ToolName.RUFF, args=[]),
+                tool=ToolName.MYPY,
+            )
+        assert "LintingConfig" in str(exc_info.value)
+
+    def test_legacy_only_still_accepted(self):
+        """Legacy tool/args form without execution is still valid (backward compat)."""
+        cfg = LintingConfig(enabled=True, tool=ToolName.RUFF, args=["check", "."])
+        assert cfg.tool is None  # cleared by normalization
+        assert cfg.execution is not None
+        assert cfg.execution.tool == ToolName.RUFF
+
+    def test_canonical_only_still_accepted(self):
+        """Canonical execution-only form without tool is valid."""
+        cfg = LintingConfig(
+            enabled=True,
+            execution=ToolExecutionSpec(tool=ToolName.MYPY, args=["--strict"]),
+        )
+        assert cfg.execution.tool == ToolName.MYPY
+        assert cfg.tool is None

--- a/tests/unit/test_yaml_parser.py
+++ b/tests/unit/test_yaml_parser.py
@@ -9,11 +9,15 @@ Tests cover:
 """
 
 import pytest
+import yaml
 from simpletask.core.models import (
     TaskStatus,
+    ToolName,
+    WorkflowRunner,
 )
 from simpletask.core.yaml_parser import (
     InvalidTaskFileError,
+    _bump_schema_version_if_canonical,
     parse_task_file,
     update_criterion_status,
     update_task_status,
@@ -120,6 +124,108 @@ class TestWriteTaskFile:
         assert parsed_spec.title == sample_spec.title
         assert len(parsed_spec.tasks) == len(sample_spec.tasks)
         assert len(parsed_spec.acceptance_criteria) == len(sample_spec.acceptance_criteria)
+
+
+class TestBumpSchemaVersion:
+    """Tests for _bump_schema_version_if_canonical — schema_version upgrade (AC3)."""
+
+    def test_bumps_schema_version_to_1_1_when_canonical_execution_present(self):
+        """schema_version is bumped to '1.1' when any section has canonical execution."""
+        data = {
+            "schema_version": "1.0",
+            "quality_requirements": {
+                "linting": {
+                    "enabled": True,
+                    "execution": {"kind": "tool", "tool": "ruff", "args": []},
+                }
+            },
+        }
+        result = _bump_schema_version_if_canonical(data)
+        assert result["schema_version"] == "1.1"
+
+    def test_does_not_bump_schema_version_when_no_execution(self):
+        """schema_version stays unchanged when no section uses canonical execution."""
+        data = {
+            "schema_version": "1.0",
+            "quality_requirements": {
+                "linting": {"enabled": True, "tool": "ruff", "args": ["check", "."]}
+            },
+        }
+        result = _bump_schema_version_if_canonical(data)
+        assert result["schema_version"] == "1.0"
+
+    def test_handles_missing_quality_requirements(self):
+        """Data without quality_requirements is returned unchanged."""
+        data = {"schema_version": "1.0", "branch": "test"}
+        result = _bump_schema_version_if_canonical(data)
+        assert result == {"schema_version": "1.0", "branch": "test"}
+
+    def test_handles_non_dict_quality_requirements(self):
+        """Non-dict quality_requirements value is returned unchanged."""
+        data = {"schema_version": "1.0", "quality_requirements": None}
+        result = _bump_schema_version_if_canonical(data)
+        assert result["schema_version"] == "1.0"
+
+
+class TestWriteTaskFileCanonicalOutput:
+    """Integration tests: write_task_file emits canonical YAML (AC3)."""
+
+    def test_write_strips_legacy_fields_and_bumps_schema_version(
+        self, tmp_path, sample_spec_filterable
+    ):
+        """write_task_file removes legacy tool/args and sets schema_version:1.1 when execution present.
+
+        sample_spec_filterable has quality_requirements built from legacy tool= kwargs, so after
+        normalization the model holds both execution and tool. write_task_file must emit
+        only canonical execution in the YAML.
+        """
+        task_file = tmp_path / "task.yml"
+        write_task_file(task_file, sample_spec_filterable)
+
+        data = yaml.safe_load(task_file.read_text())
+        linting = data["quality_requirements"]["linting"]
+
+        assert "execution" in linting, "canonical execution key must be present"
+        assert "tool" not in linting, "legacy tool key must be stripped"
+        assert "args" not in linting, "legacy args key must be stripped"
+        assert data["schema_version"] == "1.1"
+
+    def test_write_canonical_round_trip(self, tmp_path, sample_spec_filterable):
+        """Spec written in canonical form can be read back and still has execution spec."""
+        task_file = tmp_path / "task.yml"
+        write_task_file(task_file, sample_spec_filterable)
+
+        parsed = parse_task_file(task_file)
+        assert parsed.quality_requirements is not None
+        assert parsed.quality_requirements.linting.execution is not None
+        assert parsed.quality_requirements.linting.execution.tool == ToolName.RUFF
+        assert parsed.schema_version == "1.1"
+
+    def test_write_workflow_execution_strips_legacy_and_bumps_version(
+        self, tmp_path, sample_spec_filterable
+    ):
+        """Workflow execution spec also triggers legacy-field stripping and version bump."""
+        from simpletask.core.quality_ops import update_quality_config
+
+        updated = update_quality_config(
+            sample_spec_filterable,
+            "linting",
+            workflow_runner=WorkflowRunner.EARTHLY,
+            workflow_target="+lint",
+        )
+        task_file = tmp_path / "task.yml"
+        write_task_file(task_file, updated)
+
+        data = yaml.safe_load(task_file.read_text())
+        linting = data["quality_requirements"]["linting"]
+
+        assert "execution" in linting
+        assert linting["execution"]["kind"] == "workflow"
+        assert linting["execution"]["runner"] == "earthly"
+        assert linting["execution"]["target"] == "+lint"
+        assert "tool" not in linting
+        assert "args" not in linting
+        assert data["schema_version"] == "1.1"
 
 
 class TestUpdateTaskStatus:


### PR DESCRIPTION
Closes #37

## Summary

- Replaces flat `tool`/`args` quality config with a canonical nested `execution` spec (`ToolExecutionSpec` / `WorkflowExecutionSpec`) and `schema_version: 1.1`
- Backward-compatible: legacy flat fields parse successfully and are normalized on read; rewrites emit only the canonical shape
- Workflow runners `earthly` and `make` supported; `earthly` supports optional `--no-cache` and `extra_args`
- Mixed legacy + canonical fields in the same check are rejected with a descriptive `ValidationError` identifying the config class and offending fields
- CLI (`quality set --runner / --target`), defaults command, and MCP (`workflow_runner` / `workflow_target`) all support workflow configuration
- `simpletask show` and MCP responses display tool name or runner+target — never a blank label
- JSON schema updated with `ToolExecutionSpec`, `WorkflowExecutionSpec` definitions and `schema_version 1.1` support
- 1116 tests passing

## Files changed (22)

Core models, quality ops, checker, presets, YAML parser, MCP server, CLI commands, output utils, JSON schema, and corresponding test files.