### PR TITLE
feat(ai): skip template installation for undetected editors

### DIFF
--- a/cli/simpletask/__init__.py
+++ b/cli/simpletask/__init__.py
@@ -1,6 +1,6 @@
 """simpletask: A Python CLI for managing AI-friendly task definition YAML files."""
 
-__version__ = "0.36.0"
+__version__ = "0.37.0"
 
 import typer
 

--- a/cli/simpletask/commands/ai/install.py
+++ b/cli/simpletask/commands/ai/install.py
@@ -3,6 +3,7 @@
 import typer
 
 from simpletask.core.ai_templates import (
+    EditorType,
     get_global_agents_dir,
     get_global_commands_dir,
     get_global_gemini_commands_dir,
@@ -18,8 +19,40 @@ from simpletask.core.ai_templates import (
     install_qwen_templates,
     install_templates,
     install_vibe_templates,
+    is_editor_installed,
 )
 from simpletask.utils.console import error, info, success, warning
+
+
+def _should_install(editor: EditorType, display_name: str, explicit: bool, local: bool) -> bool:
+    """Determine whether to install templates for an editor.
+
+    Truth table for global installs:
+    - local=True  → always install (bypass detection)
+    - editor detected (base dir exists) → install
+    - editor not detected, explicit flag → prompt user
+    - editor not detected, implicit (all-editors default) → skip with info message
+
+    Args:
+        editor: Editor type identifier.
+        display_name: Human-readable editor name for messages.
+        explicit: True if the user passed this editor's flag explicitly.
+        local: True if --local flag was used (bypasses detection).
+
+    Returns:
+        True if installation should proceed, False otherwise.
+    """
+    if local:
+        return True
+    if is_editor_installed(editor):
+        return True
+    if explicit:
+        return typer.confirm(
+            f"{display_name} config directory not found. Install anyway?",
+            default=False,
+        )
+    info(f"{display_name} not detected — skipping")
+    return False
 
 
 def _report_installation_results(
@@ -106,17 +139,24 @@ def install_command(
         simpletask ai install --vibe          # Install Mistral Vibe only
         simpletask ai install --opencode --qwen --gemini --vibe --local  # All four, locally
     """
-    # If no flags specified, install all four
+    # If no flags specified, install all four (implicit mode)
     none_specified = not opencode and not qwen and not gemini and not vibe
     install_opencode = opencode or none_specified
     install_qwen = qwen or none_specified
     install_gemini = gemini or none_specified
     install_vibe = vibe or none_specified
 
+    # Track whether each editor was explicitly requested by the user
+    opencode_explicit = bool(opencode)
+    qwen_explicit = bool(qwen)
+    gemini_explicit = bool(gemini)
+    vibe_explicit = bool(vibe)
+
     any_skipped = False
+    opencode_installed = False
 
     # Install OpenCode templates
-    if install_opencode:
+    if install_opencode and _should_install("opencode", "OpenCode", opencode_explicit, local):
         try:
             target_dir = get_local_commands_dir() if local else get_global_commands_dir()
 
@@ -130,13 +170,14 @@ def install_command(
             any_skipped = (
                 _report_installation_results(installed, skipped, overwritten) or any_skipped
             )
+            opencode_installed = True
         except FileNotFoundError as e:
             warning(f"Skipping OpenCode installation: {e}")
         except Exception as e:
             error(f"Unexpected error installing OpenCode: {e}")
 
     # Install Qwen templates
-    if install_qwen:
+    if install_qwen and _should_install("qwen", "Qwen", qwen_explicit, local):
         try:
             target_dir = get_local_qwen_commands_dir() if local else get_global_qwen_commands_dir()
 
@@ -156,7 +197,7 @@ def install_command(
             error(f"Unexpected error installing Qwen: {e}")
 
     # Install Gemini CLI templates
-    if install_gemini:
+    if install_gemini and _should_install("gemini", "Gemini CLI", gemini_explicit, local):
         try:
             target_dir = (
                 get_local_gemini_commands_dir() if local else get_global_gemini_commands_dir()
@@ -178,7 +219,7 @@ def install_command(
             error(f"Unexpected error installing Gemini: {e}")
 
     # Install Vibe skills
-    if install_vibe:
+    if install_vibe and _should_install("vibe", "Mistral Vibe", vibe_explicit, local):
         try:
             target_dir = get_local_vibe_commands_dir() if local else get_global_vibe_commands_dir()
 
@@ -197,8 +238,8 @@ def install_command(
         except Exception as e:
             error(f"Unexpected error installing Vibe: {e}")
 
-    # Install OpenCode agents separately with independent error handling
-    if install_opencode:
+    # Install OpenCode agents alongside OpenCode commands
+    if install_opencode and opencode_installed:
         try:
             agents_dir = get_local_agents_dir() if local else get_global_agents_dir()
 

--- a/cli/simpletask/core/ai_templates.py
+++ b/cli/simpletask/core/ai_templates.py
@@ -18,6 +18,7 @@ class EditorConfig:
     file_extension: str
     global_config_dir: tuple[str, ...]
     local_config_dir: tuple[str, ...]
+    global_base_dir: tuple[str, ...] = ()
     global_agents_dir: tuple[str, ...] | None = None
     local_agents_dir: tuple[str, ...] | None = None
     is_directory_based: bool = False
@@ -30,6 +31,7 @@ EDITOR_CONFIGS: dict[EditorType, EditorConfig] = {
         file_extension=".md",
         global_config_dir=(".config", "opencode", "commands"),
         local_config_dir=(".opencode", "commands"),
+        global_base_dir=(".config", "opencode"),
         global_agents_dir=(".config", "opencode", "agents"),
         local_agents_dir=(".opencode", "agents"),
     ),
@@ -39,6 +41,7 @@ EDITOR_CONFIGS: dict[EditorType, EditorConfig] = {
         file_extension=".md",
         global_config_dir=(".qwen", "commands"),
         local_config_dir=(".qwen", "commands"),
+        global_base_dir=(".qwen",),
     ),
     "gemini": EditorConfig(
         display_name="Gemini CLI",
@@ -46,6 +49,7 @@ EDITOR_CONFIGS: dict[EditorType, EditorConfig] = {
         file_extension=".toml",
         global_config_dir=(".gemini", "commands"),
         local_config_dir=(".gemini", "commands"),
+        global_base_dir=(".gemini",),
     ),
     "vibe": EditorConfig(
         display_name="Mistral Vibe",
@@ -53,6 +57,7 @@ EDITOR_CONFIGS: dict[EditorType, EditorConfig] = {
         file_extension=".md",
         global_config_dir=(".vibe", "skills"),
         local_config_dir=(".vibe", "skills"),
+        global_base_dir=(".vibe",),
         is_directory_based=True,
     ),
 }
@@ -131,6 +136,36 @@ def _get_local_commands_dir(editor: EditorType) -> Path:
     """
     config = EDITOR_CONFIGS[editor]
     return Path.cwd().joinpath(*config.local_config_dir)
+
+
+def get_editor_base_dir(editor: EditorType) -> Path:
+    """Get the global base directory for an editor.
+
+    This is the top-level directory whose existence indicates whether the
+    editor is installed on the machine (e.g. ~/.config/opencode for OpenCode).
+
+    Args:
+        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
+
+    Returns:
+        Path to the editor's global base directory.
+    """
+    config = EDITOR_CONFIGS[editor]
+    return Path.home().joinpath(*config.global_base_dir)
+
+
+def is_editor_installed(editor: EditorType) -> bool:
+    """Check whether an editor is installed on the current machine.
+
+    An editor is considered installed if its global base directory exists.
+
+    Args:
+        editor: Editor type ("opencode", "qwen", "gemini", or "vibe")
+
+    Returns:
+        True if the editor's global base directory exists, False otherwise.
+    """
+    return get_editor_base_dir(editor).exists()
 
 
 def _install_files(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simpletask"
-version = "0.36.0"
+version = "0.37.0"
 description = "CLI tool for managing AI-friendly task definitions in branch-based development workflows"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/tests/integration/test_ai_install_cli.py
+++ b/tests/integration/test_ai_install_cli.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from simpletask import app
 from typer.testing import CliRunner
 
@@ -11,6 +12,12 @@ runner = CliRunner()
 
 class TestAiInstallCLI:
     """Integration tests for 'simpletask ai install' command."""
+
+    @pytest.fixture(autouse=True)
+    def mock_editor_installed(self):
+        """Assume all editors are installed for these behavioural tests."""
+        with patch("simpletask.commands.ai.install.is_editor_installed", return_value=True):
+            yield
 
     @patch("simpletask.commands.ai.install.get_global_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_qwen_commands_dir")
@@ -297,6 +304,12 @@ class TestAiInstallCLI:
 class TestAiInstallAgentsCLI:
     """Integration tests for agent installation via 'simpletask ai install' command."""
 
+    @pytest.fixture(autouse=True)
+    def mock_editor_installed(self):
+        """Assume all editors are installed for these behavioural tests."""
+        with patch("simpletask.commands.ai.install.is_editor_installed", return_value=True):
+            yield
+
     @patch("simpletask.commands.ai.install.get_global_commands_dir")
     @patch("simpletask.commands.ai.install.get_global_agents_dir")
     def test_opencode_flag_installs_agents(
@@ -409,6 +422,12 @@ class TestAiInstallAgentsCLI:
 
 class TestAiInstallVibeCLI:
     """Integration tests for Vibe skill installation via 'simpletask ai install' command."""
+
+    @pytest.fixture(autouse=True)
+    def mock_editor_installed(self):
+        """Assume all editors are installed for these behavioural tests."""
+        with patch("simpletask.commands.ai.install.is_editor_installed", return_value=True):
+            yield
 
     @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
     def test_vibe_flag_only(self, mock_vibe_dir, tmp_path: Path):
@@ -535,3 +554,150 @@ class TestAiInstallVibeCLI:
 
         assert result.exit_code == 0
         assert "Installing OpenCode agents" not in result.stdout
+
+
+class TestInstallEditorDetection:
+    """Integration tests for editor detection behaviour in 'simpletask ai install'."""
+
+    @patch("simpletask.commands.ai.install.get_global_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_qwen_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_gemini_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_agents_dir")
+    @patch("simpletask.commands.ai.install.is_editor_installed", return_value=False)
+    def test_default_skips_missing_editors(
+        self,
+        mock_installed,
+        mock_agents_dir,
+        mock_vibe_dir,
+        mock_gemini_dir,
+        mock_qwen_dir,
+        mock_opencode_dir,
+        tmp_path: Path,
+    ):
+        """Default install skips editors whose base directory does not exist."""
+        for mock, name in [
+            (mock_opencode_dir, "opencode"),
+            (mock_qwen_dir, "qwen"),
+            (mock_gemini_dir, "gemini"),
+            (mock_vibe_dir, "vibe"),
+            (mock_agents_dir, "agents"),
+        ]:
+            mock.return_value = tmp_path / name
+
+        result = runner.invoke(app, ["ai", "install"])
+
+        assert result.exit_code == 0
+        assert "not detected" in result.stdout
+        # No templates should be written
+        assert not (tmp_path / "opencode").exists()
+        assert not (tmp_path / "qwen").exists()
+        assert not (tmp_path / "gemini").exists()
+        assert not (tmp_path / "vibe").exists()
+
+    @patch("simpletask.commands.ai.install.get_global_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_agents_dir")
+    @patch("simpletask.commands.ai.install.is_editor_installed", return_value=False)
+    def test_explicit_flag_prompts_when_editor_missing_and_user_declines(
+        self,
+        mock_installed,
+        mock_agents_dir,
+        mock_commands_dir,
+        tmp_path: Path,
+    ):
+        """Explicit --opencode flag prompts when editor missing; no files written on decline."""
+        mock_commands_dir.return_value = tmp_path / "opencode"
+        mock_agents_dir.return_value = tmp_path / "agents"
+
+        result = runner.invoke(app, ["ai", "install", "--opencode"], input="n\n")
+
+        assert result.exit_code == 0
+        assert "not found" in result.stdout
+        assert not (tmp_path / "opencode").exists()
+
+    @patch("simpletask.commands.ai.install.get_global_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_agents_dir")
+    @patch("simpletask.commands.ai.install.is_editor_installed", return_value=False)
+    def test_explicit_flag_installs_when_editor_missing_and_user_confirms(
+        self,
+        mock_installed,
+        mock_agents_dir,
+        mock_commands_dir,
+        tmp_path: Path,
+    ):
+        """Explicit --opencode flag installs when editor missing and user confirms."""
+        mock_commands_dir.return_value = tmp_path / "opencode"
+        mock_agents_dir.return_value = tmp_path / "agents"
+
+        result = runner.invoke(app, ["ai", "install", "--opencode"], input="y\n")
+
+        assert result.exit_code == 0
+        assert (tmp_path / "opencode" / "simpletask.plan.md").exists()
+
+    @patch("simpletask.commands.ai.install.get_local_commands_dir")
+    @patch("simpletask.commands.ai.install.get_local_qwen_commands_dir")
+    @patch("simpletask.commands.ai.install.get_local_gemini_commands_dir")
+    @patch("simpletask.commands.ai.install.get_local_vibe_commands_dir")
+    @patch("simpletask.commands.ai.install.get_local_agents_dir")
+    @patch("simpletask.commands.ai.install.is_editor_installed", return_value=False)
+    def test_local_flag_bypasses_detection(
+        self,
+        mock_installed,
+        mock_agents_dir,
+        mock_vibe_dir,
+        mock_gemini_dir,
+        mock_qwen_dir,
+        mock_opencode_dir,
+        tmp_path: Path,
+    ):
+        """--local flag bypasses editor detection; all editors install regardless."""
+        for mock, name in [
+            (mock_opencode_dir, "opencode"),
+            (mock_qwen_dir, "qwen"),
+            (mock_gemini_dir, "gemini"),
+            (mock_vibe_dir, "vibe"),
+            (mock_agents_dir, "agents"),
+        ]:
+            mock.return_value = tmp_path / name
+
+        result = runner.invoke(app, ["ai", "install", "--local"])
+
+        assert result.exit_code == 0
+        assert (tmp_path / "opencode" / "simpletask.plan.md").exists()
+        assert (tmp_path / "qwen" / "simpletask.plan.md").exists()
+        assert (tmp_path / "gemini" / "simpletask.plan.toml").exists()
+        assert (tmp_path / "vibe" / "simpletask-plan").is_dir()
+
+    @patch("simpletask.commands.ai.install.get_global_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_qwen_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_gemini_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_vibe_commands_dir")
+    @patch("simpletask.commands.ai.install.get_global_agents_dir")
+    @patch("simpletask.commands.ai.install.is_editor_installed", return_value=True)
+    def test_default_installs_all_detected_editors(
+        self,
+        mock_installed,
+        mock_agents_dir,
+        mock_vibe_dir,
+        mock_gemini_dir,
+        mock_qwen_dir,
+        mock_opencode_dir,
+        tmp_path: Path,
+    ):
+        """Default install proceeds for all editors when all are detected."""
+        for mock, name in [
+            (mock_opencode_dir, "opencode"),
+            (mock_qwen_dir, "qwen"),
+            (mock_gemini_dir, "gemini"),
+            (mock_vibe_dir, "vibe"),
+            (mock_agents_dir, "agents"),
+        ]:
+            mock.return_value = tmp_path / name
+
+        result = runner.invoke(app, ["ai", "install"])
+
+        assert result.exit_code == 0
+        assert (tmp_path / "opencode" / "simpletask.plan.md").exists()
+        assert (tmp_path / "qwen" / "simpletask.plan.md").exists()
+        assert (tmp_path / "gemini" / "simpletask.plan.toml").exists()
+        assert (tmp_path / "vibe" / "simpletask-plan").is_dir()

--- a/tests/unit/test_ai_templates.py
+++ b/tests/unit/test_ai_templates.py
@@ -1,0 +1,132 @@
+"""Unit tests for ai_templates editor-detection helpers."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from simpletask.commands.ai.install import _should_install
+from simpletask.core.ai_templates import (
+    EditorType,
+    get_editor_base_dir,
+    is_editor_installed,
+)
+
+ALL_EDITORS: list[EditorType] = ["opencode", "qwen", "gemini", "vibe"]
+
+
+class TestGetEditorBaseDir:
+    """Tests for get_editor_base_dir()."""
+
+    @pytest.mark.parametrize("editor", ALL_EDITORS)
+    def test_returns_path_for_all_editors(self, editor: EditorType):
+        """Should return a Path for every supported editor without errors."""
+        result = get_editor_base_dir(editor)
+        assert isinstance(result, Path)
+
+    def test_opencode_base_dir(self):
+        """OpenCode base dir should be ~/.config/opencode."""
+        result = get_editor_base_dir("opencode")
+        assert result == Path.home() / ".config" / "opencode"
+
+    def test_qwen_base_dir(self):
+        """Qwen base dir should be ~/.qwen."""
+        result = get_editor_base_dir("qwen")
+        assert result == Path.home() / ".qwen"
+
+    def test_gemini_base_dir(self):
+        """Gemini base dir should be ~/.gemini."""
+        result = get_editor_base_dir("gemini")
+        assert result == Path.home() / ".gemini"
+
+    def test_vibe_base_dir(self):
+        """Vibe base dir should be ~/.vibe."""
+        result = get_editor_base_dir("vibe")
+        assert result == Path.home() / ".vibe"
+
+
+class TestIsEditorInstalled:
+    """Tests for is_editor_installed()."""
+
+    def test_returns_true_when_base_dir_exists(self):
+        """Should return True when the editor's base directory exists."""
+        with patch.object(Path, "exists", return_value=True):
+            assert is_editor_installed("opencode") is True
+
+    def test_returns_false_when_base_dir_missing(self):
+        """Should return False when the editor's base directory does not exist."""
+        with patch.object(Path, "exists", return_value=False):
+            assert is_editor_installed("opencode") is False
+
+    @pytest.mark.parametrize("editor", ALL_EDITORS)
+    def test_all_editors_delegate_to_exists(self, editor: EditorType):
+        """Should call exists() on the base dir path for every editor."""
+        with patch.object(Path, "exists", return_value=True) as mock_exists:
+            result = is_editor_installed(editor)
+            assert result is True
+            mock_exists.assert_called_once()
+
+    @pytest.mark.parametrize("editor", ALL_EDITORS)
+    def test_not_affected_by_unrelated_path_exists(self, editor: EditorType, tmp_path: Path):
+        """Detection is based solely on get_editor_base_dir, not on template dirs."""
+        with patch(
+            "simpletask.core.ai_templates.get_editor_base_dir",
+            return_value=tmp_path / "nonexistent",
+        ):
+            assert is_editor_installed(editor) is False
+
+
+class TestShouldInstall:
+    """Tests for _should_install() — truth table verification."""
+
+    def test_local_true_always_returns_true(self):
+        """--local bypasses detection unconditionally."""
+        with patch("simpletask.commands.ai.install.is_editor_installed", return_value=False):
+            result = _should_install("opencode", "OpenCode", explicit=False, local=True)
+        assert result is True
+
+    def test_local_true_skips_confirm_even_when_explicit(self):
+        """--local should not call typer.confirm even for explicit flags."""
+        with patch("simpletask.commands.ai.install.is_editor_installed", return_value=False):
+            with patch("simpletask.commands.ai.install.typer.confirm") as mock_confirm:
+                result = _should_install("opencode", "OpenCode", explicit=True, local=True)
+        assert result is True
+        mock_confirm.assert_not_called()
+
+    def test_editor_detected_implicit_returns_true(self):
+        """Row 1: editor detected, implicit → install without prompt."""
+        with patch("simpletask.commands.ai.install.is_editor_installed", return_value=True):
+            with patch("simpletask.commands.ai.install.typer.confirm") as mock_confirm:
+                result = _should_install("opencode", "OpenCode", explicit=False, local=False)
+        assert result is True
+        mock_confirm.assert_not_called()
+
+    def test_editor_detected_explicit_returns_true(self):
+        """Row 3: editor detected, explicit flag → install without prompt."""
+        with patch("simpletask.commands.ai.install.is_editor_installed", return_value=True):
+            with patch("simpletask.commands.ai.install.typer.confirm") as mock_confirm:
+                result = _should_install("qwen", "Qwen", explicit=True, local=False)
+        assert result is True
+        mock_confirm.assert_not_called()
+
+    def test_editor_missing_implicit_returns_false_with_info(self):
+        """Row 2: editor not detected, implicit → skip and print info message."""
+        with patch("simpletask.commands.ai.install.is_editor_installed", return_value=False):
+            with patch("simpletask.commands.ai.install.info") as mock_info:
+                result = _should_install("gemini", "Gemini CLI", explicit=False, local=False)
+        assert result is False
+        mock_info.assert_called_once()
+        assert "Gemini CLI" in mock_info.call_args[0][0]
+
+    def test_editor_missing_explicit_user_confirms(self):
+        """Row 4: editor not detected, explicit flag, user confirms → install."""
+        with patch("simpletask.commands.ai.install.is_editor_installed", return_value=False):
+            with patch("simpletask.commands.ai.install.typer.confirm", return_value=True):
+                result = _should_install("vibe", "Mistral Vibe", explicit=True, local=False)
+        assert result is True
+
+    def test_editor_missing_explicit_user_declines(self):
+        """Row 5: editor not detected, explicit flag, user declines → do not install."""
+        with patch("simpletask.commands.ai.install.is_editor_installed", return_value=False):
+            with patch("simpletask.commands.ai.install.typer.confirm", return_value=False):
+                result = _should_install("vibe", "Mistral Vibe", explicit=True, local=False)
+        assert result is False


### PR DESCRIPTION
## Summary

- Before installing templates for each editor, check whether the editor's root config directory exists on the machine
- When no explicit editor flag is given and the editor directory is missing, skip silently with an info message
- When an explicit flag is given (`--opencode`, `--qwen`, etc.) but the editor is not detected, prompt the user to confirm before installing
- `--local` installs always proceed without detection checks

## Changes

- Added `global_base_dir` field to `EditorConfig` in `ai_templates.py` to track each editor's base config directory
- Added `get_editor_base_dir()` and `is_editor_installed()` helpers
- Added `_should_install()` private helper in `install.py` that encapsulates the detection + prompt logic
- Wrapped each editor's installation block with a call to `_should_install()`
- Added integration tests (`test_ai_install_cli.py`) and unit tests (`test_ai_templates.py`) covering all scenarios

Closes #41