### PR TITLE
feat(cli): add simpletask fmt and fmt --check for canonical YAML formatting

### DIFF
--- a/cli/simpletask/__init__.py
+++ b/cli/simpletask/__init__.py
@@ -1,6 +1,6 @@
 """simpletask: A Python CLI for managing AI-friendly task definition YAML files."""
 
-__version__ = "0.37.9"
+__version__ = "0.38.0"
 
 import typer
 
@@ -23,6 +23,7 @@ from .commands import (
     task,
 )
 from .commands import list as list_cmd
+from .commands.fmt import commands as fmt_commands
 
 
 def version_callback(value: bool):
@@ -60,6 +61,7 @@ app.command(name="new")(new.new)
 app.command(name="list")(list_cmd.list_tasks)
 app.command(name="show")(show.show)
 app.command(name="serve")(serve.serve)
+app.command(name="fmt")(fmt_commands.fmt_command)
 
 # Register subcommand groups
 app.add_typer(schema.app, name="schema")

--- a/cli/simpletask/commands/fmt/commands.py
+++ b/cli/simpletask/commands/fmt/commands.py
@@ -1,0 +1,126 @@
+"""fmt command - Format task files to canonical YAML."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from ...core.project import ensure_project
+from ...core.yaml_parser import InvalidTaskFileError, parse_task_file_from_text, serialize_task_file
+from ...utils.console import console, error_console
+
+
+@dataclass
+class _FmtResults:
+    """Files partitioned by their canonicalization status."""
+
+    ok_files: list[Path] = field(default_factory=list)
+    dirty_files: list[tuple[Path, str]] = field(default_factory=list)  # (path, canonical_content)
+    error_files: list[Path] = field(default_factory=list)
+
+
+def _collect_fmt_results(task_files: list[Path]) -> _FmtResults:
+    """Read and classify each task file as ok, dirty, or error.
+
+    Each file is read exactly once to avoid double I/O and TOCTOU issues.
+    Dirty files carry their canonical content so callers can write without
+    a second serialization pass.
+
+    Args:
+        task_files: Sorted list of task YAML file paths to process.
+
+    Returns:
+        _FmtResults with files partitioned into ok, dirty, and error categories.
+    """
+    results = _FmtResults()
+
+    for file_path in task_files:
+        try:
+            current = file_path.read_text(encoding="utf-8")
+        except OSError as e:
+            error_console.print(f"[red]✗[/red] {file_path.name}: {e}")
+            results.error_files.append(file_path)
+            continue
+
+        try:
+            spec = parse_task_file_from_text(current, file_path)
+        except InvalidTaskFileError as e:
+            error_console.print(f"[red]✗[/red] {file_path.name}: {e}")
+            results.error_files.append(file_path)
+            continue
+
+        canonical = serialize_task_file(spec)
+        if current == canonical:
+            results.ok_files.append(file_path)
+        else:
+            results.dirty_files.append((file_path, canonical))
+
+    return results
+
+
+def fmt_command(
+    check: Annotated[
+        bool,
+        typer.Option(
+            "--check",
+            help="Exit non-zero if any file would change, without modifying files",
+        ),
+    ] = False,
+) -> None:
+    """Format all task files to canonical YAML.
+
+    Rewrites every .tasks/*.yml file (excluding defaults.yml) through the
+    canonical parse/write pipeline, normalizing key ordering, indentation,
+    and quoting. Idempotent: running twice produces identical output.
+
+    With --check, no files are written; exit code is 1 if any file would
+    change (CI-friendly). No output is produced on success.
+
+    Examples:
+        simpletask fmt              # Rewrite all task files
+        simpletask fmt --check      # Check formatting without writing
+    """
+    try:
+        project = ensure_project()
+    except ValueError as e:
+        error_console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1) from None
+
+    tasks_dir: Path = project.tasks_dir
+
+    if not tasks_dir.exists():
+        if not check:
+            console.print("[dim]No .tasks/ directory found. Nothing to format.[/dim]")
+        return
+
+    task_files = sorted(p for p in tasks_dir.glob("*.yml") if p.name != "defaults.yml")
+
+    if not task_files:
+        if not check:
+            console.print("[dim]No task files found. Nothing to format.[/dim]")
+        return
+
+    results = _collect_fmt_results(task_files)
+
+    if check:
+        if results.dirty_files:
+            console.print("[red]Would reformat:[/red]")
+            for path, _ in results.dirty_files:
+                console.print(f"  {path.name}")
+            console.print("Run `simpletask fmt` to apply.")
+        if results.error_files:
+            error_console.print("[red]Parse errors (fix these first):[/red]")
+            for path in results.error_files:
+                error_console.print(f"  {path.name}")
+        if results.dirty_files or results.error_files:
+            raise typer.Exit(1)
+        # All canonical - exit 0 silently (AC4: no error output on success)
+    else:
+        for file_path in results.ok_files:
+            console.print(f"[green]✓[/green] {file_path.name}")
+        for file_path, canonical in results.dirty_files:
+            file_path.write_text(canonical, encoding="utf-8")
+            console.print(f"[yellow]↻[/yellow] {file_path.name} (reformatted)")
+        if results.error_files:
+            raise typer.Exit(1)

--- a/cli/simpletask/core/yaml_parser.py
+++ b/cli/simpletask/core/yaml_parser.py
@@ -13,6 +13,52 @@ class InvalidTaskFileError(Exception):
     """Raised when task file format is invalid or doesn't match schema."""
 
 
+def parse_task_file_from_text(text: str, source_path: Path | None = None) -> SimpleTaskSpec:
+    """Parse task YAML from a pre-read string without filesystem I/O.
+
+    Args:
+        text: Raw YAML content to parse.
+        source_path: Optional path used only for error message context.
+
+    Returns:
+        SimpleTaskSpec instance.
+
+    Raises:
+        InvalidTaskFileError: If YAML is invalid or doesn't match schema.
+    """
+    path_label = str(source_path) if source_path else "<string>"
+
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        raise InvalidTaskFileError(f"Invalid YAML syntax:\n{e!s}\n\nFile: {path_label}") from e
+
+    if not isinstance(data, dict):
+        raise InvalidTaskFileError(
+            f"Invalid YAML content: Expected a dictionary/object, got {type(data).__name__}.\n"
+            f"File: {path_label}"
+        )
+
+    try:
+        spec = SimpleTaskSpec.model_validate(data)
+    except ValidationError as e:
+        error_messages = []
+        for error in e.errors():
+            field = ".".join(str(x) for x in error["loc"])
+            message = error["msg"]
+            error_type = error["type"]
+            error_messages.append(f"  • {field}: {message} (type: {error_type})")
+
+        raise InvalidTaskFileError(
+            "Invalid task file schema - YAML content doesn't match expected format:\n\n"
+            + "\n".join(error_messages)
+            + f"\n\nFile: {path_label}\n\n"
+            f"See documentation for correct schema format."
+        ) from e
+
+    return spec
+
+
 def parse_task_file(path: Path) -> SimpleTaskSpec:
     """Parse task YAML file.
 
@@ -29,41 +75,7 @@ def parse_task_file(path: Path) -> SimpleTaskSpec:
     if not path.exists():
         raise FileNotFoundError(f"Task file not found: {path}")
 
-    content = path.read_text(encoding="utf-8")
-
-    # Parse YAML
-    try:
-        data = yaml.safe_load(content)
-    except yaml.YAMLError as e:
-        raise InvalidTaskFileError(f"Invalid YAML syntax:\n{e!s}\n\nFile: {path}") from e
-
-    # Validate that YAML parsed to a dict
-    if not isinstance(data, dict):
-        raise InvalidTaskFileError(
-            f"Invalid YAML content: Expected a dictionary/object, got {type(data).__name__}.\n"
-            f"File: {path}"
-        )
-
-    # Validate against Pydantic schema
-    try:
-        spec = SimpleTaskSpec.model_validate(data)
-    except ValidationError as e:
-        # Format validation errors nicely
-        error_messages = []
-        for error in e.errors():
-            field = ".".join(str(x) for x in error["loc"])
-            message = error["msg"]
-            error_type = error["type"]
-            error_messages.append(f"  • {field}: {message} (type: {error_type})")
-
-        raise InvalidTaskFileError(
-            "Invalid task file schema - YAML content doesn't match expected format:\n\n"
-            + "\n".join(error_messages)
-            + f"\n\nFile: {path}\n\n"
-            f"See documentation for correct schema format."
-        ) from e
-
-    return spec
+    return parse_task_file_from_text(path.read_text(encoding="utf-8"), path)
 
 
 def parse_task_file_lenient(path: Path) -> dict[str, Any]:
@@ -129,6 +141,30 @@ def _bump_schema_version_if_canonical(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
+def serialize_task_file(spec: SimpleTaskSpec) -> str:
+    """Serialize a task spec to canonical YAML string without touching the filesystem.
+
+    Produces the same output as write_task_file() without any I/O. Used by
+    fmt --check to compare in-memory canonical form against current file content.
+
+    Args:
+        spec: SimpleTaskSpec instance to serialize
+
+    Returns:
+        Canonical YAML string
+    """
+    data = spec.model_dump(mode="json", exclude_none=True)
+    data = _bump_schema_version_if_canonical(data)
+    return yaml.dump(
+        data,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+        width=100,
+        indent=2,
+    )
+
+
 def write_task_file(path: Path, spec: SimpleTaskSpec) -> None:
     """Write task YAML file.
 
@@ -159,24 +195,8 @@ def write_task_file(path: Path, spec: SimpleTaskSpec) -> None:
     # Ensure parent directory exists
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Convert spec to dict (mode='json' for datetime serialization)
-    data = spec.model_dump(mode="json", exclude_none=True)
-
-    # Bump schema_version for files using canonical execution specs
-    data = _bump_schema_version_if_canonical(data)
-
-    # Generate YAML with nice formatting
-    yaml_content = yaml.dump(
-        data,
-        default_flow_style=False,
-        sort_keys=False,
-        allow_unicode=True,
-        width=100,  # Wrap long lines at 100 chars
-        indent=2,
-    )
-
-    # Write to file
-    path.write_text(yaml_content, encoding="utf-8")
+    # Serialize and write
+    path.write_text(serialize_task_file(spec), encoding="utf-8")
 
 
 def update_task_status(path: Path, task_id: str, new_status: TaskStatus) -> None:
@@ -250,7 +270,9 @@ def update_criterion_status(path: Path, criterion_id: str, completed: bool) -> N
 __all__ = [
     "InvalidTaskFileError",
     "parse_task_file",
+    "parse_task_file_from_text",
     "parse_task_file_lenient",
+    "serialize_task_file",
     "update_criterion_status",
     "update_task_status",
     "write_task_file",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simpletask"
-version = "0.37.9"
+version = "0.38.0"
 description = "CLI tool for managing AI-friendly task definitions in branch-based development workflows"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/tests/unit/test_fmt_command.py
+++ b/tests/unit/test_fmt_command.py
@@ -1,0 +1,316 @@
+"""Unit tests for the fmt command.
+
+Tests cover:
+- fmt rewrites non-canonical files (extra blank lines, wrong indentation)
+- fmt is idempotent (running twice produces identical output)
+- fmt skips schema-invalid files without overwriting them
+- fmt --check exits 0 when all files are already canonical
+- fmt --check exits 1 when any file would change
+- fmt --check exits 1 when any file has parse errors, naming them separately
+- fmt --check never writes to disk
+- fmt --check is silent on success (no error output)
+- fmt + fmt --check sequence always exits 0 (post-fmt idempotency)
+- serialize_task_file is idempotent at the parser level (round-trip test)
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+import yaml
+from simpletask.commands.fmt.commands import fmt_command
+from simpletask.core.models import AcceptanceCriterion, SimpleTaskSpec, Task, TaskStatus
+from simpletask.core.yaml_parser import (
+    parse_task_file_from_text,
+    serialize_task_file,
+    write_task_file,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_spec(branch: str = "test-feature") -> SimpleTaskSpec:
+    """Return a minimal but valid SimpleTaskSpec."""
+    return SimpleTaskSpec(
+        schema_version="1.0",
+        branch=branch,
+        title="Test Feature",
+        original_prompt="Implement test feature",
+        created=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+        acceptance_criteria=[
+            AcceptanceCriterion(id="AC1", description="Feature works", completed=False),
+        ],
+        tasks=[
+            Task(
+                id="T001",
+                name="Setup",
+                status=TaskStatus.NOT_STARTED,
+                goal="Configure environment",
+                steps=["Install deps"],
+            )
+        ],
+    )
+
+
+def _write_canonical(path: Path, spec: SimpleTaskSpec) -> None:
+    """Write a canonical task file (through write_task_file)."""
+    write_task_file(path, spec)
+
+
+def _write_non_canonical(path: Path, spec: SimpleTaskSpec) -> None:
+    """Write a task file with extra blank lines (non-canonical)."""
+    canonical = serialize_task_file(spec)
+    # Insert extra blank lines to make it non-canonical
+    non_canonical = canonical.replace("\n", "\n\n", 3)
+    path.write_text(non_canonical, encoding="utf-8")
+
+
+def _write_non_canonical_indent(path: Path, spec: SimpleTaskSpec) -> None:
+    """Write a task file with indent=4 instead of the canonical indent=2."""
+    data = spec.model_dump(mode="json", exclude_none=True)
+    non_canonical = yaml.dump(
+        data,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+        width=100,
+        indent=4,
+    )
+    path.write_text(non_canonical, encoding="utf-8")
+
+
+def _mock_project(tasks_dir: Path) -> MagicMock:
+    """Return a mock Project with the given tasks_dir."""
+    mock = MagicMock()
+    mock.tasks_dir = tasks_dir
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tasks_dir(tmp_path: Path) -> Path:
+    """Return an empty temporary .tasks/ directory."""
+    d = tmp_path / ".tasks"
+    d.mkdir()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFmtNormalMode:
+    """Tests for `simpletask fmt` (normal rewrite mode, check=False)."""
+
+    def test_rewrites_non_canonical_file(self, tasks_dir: Path) -> None:
+        """fmt rewrites a non-canonical file to canonical form."""
+        spec = _make_spec()
+        file_path = tasks_dir / "test-feature.yml"
+        _write_non_canonical(file_path, spec)
+
+        before = file_path.read_text(encoding="utf-8")
+        expected_canonical = serialize_task_file(spec)
+        assert before != expected_canonical, "Precondition: file must not yet be canonical"
+
+        with patch(
+            "simpletask.commands.fmt.commands.ensure_project", return_value=_mock_project(tasks_dir)
+        ):
+            fmt_command(check=False)
+
+        after = file_path.read_text(encoding="utf-8")
+        assert after == expected_canonical
+
+    def test_rewrites_wrong_indentation(self, tasks_dir: Path) -> None:
+        """fmt normalizes a file written with indent=4 to the canonical indent=2."""
+        spec = _make_spec()
+        file_path = tasks_dir / "test-feature.yml"
+        _write_non_canonical_indent(file_path, spec)
+
+        before = file_path.read_text(encoding="utf-8")
+        expected_canonical = serialize_task_file(spec)
+        assert before != expected_canonical, "Precondition: indent=4 file must not be canonical"
+
+        with patch(
+            "simpletask.commands.fmt.commands.ensure_project", return_value=_mock_project(tasks_dir)
+        ):
+            fmt_command(check=False)
+
+        after = file_path.read_text(encoding="utf-8")
+        assert after == expected_canonical
+
+    def test_idempotent(self, tasks_dir: Path) -> None:
+        """Running fmt twice produces identical byte-for-byte output."""
+        spec = _make_spec()
+        file_path = tasks_dir / "test-feature.yml"
+        _write_non_canonical(file_path, spec)
+
+        with patch(
+            "simpletask.commands.fmt.commands.ensure_project", return_value=_mock_project(tasks_dir)
+        ):
+            fmt_command(check=False)
+
+        after_first = file_path.read_text(encoding="utf-8")
+
+        with patch(
+            "simpletask.commands.fmt.commands.ensure_project", return_value=_mock_project(tasks_dir)
+        ):
+            fmt_command(check=False)
+
+        after_second = file_path.read_text(encoding="utf-8")
+        assert after_first == after_second
+
+    def test_already_canonical_file_unchanged(self, tasks_dir: Path) -> None:
+        """fmt does not modify a file already in canonical form."""
+        spec = _make_spec()
+        file_path = tasks_dir / "test-feature.yml"
+        _write_canonical(file_path, spec)
+        before = file_path.read_text(encoding="utf-8")
+
+        with patch(
+            "simpletask.commands.fmt.commands.ensure_project", return_value=_mock_project(tasks_dir)
+        ):
+            fmt_command(check=False)
+
+        assert file_path.read_text(encoding="utf-8") == before
+
+    def test_skips_invalid_file_without_overwriting(self, tasks_dir: Path) -> None:
+        """fmt does not overwrite a schema-invalid YAML file."""
+        file_path = tasks_dir / "bad.yml"
+        invalid_yaml = "not_a_valid_task: true\nmissing_required_fields: yes\n"
+        file_path.write_text(invalid_yaml, encoding="utf-8")
+
+        with patch(
+            "simpletask.commands.fmt.commands.ensure_project", return_value=_mock_project(tasks_dir)
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                fmt_command(check=False)
+
+        # File must be unchanged
+        assert file_path.read_text(encoding="utf-8") == invalid_yaml
+        # Must exit with code 1 specifically
+        assert exc_info.value.exit_code == 1
+
+
+class TestFmtCheckMode:
+    """Tests for `simpletask fmt --check` mode."""
+
+    def test_does_not_write_files(self, tasks_dir: Path) -> None:
+        """--check never modifies files even when they would change."""
+        spec = _make_spec()
+        file_path = tasks_dir / "test-feature.yml"
+        _write_non_canonical(file_path, spec)
+        original_content = file_path.read_text(encoding="utf-8")
+
+        with patch(
+            "simpletask.commands.fmt.commands.ensure_project", return_value=_mock_project(tasks_dir)
+        ):
+            with pytest.raises(typer.Exit):
+                fmt_command(check=True)
+
+        assert file_path.read_text(encoding="utf-8") == original_content
+
+    def test_names_all_dirty_files(self, tasks_dir: Path) -> None:
+        """--check output includes the name of every file that would change."""
+        spec_a = _make_spec("feature-a")
+        spec_b = _make_spec("feature-b")
+        _write_non_canonical(tasks_dir / "feature-a.yml", spec_a)
+        _write_non_canonical(tasks_dir / "feature-b.yml", spec_b)
+
+        with patch(
+            "simpletask.commands.fmt.commands.ensure_project", return_value=_mock_project(tasks_dir)
+        ):
+            with patch("simpletask.commands.fmt.commands.console") as mock_console:
+                with pytest.raises(typer.Exit):
+                    fmt_command(check=True)
+
+                all_output = " ".join(str(c) for c in mock_console.print.call_args_list)
+                assert "feature-a.yml" in all_output
+                assert "feature-b.yml" in all_output
+
+    def test_check_mode_names_parse_error_files(self, tasks_dir: Path) -> None:
+        """--check names files with parse errors separately and exits 1."""
+        file_path = tasks_dir / "bad.yml"
+        invalid_yaml = "not_a_valid_task: true\nmissing_required_fields: yes\n"
+        file_path.write_text(invalid_yaml, encoding="utf-8")
+
+        with patch(
+            "simpletask.commands.fmt.commands.ensure_project", return_value=_mock_project(tasks_dir)
+        ):
+            with patch("simpletask.commands.fmt.commands.error_console") as mock_error_console:
+                with pytest.raises(typer.Exit) as exc_info:
+                    fmt_command(check=True)
+
+                all_output = " ".join(str(c) for c in mock_error_console.print.call_args_list)
+                assert "bad.yml" in all_output
+                assert "Parse errors" in all_output
+                assert exc_info.value.exit_code == 1
+
+    def test_check_mode_separates_dirty_and_error_files(self, tasks_dir: Path) -> None:
+        """--check prints dirty files and parse-error files under separate headers."""
+        spec = _make_spec("clean-feature")
+        _write_non_canonical(tasks_dir / "dirty.yml", spec)
+        (tasks_dir / "bad.yml").write_text(
+            "not_a_valid_task: true\nmissing_required_fields: yes\n", encoding="utf-8"
+        )
+
+        with patch(
+            "simpletask.commands.fmt.commands.ensure_project", return_value=_mock_project(tasks_dir)
+        ):
+            with patch("simpletask.commands.fmt.commands.console") as mock_console:
+                with patch("simpletask.commands.fmt.commands.error_console") as mock_error_console:
+                    with pytest.raises(typer.Exit) as exc_info:
+                        fmt_command(check=True)
+
+                    console_output = " ".join(str(c) for c in mock_console.print.call_args_list)
+                    error_output = " ".join(str(c) for c in mock_error_console.print.call_args_list)
+                    assert "dirty.yml" in console_output
+                    assert "Would reformat" in console_output
+                    assert "bad.yml" in error_output
+                    assert "Parse errors" in error_output
+                    assert exc_info.value.exit_code == 1
+
+    def test_post_fmt_check_exits_0(self, tasks_dir: Path) -> None:
+        """Running fmt then fmt --check always exits 0 (post-fmt idempotency)."""
+        spec = _make_spec()
+        _write_non_canonical(tasks_dir / "test-feature.yml", spec)
+
+        # First: fmt (normal mode)
+        with patch(
+            "simpletask.commands.fmt.commands.ensure_project", return_value=_mock_project(tasks_dir)
+        ):
+            fmt_command(check=False)
+
+        # Then: fmt --check must succeed (no Exit raised)
+        with patch(
+            "simpletask.commands.fmt.commands.ensure_project", return_value=_mock_project(tasks_dir)
+        ):
+            fmt_command(check=True)
+
+
+class TestFmtSerializeIdempotency:
+    """Tests verifying serializer-level idempotency independent of the fmt command."""
+
+    def test_serialize_is_idempotent_at_parser_level(self) -> None:
+        """parse -> serialize -> parse -> serialize produces identical output both times.
+
+        This test can fail if serialize_task_file or the Pydantic models introduce
+        any non-deterministic output, making it a meaningful regression guard.
+        """
+        spec = _make_spec()
+
+        # First round-trip: serialize, re-parse in-memory, serialize again
+        first_yaml = serialize_task_file(spec)
+        reparsed = parse_task_file_from_text(first_yaml)
+
+        # Second serialization must be byte-for-byte identical
+        second_yaml = serialize_task_file(reparsed)
+        assert first_yaml == second_yaml


### PR DESCRIPTION
Closes #51

## Summary

- Adds `simpletask fmt` - rewrites all task files through the existing `serialize_task_file()` pipeline, normalizing key ordering, indentation, and quoting
- Adds `simpletask fmt --check` - exits 1 and names every file that would change; dirty files and parse-error files are printed to separate streams (stdout / stderr) so a CI consumer can distinguish the correct remediation action
- Invalid files are never overwritten; a descriptive error names the file and skips it

## Implementation notes

- No new serialization logic - reuses `serialize_task_file()` from `yaml_parser.py` verbatim; `fmt` is purely a thin driver over the existing parse/write round-trip
- `_collect_fmt_results()` helper reads each file exactly once per iteration (no double read, no TOCTOU)
- `fmt --check` generates canonical YAML in memory and compares; never writes to disk

## Tests

Covers: normal rewrite, idempotency, `--check` exit codes, invalid file skipping, parse-error/dirty-file output separation, and serializer-level round-trip idempotency. All 1192 tests pass.