### PR TITLE
fix(mcp): prefer in_progress over paused in overall_status precedence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -840,7 +840,7 @@ Returns enriched task data with pre-computed status counts. By default, filters 
 - `file_path`: Path to task YAML file
 - `summary`: Pre-computed `StatusSummary` with **unfiltered** counts — always reflects the complete task file:
   - `branch`, `title`
-  - `overall_status`: Computed from task states (blocked > paused > in_progress > completed > not_started)
+  - `overall_status`: Computed from task states (blocked > in_progress > paused > completed > not_started)
   - `criteria_total`, `criteria_completed`
   - `tasks_total`, `tasks_completed`, `tasks_in_progress`, `tasks_not_started`, `tasks_blocked`, `tasks_paused`
 - `filters_applied` (dict or null): When filtering is active (`full=False`), contains:

--- a/cli/simpletask/mcp/models.py
+++ b/cli/simpletask/mcp/models.py
@@ -522,7 +522,7 @@ def _increment_status_counts(counts: dict[str, int], status: TaskStatus) -> None
 def _derive_overall_status(global_counts: dict[str, int], tasks_total: int) -> TaskStatus:
     """Derive the overall task status from per-status counts.
 
-    Priority chain: blocked > paused > in_progress > completed > not_started.
+    Priority chain: blocked > in_progress > paused > completed > not_started.
 
     Args:
         global_counts: Dict with keys tasks_blocked, tasks_paused, tasks_in_progress,
@@ -534,10 +534,10 @@ def _derive_overall_status(global_counts: dict[str, int], tasks_total: int) -> T
     """
     if global_counts["tasks_blocked"] > 0:
         return TaskStatus.BLOCKED
-    if global_counts["tasks_paused"] > 0:
-        return TaskStatus.PAUSED
     if global_counts["tasks_in_progress"] > 0:
         return TaskStatus.IN_PROGRESS
+    if global_counts["tasks_paused"] > 0:
+        return TaskStatus.PAUSED
     if tasks_total > 0 and global_counts["tasks_completed"] == tasks_total:
         return TaskStatus.COMPLETED
     return TaskStatus.NOT_STARTED

--- a/tests/unit/test_mcp_models.py
+++ b/tests/unit/test_mcp_models.py
@@ -50,7 +50,7 @@ class TestComputeStatusSummary:
         assert summary.tasks_paused == 1
 
     def test_overall_status_paused_priority(self, sample_spec_mixed_statuses: SimpleTaskSpec):
-        """Verify overall status priority: blocked > paused > in_progress > completed > not_started."""
+        """Verify overall status priority: blocked > in_progress > paused > completed > not_started."""
         summary = compute_status_summary(sample_spec_mixed_statuses)
         # With blocked task present, overall should be blocked
         assert summary.overall_status.value == "blocked"
@@ -65,19 +65,48 @@ class TestComputeStatusSummary:
         assert summary.tasks_paused == 1
         assert summary.tasks_in_progress == 1
 
-    def test_overall_status_paused_trumps_in_progress(
+    def test_overall_status_in_progress_trumps_paused(
         self, sample_spec_paused_and_in_progress: SimpleTaskSpec
     ):
-        """Verify paused takes priority over in_progress when no blocked tasks."""
+        """Verify in_progress takes priority over paused when no blocked tasks."""
         summary = compute_status_summary(sample_spec_paused_and_in_progress)
-        assert summary.overall_status.value == "paused"
+        assert summary.overall_status.value == "in_progress"
         assert summary.tasks_blocked == 0
         assert summary.tasks_paused == 1
         assert summary.tasks_in_progress == 1
         assert summary.tasks_completed == 1
 
+    def test_overall_status_paused_when_no_in_progress(
+        self, sample_spec_only_paused: SimpleTaskSpec
+    ):
+        """Verify paused wins when in_progress is zero and no blocked tasks."""
+        summary = compute_status_summary(sample_spec_only_paused)
+        assert summary.overall_status.value == "paused"
+        assert summary.tasks_blocked == 0
+        assert summary.tasks_in_progress == 0
+        assert summary.tasks_paused == 2
+
+    def test_overall_status_blocked_trumps_in_progress(
+        self, sample_spec_blocked_paused_in_progress: SimpleTaskSpec
+    ):
+        """Verify blocked outranks in_progress."""
+        summary = compute_status_summary(sample_spec_blocked_paused_in_progress)
+        assert summary.overall_status.value == "blocked"
+        assert summary.tasks_blocked == 1
+        assert summary.tasks_in_progress == 1
+
+    def test_overall_status_blocked_trumps_paused_and_in_progress(
+        self, sample_spec_blocked_paused_in_progress: SimpleTaskSpec
+    ):
+        """Verify blocked outranks both paused and in_progress simultaneously."""
+        summary = compute_status_summary(sample_spec_blocked_paused_in_progress)
+        assert summary.overall_status.value == "blocked"
+        assert summary.tasks_blocked == 1
+        assert summary.tasks_paused == 1
+        assert summary.tasks_in_progress == 1
+
     def test_overall_status_only_paused(self, sample_spec_only_paused: SimpleTaskSpec):
-        """Verify overall status is PAUSED when only paused tasks exist."""
+        """Verify overall status is PAUSED when only paused tasks exist (no in_progress)."""
         summary = compute_status_summary(sample_spec_only_paused)
         assert summary.overall_status.value == "paused"
         assert summary.tasks_paused == 2


### PR DESCRIPTION
## Summary

- Fixes incorrect `overall_status` precedence in `_derive_overall_status()` where a branch with active work could be reported as `paused` when paused tasks also existed
- New priority chain: `blocked > in_progress > paused > completed > not_started`
- Closes #38

## Changes

- `cli/simpletask/mcp/models.py` - swapped `in_progress`/`paused` check order; updated docstring
- `tests/unit/test_mcp_models.py` - updated stale test; added 3 new tests covering adjacent-status pairs across the full chain
- `AGENTS.md` - updated priority chain documentation
- `pyproject.toml` + `cli/simpletask/__init__.py` - version bump 0.37.5 → 0.37.6